### PR TITLE
feat(get-qodo-rules): add attribution headers for platform middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,24 +71,23 @@ Skills are automatically installed to the correct location for your agent:
 - **Git** - For repository detection
   - Usually pre-installed on macOS and most Linux distributions
   - Windows: Download from https://git-scm.com/download/win
-- **Python 3.6+** - For API requests and cross-platform compatibility
-  - No external dependencies required (uses standard library only)
+- **curl** - For HTTPS API requests (works with system SSL certificates)
+  - Pre-installed on macOS, most Linux distributions, and Windows 10+
+  - If needed, install via package manager or download from https://curl.se
   ```bash
   # Check installation
-  python3 --version
-  # or
-  python --version
+  curl --version
 
   # Install if needed:
-  # macOS: brew install python3
-  # Ubuntu/Debian: apt-get install python3
-  # Windows: https://www.python.org/downloads/
-  #   (Make sure to check "Add Python to PATH" during installation)
+  # macOS: brew install curl (or use system curl)
+  # Ubuntu/Debian: apt-get install curl
+  # Windows 10+: Included by default
   ```
+- **Python 3.6+** - For JSON parsing and path manipulation only (no API calls)
+  - Pre-installed on macOS and most Linux distributions
+  - Windows: Download from https://www.python.org/downloads/
 
-**Note:** The script automatically detects Python using:
-- **Windows:** `py -3` → `python3` → `python`
-- **Unix/macOS/Linux:** `python3` → `python`
+**Note:** All prerequisites use standard system tools with no external dependencies.
 
 ## Configuration
 

--- a/skills/get-qodo-rules/SKILL.md
+++ b/skills/get-qodo-rules/SKILL.md
@@ -56,6 +56,7 @@ Check that the required Qodo configuration is present. The default location is `
 
 - **API key**: Read from `~/.qodo/config.json` (`API_KEY` field). If not found, inform the user that an API key is required and provide setup instructions, then exit gracefully.
 - **Environment name**: Read from `~/.qodo/config.json` (`ENVIRONMENT_NAME` field), with `QODO_ENVIRONMENT_NAME` environment variable taking precedence. If not found, inform the user that an API key is required and provide setup instructions, then exit gracefully.
+- **Request ID**: Generate a UUID (e.g. via `uuidgen` or `python3 -c "import uuid; print(uuid.uuid4())"`) to use as `request-id` for all API calls in this invocation. This correlates all page fetches for a single rules load on the platform side.
 
 ### Step 4: Fetch Rules with Pagination
 

--- a/skills/get-qodo-rules/references/pagination.md
+++ b/skills/get-qodo-rules/references/pagination.md
@@ -8,7 +8,7 @@ The API returns rules in pages of 50. All pages must be fetched to ensure no rul
 2. Request: `GET {API_URL}/rules?scopes={ENCODED_SCOPE}&state=active&page={PAGE}&page_size=50`
    - Header: `Authorization: Bearer {API_KEY}`
    - Header: `request-id: {REQUEST_ID}` — UUID generated once in Step 3; same value on every page fetch
-   - Header: `qodo-client-type: get-qodo-rules` — identifies this skill as the caller
+   - Header: `qodo-client-type: skill-get-qodo-rules` — identifies this skill as the caller
    - Header: `trace_id: {TRACE_ID}` — only include if `TRACE_ID` is set in the shell environment; skip silently otherwise
 3. On non-200 response, handle the error and exit gracefully:
    - `401` — invalid/expired API key

--- a/skills/get-qodo-rules/references/pagination.md
+++ b/skills/get-qodo-rules/references/pagination.md
@@ -7,6 +7,9 @@ The API returns rules in pages of 50. All pages must be fetched to ensure no rul
 1. Start with `page=1`, `page_size=50`, accumulate results in an empty list
 2. Request: `GET {API_URL}/rules?scopes={ENCODED_SCOPE}&state=active&page={PAGE}&page_size=50`
    - Header: `Authorization: Bearer {API_KEY}`
+   - Header: `request-id: {REQUEST_ID}` — UUID generated once in Step 3; same value on every page fetch
+   - Header: `qodo-client-type: get-qodo-rules` — identifies this skill as the caller
+   - Header: `trace_id: {TRACE_ID}` — only include if `TRACE_ID` is set in the shell environment; skip silently otherwise
 3. On non-200 response, handle the error and exit gracefully:
    - `401` — invalid/expired API key
    - `403` — access forbidden
@@ -26,7 +29,11 @@ Construct `{API_URL}` from `ENVIRONMENT_NAME` (read from `~/.qodo/config.json`):
 
 | `ENVIRONMENT_NAME` | `{API_URL}` |
 |---|---|
-| set (e.g. `staging`) | `https://qodo-platform.staging.qodo.ai/rules/v1` |
+| not set / empty | `https://qodo-platform.qodo.ai/rules/v1` |
+| `staging` | `https://qodo-platform.staging.qodo.ai/rules/v1` |
+| `qodost.st` | `https://qodo-platform.qodost.st.qodo.ai/rules/v1` |
+
+The `ENVIRONMENT_NAME` value is substituted verbatim as a subdomain segment — dots in the value become dots in the hostname.
 
 ## After Fetching
 


### PR DESCRIPTION
Adds three request headers to all rules API calls so the platform's RequestContextMiddleware can capture caller context automatically:

- request-id: UUID generated once per invocation, reused across all paginated page fetches to correlate them as a single rules load
- qodo-client-type: static "get-qodo-rules" identifier for the skill
- trace_id: conditionally included when TRACE_ID env var is set

Also clarifies the API URL table in pagination.md: adds the unset-env case and a dotted-name example (qodost.st) with a note that the ENVIRONMENT_NAME value is substituted verbatim as a subdomain segment.