### PR TITLE
feat: add qodo-rules and qodo-setup skills for managing coding rules …

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,25 @@ Skills are automatically installed to the correct location for your agent:
 
 ## Configuration
 
-### get-qodo-rules Skill
+This repo currently supports **two authentication/configuration models**, depending on the skill you use:
+
+- **OIDC login (recommended for new skills)** via `/qodo-setup` → stores a short-lived `id_token` in `~/.qodo/skill_auth.json`
+- **API key configuration** (used by `get-qodo-rules`) → stores `API_KEY` in `~/.qodo/config.json` (or env vars)
+
+### OIDC Login (qodo-setup / qodo-rules)
+
+Some skills (e.g. `qodo-rules`) authenticate using an OIDC browser login flow. Run the setup skill once:
+
+```bash
+/qodo-setup --login
+```
+
+This writes:
+- `~/.qodo/skill_auth.json` (contains `id_token` + `platform_url`)
+
+If a token expires, these skills will attempt to refresh automatically (via `/qodo-setup --check`, then `--login` if needed).
+
+### API Key (get-qodo-rules Skill)
 
 Create `~/.qodo/config.json`:
 

--- a/skills/get-qodo-rules/SKILL.md
+++ b/skills/get-qodo-rules/SKILL.md
@@ -52,6 +52,9 @@ See [repository scope detection](references/repository-scope.md) for details.
 
 ### Step 3: Verify Qodo Configuration
 
+> Note: This skill currently authenticates via **API key** (`~/.qodo/config.json` or `QODO_API_KEY`).
+> Other skills in this repo may use **OIDC login** via `/qodo-setup` and `~/.qodo/skill_auth.json`.
+
 Check that the required Qodo configuration is present. The default location is `~/.qodo/config.json`.
 
 - **API key**: Read from `~/.qodo/config.json` (`API_KEY` field). If not found, inform the user that an API key is required and provide setup instructions, then exit gracefully.

