### PR TITLE
docs(EB-16): update API key URL, Claude Marketplace install, and CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,8 +271,11 @@ python3 -m pytest tests/
 ```bash
 # Install skill locally
 npx skills add /path/to/qodo-skills/skills/get-qodo-rules
+```
 
-# Claude Code marketplace: Coming soon
+**Claude Code Marketplace:**
+```
+/plugin install qodo-skills@claude-plugins-official
 ```
 
 **Testing:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,12 @@ git commit -m "Brief description of changes"
 - If `git commit` fails: Check for merge conflicts or pre-commit hooks
 ```
 
+## Qodo Endpoint Attribution
+
+If your skill calls Qodo API endpoints, all requests must include attribution headers to identify the caller and correlate requests.
+
+See [attribution guidelines](../skills/get-qodo-rules/references/attribution.md) for required headers (`Authorization`, `request-id`, `qodo-client-type`) and optional headers (`trace_id`), with implementation examples in bash and Python.
+
 ## Helper Scripts
 
 If your skill needs helper scripts:
@@ -220,7 +226,7 @@ main "$@"
 - [ ] Works with different project structures
 - [ ] Documentation is complete
 
-**Cross-compatibility** (see AGENTS.md for detailed testing procedures):
+**Cross-compatibility** (see [Testing Requirements in AGENTS.md](../AGENTS.md#testing-requirements) for full test matrix):
 - [ ] Tested on macOS, Linux (Ubuntu/Debian), and Windows
 - [ ] Tested with multiple coding agents (Claude Code, Cursor, etc.)
 - [ ] If applicable: Tested with multiple git providers (GitHub, GitLab, Bitbucket, Azure DevOps)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ npx skills add qodo-ai/qodo-skills/skills/get-qodo-rules
 npx skills add qodo-ai/qodo-skills/skills/qodo-pr-resolver
 ```
 
-**Claude Code Marketplace:** Coming soon - one-click installation
+**Claude Code Marketplace:**
+```
+/plugin install qodo-skills@claude-plugins-official
+```
 
 **Works with:**
 - **Claude Code** - Skills available as `/get-qodo-rules`, `/qodo-pr-resolver`
@@ -108,7 +111,7 @@ Create `~/.qodo/config.json`:
   - If empty/omitted: Uses `https://qodo-platform.qodo.ai/rules/v1/`
   - If specified: Uses `https://qodo-platform.<ENVIRONMENT_NAME>.qodo.ai/rules/v1/`
 
-Get your API key at: https://app.qodo.ai/settings/api-keys
+Get your API key at: https://app.qodo.ai/account/api-keys
 
 **Minimal configuration (production):**
 ```json

--- a/skills/get-qodo-rules/references/attribution.md
+++ b/skills/get-qodo-rules/references/attribution.md
@@ -1,0 +1,71 @@
+# Attribution Headers for Qodo Endpoints
+
+All HTTP requests to Qodo API endpoints must include attribution headers so the platform can identify the caller, correlate requests, and support tracing.
+
+## Required Headers
+
+| Header | Value | Notes |
+|--------|-------|-------|
+| `Authorization` | `Bearer {API_KEY}` | Required for authentication |
+| `request-id` | `{UUID}` | Generated once per invocation; reuse on every paginated request |
+| `qodo-client-type` | `skill-{skill-name}` | Identifies the skill making the request |
+
+## Optional Headers
+
+| Header | Value | Notes |
+|--------|-------|-------|
+| `trace_id` | `{TRACE_ID}` | Only include if `TRACE_ID` is set in the shell environment; skip silently otherwise |
+
+## Implementation Rules
+
+1. **`request-id`**: Generate a UUID once at the start of each skill invocation (e.g. `uuidgen` or `python3 -c "import uuid; print(uuid.uuid4())"`). Use the **same value on every page fetch** for that invocation — this correlates all page fetches for a single skill run on the platform side.
+
+2. **`qodo-client-type`**: Use the format `skill-{skill-name}` where `skill-name` matches the skill's identifier. For example:
+   - `get-qodo-rules` skill → `qodo-client-type: skill-get-qodo-rules`
+   - A new `my-skill` skill → `qodo-client-type: skill-my-skill`
+
+3. **`trace_id`**: Read from the `TRACE_ID` shell environment variable. If not set, omit the header entirely — do not send an empty value.
+
+## Example Request
+
+```bash
+curl -s \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-get-qodo-rules" \
+  "${API_URL}/rules?scopes=${ENCODED_SCOPE}&state=active&page=1&page_size=50"
+```
+
+With optional trace:
+
+```bash
+TRACE_HEADER=""
+if [ -n "${TRACE_ID:-}" ]; then
+  TRACE_HEADER="-H trace_id:${TRACE_ID}"
+fi
+
+curl -s \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-get-qodo-rules" \
+  ${TRACE_HEADER} \
+  "${API_URL}/rules?..."
+```
+
+## Python Example
+
+```python
+headers = {
+    "Authorization": f"Bearer {api_key}",
+    "request-id": request_id,
+    "qodo-client-type": "skill-get-qodo-rules",
+}
+if trace_id := os.environ.get("TRACE_ID"):
+    headers["trace_id"] = trace_id
+```
+
+## Why This Matters
+
+- **`request-id`** allows the Qodo platform to correlate all paginated page fetches into a single logical request, enabling accurate usage metrics and debugging.
+- **`qodo-client-type`** identifies which skill or integration is calling the API, enabling per-client analytics and support.
+- **`trace_id`** enables distributed tracing when running in environments that propagate trace context (e.g., CI pipelines, observability platforms).


### PR DESCRIPTION
## Summary

- Fix API key URL: `https://app.qodo.ai/settings/api-keys` → `https://app.qodo.ai/account/api-keys`
- Add Claude Marketplace install command: `/plugin install qodo-skills@claude-plugins-official`
- Add `attribution.md` documenting required headers for Qodo API calls (`Authorization`, `request-id`, `qodo-client-type`, `trace_id`)
- Update `CONTRIBUTING.md` with links to Testing Requirements (AGENTS.md) and new attribution guidelines

## Linear

Closes [EB-16](https://linear.app/qodo/issue/EB-16)

## Test plan

- [ ] Verify API key URL resolves correctly: https://app.qodo.ai/account/api-keys
- [ ] Verify Marketplace install command is accurate: `/plugin install qodo-skills@claude-plugins-official`
- [ ] Review `attribution.md` for correctness against existing `pagination.md` implementation
- [ ] Confirm `CONTRIBUTING.md` links resolve (Testing Requirements anchor, attribution.md path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)