### PR TITLE
test: rename Attribution to Usage Tracking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,11 +167,11 @@ git commit -m "Brief description of changes"
 - If `git commit` fails: Check for merge conflicts or pre-commit hooks
 ```
 
-## Qodo Endpoint Attribution
+## Qodo Endpoint Usage Tracking
 
-If your skill calls Qodo API endpoints, all requests must include attribution headers to identify the caller and correlate requests.
+If your skill calls Qodo API endpoints, all requests must include usage tracking headers to identify the caller and correlate requests.
 
-See [attribution guidelines](skills/qodo-get-rules/references/attribution.md) for required headers (`Authorization`, `request-id`, `qodo-client-type`) and optional headers (`trace_id`), with implementation examples in bash and Python.
+See [usage tracking guidelines](skills/qodo-get-rules/references/usage-tracking.md) for required headers (`Authorization`, `request-id`, `qodo-client-type`) and optional headers (`trace_id`), with implementation examples in bash and Python.
 
 ## Helper Scripts
 

--- a/skills/qodo-get-rules/references/usage-tracking.md
+++ b/skills/qodo-get-rules/references/usage-tracking.md
@@ -1,6 +1,6 @@
-# Attribution Headers for Qodo Endpoints
+# Usage Tracking Headers for Qodo Endpoints
 
-All HTTP requests to Qodo API endpoints must include attribution headers so the platform can identify the caller, correlate requests, and support tracing.
+All HTTP requests to Qodo API endpoints must include usage tracking headers so the platform can identify the caller, correlate requests, and support tracing.
 
 ## Required Headers
 


### PR DESCRIPTION
## Summary

- Renames `skills/qodo-get-rules/references/attribution.md` to `usage-tracking.md`
- Updates the file heading from "Attribution Headers for Qodo Endpoints" to "Usage Tracking Headers for Qodo Endpoints"
- Updates the description text to use "usage tracking headers" terminology

## Purpose

This is a test PR designed to touch files under `skills/` in order to trigger the Slack notification workflow.

## Test plan

- [ ] Verify the Slack notification workflow fires upon PR creation
- [ ] Confirm the PR diff shows the file rename from `attribution.md` to `usage-tracking.md`
- [ ] Check that "Attribution" is replaced with "Usage Tracking" in heading and body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)