--- a/skills/qodo-rules/SKILL.md
+++ b/skills/qodo-rules/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: qodo-rules
+description: "Manage Qodo coding rules — get, sync, create, update, delete. Use only when user explicitly asks to view, add, edit, or remove rules."
+---
+
+# Qodo Rules
+
+CRUD operations for Qodo coding rules.
+
+**Script:** `bash .claude/skills/qodo-rules/scripts/qodo-rules.sh`
+
+**Prerequisites:** `curl`, `jq`, `git` — and authenticated via `/qodo-setup`
+
+---
+
+## Get
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --get
+```
+
+Downloads all active rules and saves them as local IDE rule files:
+
+- **Cursor:** `.cursor/rules/qodo-<slug>.mdc` (with frontmatter: `description`, `alwaysApply: true`)
+- **Claude Code:** `.claude/rules/qodo-<slug>.md` (plain markdown)
+
+**Location:** saves to the project root if inside a git repo, otherwise falls back to `~/` (user home). Auto-detects the IDE from the workspace (`.cursor/` directory or `CURSOR_TRACE_ID` env var).
+
+All synced files are prefixed with `qodo-` so re-runs clean up old synced rules without affecting manually created ones.
+
+Each rule file includes: name, severity, category, content, and examples (if available).
+
+| Severity | Action |
+|----------|--------|
+| **ERROR** | Must comply. Ask user if can't satisfy. |
+| **WARNING** | Should comply. Explain briefly if skipping. |
+| **RECOMMENDATION** | Consider when appropriate. |
+
+---
+
+## Create
+
+**Always use the two-step flow: preview via `--prompt`, then pipe directly into `--create`.**
+
+### Step 1: Preview rule from prompt
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --prompt "Describe the rule in plain English"
+```
+
+Calls the server-side LLM to generate a complete rule JSON (name, category, content, examples, severity). Returns the generated `RuleBase` JSON. **Never manually construct rule JSON** — always use `--prompt` to avoid escaping issues.
+
+After getting the JSON, show it to the user in this format:
+
+```
+---
+**Name:** <name>
+**Category:** <category>
+**Severity:** <severity>
+
+**Rule:**
+<content>
+
+**Good example:**
+<goodExamples>
+
+**Bad example:**
+<badExamples>
+
+Create this rule?
+```
+
+Wait for user confirmation before proceeding to Step 2.
+
+### Step 2: Create (after user approval)
+
+Re-run `--prompt` and pipe its output directly into `--create`. **Never use `echo '<json>'`** — multi-line JSON fields break shell quoting.
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --prompt "Describe the rule in plain English" \
+  | bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --create
+```
+
+With optional scope override:
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --prompt "Describe the rule in plain English" \
+  | bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --create --scope "/org/repo/src/"
+```
+
+Scope is auto-added from git remote. Returns `{"ruleId": <id>}`. Rule is created as a suggestion needing admin approval. HTTP 409 = name already exists.
+
+---
+
+## Update
+
+Requires the full rule JSON (admin only).
+
+```bash
+echo '<full-rule-json>' | bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --update <rule_id>
+```
+
+HTTP 403 = not an admin.
+
+---
+
+## Delete
+
+**Always confirm with user before deleting.**
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --delete <rule_id>
+```
+
+HTTP 204 = success. HTTP 403 = not an admin.
+
+---
+
+## Auth
+
+Reads `id_token` and `platform_url` from `~/.qodo/skill_auth.json` (written by `/qodo-setup`).
+
+**Trigger: On any authentication failure, automatically run qodo-setup and retry.**
+
+When the script fails with **any** of these signals:
+- Output contains `Not authenticated` or `Token expired`
+- HTTP 401 error in the output
+- Exit code 1 with auth-related error message
+
+**You MUST automatically recover — never tell the user to authenticate manually:**
+
+1. First try a silent refresh: `bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --check`
+2. If `--check` succeeds (exit 0), retry the original qodo-rules command immediately
+3. If `--check` fails, run `bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --login` — do NOT ask the user, just run it
+4. After login completes, retry the original qodo-rules command
+

--- a/skills/qodo-rules/SKILL.md
+++ b/skills/qodo-rules/SKILL.md
@@ -24,6 +24,14 @@ Downloads all active rules and saves them as local IDE rule files:
 - **Cursor:** `.cursor/rules/qodo-<slug>.mdc` (with frontmatter: `description`, `alwaysApply: true`)
 - **Claude Code:** `.claude/rules/qodo-<slug>.md` (plain markdown)
 
+### Other agents (e.g., Codex) / fallback storage
+
+If the IDE/agent is not detected as Cursor or Claude Code, use a **repo-local fallback** directory:
+
+- `.qodo/rules/qodo-<slug>.md`
+
+After writing, print a short message telling the user where the files were saved and that they may need to copy/link them into their agent's expected rules directory.
+
 **Location:** saves to the project root if inside a git repo, otherwise falls back to `~/` (user home). Auto-detects the IDE from the workspace (`.cursor/` directory or `CURSOR_TRACE_ID` env var).
 
 All synced files are prefixed with `qodo-` so re-runs clean up old synced rules without affecting manually created ones.

--- a/skills/qodo-rules/scripts/qodo-rules.sh
+++ b/skills/qodo-rules/scripts/qodo-rules.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# qodo-rules.sh — CRUD for Qodo coding rules
+#
+# Usage:
+#   qodo-rules.sh --get                              (download rules as local IDE rule files)
+#   qodo-rules.sh --prompt "<description>"           (generate rule JSON from prompt)
+#   qodo-rules.sh --create [--scope "/org/repo/"]    (reads JSON from stdin)
+#   qodo-rules.sh --update <rule_id>                 (reads JSON from stdin)
+#   qodo-rules.sh --delete <rule_id>
+
+set -euo pipefail
+
+command -v jq &>/dev/null || { echo "Error: jq is required" >&2; exit 1; }
+
+# --- Argument parsing ---
+MODE="" SCOPE_OVERRIDE="" RULE_ID="" PROMPT_TEXT=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --get)     MODE="get";  shift ;;
+        --prompt)  MODE="prompt"; [ -z "${2:-}" ] && { echo "Error: --prompt requires a description" >&2; exit 1; }; PROMPT_TEXT="$2"; shift 2 ;;
+        --create)  MODE="create"; shift ;;
+        --update)  MODE="update"; [ -z "${2:-}" ] && { echo "Error: --update requires a rule ID" >&2; exit 1; }; RULE_ID="$2"; shift 2 ;;
+        --delete)  MODE="delete"; [ -z "${2:-}" ] && { echo "Error: --delete requires a rule ID" >&2; exit 1; }; RULE_ID="$2"; shift 2 ;;
+        --scope)   [ -z "${2:-}" ] && { echo "Error: --scope requires a path" >&2; exit 1; }; SCOPE_OVERRIDE="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+[ -z "$MODE" ] && { echo "Usage: qodo-rules.sh --get | --prompt <desc> | --create | --update <id> | --delete <id>"; exit 1; }
+
+# --- Prerequisites ---
+for cmd in curl git; do
+    command -v "$cmd" &>/dev/null || { echo "Error: $cmd is required" >&2; exit 1; }
+done
+
+# --- Auth ---
+[ -f "$HOME/.qodo/skill_auth.json" ] || { echo "ℹ️  Not authenticated. Run: /qodo-setup --login" >&2; exit 1; }
+_auth=$(cat "$HOME/.qodo/skill_auth.json")
+API_KEY=$(echo "$_auth" | jq -r '.id_token // empty')
+API_URL=$(echo "$_auth" | jq -r '.platform_url // empty')
+[ -z "$API_URL" ] && API_URL="https://qodo-platform.qodo.ai"
+API_URL="${API_URL%/}"
+
+[ -z "$API_KEY" ] && { echo "ℹ️  Not authenticated. Run: /qodo-setup --login" >&2; exit 1; }
+
+# --- API call helper ---
+# call <METHOD> <path> [extra curl args]
+call() {
+    local method="$1" path="$2"; shift 2
+    curl -s -w "\n%{http_code}" -X "$method" -H "Authorization: Bearer $API_KEY" "$@" "${API_URL}${path}" 2>/dev/null
+}
+code() { echo "$1" | tail -n1; }
+body() { echo "$1" | sed '$d'; }
+
+# --- Scope detection ---
+detect_scope() {
+    if [ -n "$SCOPE_OVERRIDE" ]; then
+        QUERY_SCOPE="$SCOPE_OVERRIDE"; SCOPE_CONTEXT="Custom scope"; return
+    fi
+    local remote; remote=$(git config --get remote.origin.url 2>/dev/null || echo "")
+    [ -z "$remote" ] && { echo "Error: No git remote" >&2; return 1; }
+    QUERY_SCOPE=$(echo "$remote" | sed -E 's|\.git$||' | sed -E 's|^.*[:/]([^/]+/[^/]+)$|/\1/|')
+    [ -z "$QUERY_SCOPE" ] || [ "$QUERY_SCOPE" = "$remote" ] && { echo "Error: Could not parse scope from git remote" >&2; return 1; }
+    SCOPE_CONTEXT="Repository"
+    local root; root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [ -n "$root" ]; then
+        local rel="${PWD#"$root"/}"
+        if [[ "$rel" == modules/* ]] && [ "$rel" != "$PWD" ]; then
+            local mod; mod=$(echo "$rel" | cut -d'/' -f1-2)
+            QUERY_SCOPE="${QUERY_SCOPE}${mod}/"
+            SCOPE_CONTEXT="Module: \`${mod}\`"
+        fi
+    fi
+}
+
+# --- Get: download rules as local IDE rule files ---
+if [ "$MODE" = "get" ]; then
+    detect_scope || { echo "⚠️  Could not detect scope. Skipping rules get."; exit 0; }
+
+    # Determine rules directory: project root if in a git repo, else user home
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    BASE_DIR="${GIT_ROOT:-$HOME}"
+
+    RULES_DIR="" RULES_EXT="" IDE_NAME=""
+    if [ -d "${BASE_DIR}/.cursor" ] || [ -n "${CURSOR_TRACE_ID:-}" ]; then
+        RULES_DIR="${BASE_DIR}/.cursor/rules"
+        RULES_EXT=".mdc"
+        IDE_NAME="Cursor"
+    else
+        RULES_DIR="${BASE_DIR}/.claude/rules"
+        RULES_EXT=".md"
+        IDE_NAME="Claude"
+    fi
+
+    ALL_RULES="[]"; PAGE=1; PAGE_SIZE=50
+    while true; do
+        ENC=$(printf '%s' "$QUERY_SCOPE" | jq -Rr @uri)
+        set +e; R=$(call GET "/rules/v1/rules?scopes=${ENC}&state=active&page=${PAGE}&page_size=${PAGE_SIZE}"); EC=$?; set -e
+        [ $EC -ne 0 ] && { echo "⚠️  Network error" >&2; exit 1; }
+        C=$(code "$R"); B=$(body "$R")
+        [ "$C" = "401" ] && { echo "⚠️  Token expired. Run: /qodo-setup --login" >&2; exit 1; }
+        [ "$C" != "200" ] && { echo "⚠️  Failed to get rules (HTTP $C)" >&2; exit 1; }
+        PAGE_RULES=$(echo "$B" | jq '.rules // []')
+        ALL_RULES=$(echo "$ALL_RULES $PAGE_RULES" | jq -s '.[0] + .[1]')
+        COUNT=$(echo "$PAGE_RULES" | jq 'length')
+        [ "$COUNT" -lt "$PAGE_SIZE" ] && break
+        PAGE=$((PAGE + 1))
+    done
+
+    TOTAL=$(echo "$ALL_RULES" | jq 'length')
+    [ "$TOTAL" -eq 0 ] && { echo "ℹ️  No rules for: ${QUERY_SCOPE}"; exit 0; }
+
+    mkdir -p "$RULES_DIR"
+
+    # Remove previously synced qodo rules
+    for old_file in "$RULES_DIR"/qodo-*"${RULES_EXT}"; do
+        [ -f "$old_file" ] && rm "$old_file"
+    done
+
+    echo "$ALL_RULES" | jq -c '.[]' | while IFS= read -r rule; do
+        NAME=$(echo "$rule" | jq -r '.name')
+        SEVERITY=$(echo "$rule" | jq -r '.severity // "recommendation"')
+        CATEGORY=$(echo "$rule" | jq -r '.category // ""')
+        CONTENT=$(echo "$rule" | jq -r '.content // .description // ""')
+        DESCRIPTION=$(echo "$rule" | jq -r '.description // .name')
+        GOOD_EXAMPLES=$(echo "$rule" | jq -r 'if .goodExamples and .goodExamples != "" then .goodExamples else empty end')
+        BAD_EXAMPLES=$(echo "$rule" | jq -r 'if .badExamples and .badExamples != "" then .badExamples else empty end')
+
+        SLUG=$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+        FILEPATH="${RULES_DIR}/qodo-${SLUG}${RULES_EXT}"
+
+        {
+            if [ "$IDE_NAME" = "Cursor" ]; then
+                echo "---"
+                echo "description: ${DESCRIPTION}"
+                echo "alwaysApply: true"
+                echo "---"
+                echo ""
+            fi
+            echo "# ${NAME}"
+            echo ""
+            SEVERITY_UPPER=$(echo "$SEVERITY" | tr '[:lower:]' '[:upper:]')
+            echo "**Severity:** ${SEVERITY_UPPER} | **Category:** ${CATEGORY}"
+            echo ""
+            echo "${CONTENT}"
+            if [ -n "${GOOD_EXAMPLES:-}" ]; then
+                echo ""
+                echo "## Good Examples"
+                echo ""
+                echo "${GOOD_EXAMPLES}"
+            fi
+            if [ -n "${BAD_EXAMPLES:-}" ]; then
+                echo ""
+                echo "## Bad Examples"
+                echo ""
+                echo "${BAD_EXAMPLES}"
+            fi
+        } > "$FILEPATH"
+
+        echo "  ✓ ${NAME} → qodo-${SLUG}${RULES_EXT}"
+    done
+
+    echo ""
+    echo "Synced ${TOTAL} Qodo rules to ${RULES_DIR}/ (${IDE_NAME} format)"
+    exit 0
+fi
+
+# --- Prompt to Rule ---
+if [ "$MODE" = "prompt" ]; then
+    J=$(jq -n --arg p "$PROMPT_TEXT" '{prompt: $p}')
+    R=$(call POST "/rules/v1/prompt-to-rule" -H "Content-Type: application/json" -d "$J")
+    C=$(code "$R"); B=$(body "$R")
+    [ "$C" != "200" ] && { echo "Error: Failed to generate rule (HTTP $C)" >&2; echo "$B" >&2; exit 1; }
+    echo "$B"; exit 0
+fi
+
+# --- Create ---
+if [ "$MODE" = "create" ]; then
+    detect_scope || { echo "Error: Could not detect scope" >&2; exit 1; }
+    J=$(cat | jq --arg s "$QUERY_SCOPE" '. + {scopes: [$s]}')
+    R=$(call POST "/rules/v1/rule" -H "Content-Type: application/json" -d "$J")
+    C=$(code "$R"); B=$(body "$R")
+    [ "$C" != "201" ] && { echo "Error: Failed to create rule (HTTP $C)" >&2; echo "$B" >&2; exit 1; }
+    echo "$B"; exit 0
+fi
+
+# --- Update ---
+if [ "$MODE" = "update" ]; then
+    J=$(cat)
+    [ -n "$SCOPE_OVERRIDE" ] && J=$(echo "$J" | jq --arg s "$SCOPE_OVERRIDE" '. + {scopes: [$s]}')
+    R=$(call PUT "/rules/v1/rule/${RULE_ID}" -H "Content-Type: application/json" -d "$J")
+    C=$(code "$R"); B=$(body "$R")
+    [ "$C" != "200" ] && { echo "Error: Failed to update rule (HTTP $C)" >&2; echo "$B" >&2; exit 1; }
+    echo "$B"; exit 0
+fi
+
+# --- Delete ---
+if [ "$MODE" = "delete" ]; then
+    R=$(call DELETE "/rules/v1/rule/${RULE_ID}")
+    C=$(code "$R")
+    [ "$C" != "204" ] && { echo "Error: Failed to delete rule (HTTP $C)" >&2; body "$R" >&2; exit 1; }
+    echo "Rule ${RULE_ID} deleted"; exit 0
+fi

--- a/skills/qodo-setup/SKILL.md
+++ b/skills/qodo-setup/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: qodo-setup
+description: "PROACTIVE: Guide users through Qodo authentication when they first use Qodo features. Use when user tries qodo-rules but is not authenticated. Browser-based OIDC login that automatically obtains JWT and saves to ~/.qodo/skill_auth.json for automatic use by other Qodo skills."
+---
+
+# Qodo Setup - OIDC Authentication
+
+Browser-based OIDC authentication for Qodo platform in Claude Code skills.
+
+**Script:** `bash .claude/skills/qodo-setup/scripts/qodo-setup.sh`
+
+**Prerequisites:** `curl`, `jq`, browser
+
+---
+
+## When to Use (PROACTIVE)
+
+Use this skill **automatically** when:
+
+1. User tries `/qodo-rules` but gets authentication error
+2. User mentions wanting to use Qodo features
+3. User asks "how do I set up Qodo?"
+4. Any Qodo skill fails due to missing authentication
+
+**Check first:**
+```bash
+bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --check
+```
+- Exit code 0 = authenticated (skip setup)
+- Exit code 1 = not authenticated (run setup)
+
+---
+
+## Setup Flow
+
+### Check Authentication Status
+
+```bash
+bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --check
+```
+
+Silent check — returns exit code only:
+- **0**: Token is valid, or was expired but successfully refreshed via refresh token
+- **1**: Token expired and refresh failed (or no token stored) → re-run `--login`
+
+If the token is expired, `--check` automatically attempts a silent refresh via `POST /auth/v1/oidc/token`. The auth file is updated transparently on success.
+
+### Interactive Browser Login (Primary Method)
+
+```bash
+bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --login
+```
+
+This command:
+1. Initializes OIDC login session with Qodo platform
+2. Opens browser to login URL
+3. Waits for user to authenticate in browser
+4. Polls for authentication completion
+5. Receives JWT token and refresh token
+6. Detects tenant-specific platform URL (via redirect check)
+7. Saves to `~/.qodo/skill_auth.json` (mode 600)
+8. Displays user info, platform URL (if tenant-specific), and token expiration
+
+**OIDC Flow:**
+- **Init**: POST `/auth/v1/oidc/init_login` with trace_id and init_client=command
+- **Open**: Browser opens login_url from response
+- **Poll**: Continuously polls `/auth/v1/oidc/poll_token` until HTTP 200
+- **Detect**: Calls API to check for tenant redirect (HTTP 409). If redirected, extracts the correct platform URL by replacing `app.` subdomain with `qodo-platform.`
+- **Save**: Stores id_token, refresh_token, and platform_url (if tenant-specific)
+- **Auto-refresh**: On subsequent `--check`, refreshes expired tokens automatically via `/auth/v1/oidc/token` (preserves platform_url)
+
+### Manual JWT Token (Fallback)
+
+```bash
+bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --set-token "eyJhbG..."
+```
+
+Use this if browser login fails. Manually validates and saves JWT token.
+
+### Clear Stored Token
+
+```bash
+bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --clear
+```
+
+Removes stored authentication.
+
+---
+
+## What Gets Saved
+
+After successful token validation:
+
+**Token Storage:** `~/.qodo/skill_auth.json`
+
+```json
+{
+  "id_token": "eyJhbG...",
+  "refresh_token": "",
+  "platform_url": "https://qodo-platform.acme-corp.qodo.ai",
+  "expires_at": 1234567890,
+  "updated_at": 1234567890
+}
+```
+
+**Fields:**
+- `id_token` - JWT for authentication
+- `refresh_token` - Token for auto-refresh
+- `platform_url` - API base URL, detected automatically after login. Defaults to `https://qodo-platform.qodo.ai`; set to a tenant-specific URL when the user belongs to a dedicated tenant. Used by qodo-rules and other Qodo skills.
+- `expires_at` - Token expiration timestamp
+- `updated_at` - Last update timestamp
+
+**JWT Claims Extracted:**
+- `email` - User identification
+- `workspace_id` - **Automatically used by qodo-rules**
+- `exp` - Token expiration
+
+**Security:**
+- File mode 600 (owner read/write only)
+- Directory `~/.qodo/` mode 700
+
+---
+
+## After Setup
+
+Once authenticated, qodo-rules works automatically:
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --get
+```
+
+The script automatically:
+- Reads JWT from `~/.qodo/skill_auth.json`
+- Uses token as Bearer authentication for API requests
+
+---
+
+## Guidelines for Claude
+
+- **Always check first** with `--check` before suggesting setup
+- **Don't interrupt** if already authenticated
+- **When authentication needed:**
+  1. Run `--login` to start browser-based OIDC flow
+  2. Script will open browser automatically
+  3. Wait for polling to complete (shows dots while waiting)
+  4. Confirm success by showing extracted user info
+- **If login fails:**
+  - Offer manual fallback with `--set-token`
+  - Guide user to obtain JWT from browser DevTools
+- **Guide to next steps** - suggest trying `/qodo-rules --get`
+- **If token expires** - `--check` auto-refreshes using the stored refresh token
+- **If refresh token also expired** - run `--login` again for full re-authentication

--- a/skills/qodo-setup/scripts/qodo-setup.sh
+++ b/skills/qodo-setup/scripts/qodo-setup.sh
@@ -1,0 +1,253 @@
+#!/bin/bash
+# qodo-setup.sh — Qodo platform authentication via OIDC
+#
+# Usage:
+#   qodo-setup.sh --check              # Check if authenticated (auto-refreshes if expired)
+#   qodo-setup.sh --login              # Interactive browser login
+#   qodo-setup.sh --set-token <token>  # Set JWT token manually
+#   qodo-setup.sh --clear              # Clear stored token
+
+set -euo pipefail
+
+CONFIG_DIR="$HOME/.qodo"
+AUTH_FILE="$CONFIG_DIR/skill_auth.json"
+API_URL="${QODO_PLATFORM_URL:-https://qodo-platform.qodo.ai}"
+API_URL="${API_URL%/}"
+
+MODE=""
+TOKEN_VALUE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check) MODE="check"; shift ;;
+        --login) MODE="login"; shift ;;
+        --set-token)
+            MODE="set-token"
+            if [ -z "${2:-}" ]; then echo "Error: --set-token requires a JWT token" >&2; exit 1; fi
+            TOKEN_VALUE="$2"; shift 2 ;;
+        --clear) MODE="clear"; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$MODE" ]; then
+    echo "Usage: qodo-setup.sh --check | --login | --set-token <token> | --clear"
+    exit 1
+fi
+
+# --- Helpers ---
+
+generate_trace_id() {
+    if command -v uuidgen &>/dev/null; then
+        uuidgen | tr '[:upper:]' '[:lower:]'
+    else
+        python3 -c 'import uuid; print(uuid.uuid4())' 2>/dev/null || echo "$(date +%s)-$RANDOM"
+    fi
+}
+
+decode_jwt_payload() {
+    local token="$1"
+    [[ "$token" =~ ^[^.]+\.[^.]+\.[^.]+$ ]] || return 1
+    local payload padded
+    payload=$(echo "$token" | cut -d'.' -f2)
+    padded="$payload"
+    case $((${#payload} % 4)) in
+        2) padded="${payload}==" ;;
+        3) padded="${payload}=" ;;
+    esac
+    echo "$padded" | tr '_-' '/+' | { base64 --decode 2>/dev/null || base64 -D 2>/dev/null; } || return 1
+}
+
+save_tokens() {
+    local id_token="$1" refresh_token="${2:-}" expires_at="$3" platform_url="${4:-}"
+    mkdir -p "$CONFIG_DIR" && chmod 700 "$CONFIG_DIR"
+    jq -n \
+        --arg id "$id_token" \
+        --arg rt "$refresh_token" \
+        --arg url "$platform_url" \
+        --argjson exp "$expires_at" \
+        --argjson now "$(date +%s)" \
+        '{id_token: $id, refresh_token: $rt, platform_url: $url, expires_at: $exp, updated_at: $now}' \
+        > "$AUTH_FILE"
+    chmod 600 "$AUTH_FILE"
+}
+
+detect_platform_url() {
+    local token="$1"
+    local response http_code body
+    response=$(curl -s -w "\n%{http_code}" -H "Authorization: Bearer $token" "${API_URL}/rules/v1/rules?page=1&page_size=1" 2>/dev/null)
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+
+    if [ "$http_code" = "409" ]; then
+        local redirect_url base_url platform_url verify_code
+        redirect_url=$(echo "$body" | jq -r '.detail.redirectTo // empty' 2>/dev/null || echo "")
+        if [ -n "$redirect_url" ]; then
+            base_url=$(echo "$redirect_url" | sed 's|^\(https\{0,1\}://[^/]*\).*|\1|')
+            platform_url=$(echo "$base_url" | sed 's|://app\.|://qodo-platform.|')
+            verify_code=$(curl -s -o /dev/null -w "%{http_code}" \
+                -H "Authorization: Bearer $token" \
+                "${platform_url}/rules/v1/rules?page=1&page_size=1" 2>/dev/null)
+            [ "$verify_code" = "200" ] && echo "$platform_url" && return 0
+        fi
+    fi
+
+    echo "$API_URL"
+}
+
+# --- Check mode ---
+if [ "$MODE" = "check" ]; then
+    [ -f "$AUTH_FILE" ] || exit 1
+    auth_data=$(cat "$AUTH_FILE" 2>/dev/null || echo "")
+    [ -n "$auth_data" ] || exit 1
+
+    id_token=$(echo "$auth_data" | jq -r '.id_token // empty' 2>/dev/null || echo "")
+    expires_at=$(echo "$auth_data" | jq -r '.expires_at // 0' 2>/dev/null || echo "0")
+    now=$(date +%s)
+
+    # Token still valid (5-minute buffer)
+    [ -n "$id_token" ] && [ "$now" -lt "$((expires_at - 300))" ] && exit 0
+
+    # Token expired — attempt refresh
+    refresh_token=$(echo "$auth_data" | jq -r '.refresh_token // empty' 2>/dev/null || echo "")
+    [ -z "$refresh_token" ] && exit 1
+
+    response=$(curl -s -w "\n%{http_code}" \
+        -X POST "${API_URL}/auth/v1/oidc/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        --data-urlencode "grant_type=refresh_token" \
+        --data-urlencode "refresh_token=${refresh_token}" 2>/dev/null)
+    http_code=$(echo "$response" | tail -n1)
+    body=$(echo "$response" | sed '$d')
+
+    [ "$http_code" != "200" ] && exit 1
+
+    new_id_token=$(echo "$body" | jq -r '.id_token // empty')
+    new_refresh_token=$(echo "$body" | jq -r '.refresh_token // empty')
+    new_expires_in=$(echo "$body" | jq -r '.expires_in // 3600')
+    existing_platform_url=$(echo "$auth_data" | jq -r '.platform_url // empty' 2>/dev/null || echo "")
+    [ -z "$existing_platform_url" ] && existing_platform_url="https://qodo-platform.qodo.ai"
+
+    [ -z "$new_id_token" ] && exit 1
+    [ -z "$new_refresh_token" ] && new_refresh_token="$refresh_token"
+
+    save_tokens "$new_id_token" "$new_refresh_token" "$((now + new_expires_in))" "$existing_platform_url"
+    exit 0
+fi
+
+# --- Clear mode ---
+if [ "$MODE" = "clear" ]; then
+    rm -f "$AUTH_FILE"
+    echo "✓ Authentication cleared"
+    exit 0
+fi
+
+# --- Login mode (OIDC flow) ---
+if [ "$MODE" = "login" ]; then
+    TRACE_ID=$(generate_trace_id)
+
+    init_response=$(curl -s -w "\n%{http_code}" \
+        -X POST "${API_URL}/auth/v1/oidc/init_login" \
+        -H "Content-Type: application/json" \
+        -H "Qodo-Client-Type: skill" \
+        -d "{\"trace_id\": \"$TRACE_ID\", \"init_client\": \"command\"}" 2>/dev/null)
+
+    http_code=$(echo "$init_response" | tail -n1)
+    response_body=$(echo "$init_response" | sed '$d')
+
+    if [ "$http_code" != "200" ]; then
+        echo "Error: Failed to initialize login (HTTP $http_code)" >&2
+        echo "$response_body" >&2
+        exit 1
+    fi
+
+    login_url=$(echo "$response_body" | jq -r '.login_url // empty')
+    session_id=$(echo "$response_body" | jq -r '.session_id // empty')
+    poll_delay=$(echo "$response_body" | jq -r '.poll_delay // 2')
+    poll_interval=$(echo "$response_body" | jq -r '.poll_interval // 2')
+    poll_timeout=$(echo "$response_body" | jq -r '.poll_timeout // 300')
+
+    if [ -z "$login_url" ] || [ -z "$session_id" ]; then
+        echo "Error: Invalid init_login response" >&2; exit 1
+    fi
+
+    echo "Opening browser: $login_url"
+    if command -v xdg-open &>/dev/null; then xdg-open "$login_url" &>/dev/null
+    elif command -v open &>/dev/null; then open "$login_url" &>/dev/null
+    else echo "Please open this URL manually: $login_url"; fi
+
+    echo -n "Waiting for authentication"
+    sleep "$poll_delay"
+
+    attempt=1
+    max_attempts=$((poll_timeout / poll_interval))
+
+    while [ $attempt -le $max_attempts ]; do
+        poll_response=$(curl -s -w "\n%{http_code}" \
+            -X POST "${API_URL}/auth/v1/oidc/poll_token" \
+            -H "Content-Type: application/json" \
+            -H "Qodo-Client-Type: skill" \
+            -H "X-Request-Attempt: $attempt" \
+            -d "{\"trace_id\": \"$TRACE_ID\", \"session_id\": \"$session_id\"}" 2>/dev/null)
+
+        poll_http_code=$(echo "$poll_response" | tail -n1)
+        poll_body=$(echo "$poll_response" | sed '$d')
+
+        if [ "$poll_http_code" = "200" ]; then
+            id_token=$(echo "$poll_body" | jq -r '.id_token // empty')
+            refresh_token=$(echo "$poll_body" | jq -r '.refresh_token // empty')
+            expires_in=$(echo "$poll_body" | jq -r '.expires_in // 3600')
+
+            [ -z "$id_token" ] && { echo "" && echo "Error: No id_token in response" >&2; exit 1; }
+
+            now=$(date +%s)
+            payload=$(decode_jwt_payload "$id_token" 2>/dev/null || echo "")
+            email=$(echo "$payload" | jq -r '.email // empty' 2>/dev/null || echo "")
+
+            echo ""
+            detected_url=$(detect_platform_url "$id_token")
+            save_tokens "$id_token" "$refresh_token" "$((now + expires_in))" "$detected_url"
+
+            echo "✓ Authenticated"
+            [ -n "$email" ] && echo "  Email: $email"
+            echo "  Platform URL: $detected_url"
+            echo "  Token expires in: $((expires_in / 3600)) hours"
+            exit 0
+
+        elif [ "$poll_http_code" = "202" ]; then
+            echo -n "."
+            sleep "$poll_interval"
+            attempt=$((attempt + 1))
+        else
+            echo ""
+            echo "Error: Polling failed (HTTP $poll_http_code)" >&2
+            echo "$poll_body" >&2
+            exit 1
+        fi
+    done
+
+    echo "" && echo "Error: Authentication timeout" >&2; exit 1
+fi
+
+# --- Set token mode ---
+if [ "$MODE" = "set-token" ]; then
+    [[ "$TOKEN_VALUE" =~ ^[^.]+\.[^.]+\.[^.]+$ ]] || {
+        echo "Error: Invalid JWT format (expected header.payload.signature)" >&2; exit 1
+    }
+
+    payload=$(decode_jwt_payload "$TOKEN_VALUE" 2>/dev/null || echo "")
+    [ -z "$payload" ] && { echo "Error: Failed to decode JWT" >&2; exit 1; }
+
+    exp=$(echo "$payload" | jq -r '.exp // empty' 2>/dev/null || echo "")
+    email=$(echo "$payload" | jq -r '.email // empty' 2>/dev/null || echo "")
+    [ -z "$exp" ] && { echo "Error: JWT missing expiration" >&2; exit 1; }
+
+    detected_url=$(detect_platform_url "$TOKEN_VALUE")
+    save_tokens "$TOKEN_VALUE" "" "$exp" "$detected_url"
+
+    echo "✓ Token saved"
+    [ -n "$email" ] && echo "  Email: $email"
+    echo "  Platform URL: $detected_url"
+    echo "  Token expires in: $(( (exp - $(date +%s)) / 3600 )) hours"
+    exit 0
+fi


### PR DESCRIPTION
I'm proposing adding two new skills that take a different approach from the current Qodo skills:

1. These skills don’t require the user to generate a new API key. Instead, they use a browser login flow to generate a Qodo Skill JWT.

2. The Rules skill supports CRUD operations for rules.

3. The rules are not automatically added to the context or triggered on every new chat. Instead, they’re downloaded into Cursor/Claude’s predefined rules folder, and Claude/.Cursor decides automatically what to use and when.
