### PR TITLE
chore: remove test comment from qodo-get-rules SKILL.md

### DIFF
--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: qodo-get-rules
 description: "Loads org- and repo-level coding rules from Qodo before code tasks begin, ensuring all generation and modification follows team standards. Use before any code generation or modification task when rules are not already loaded. Invoke when user asks to write, edit, refactor, or review code, or when starting implementation planning."
-# test-skill-detection: added for DETECT-01 workflow test, safe to remove
 allowed-tools: ["Bash"]
 triggers:
   - "get.?qodo.?rules"


### PR DESCRIPTION
Removes the temporary comment added to skills/qodo-get-rules/SKILL.md during DETECT-01 workflow verification testing.