### PR TITLE
docs: remove Must load before coding bullet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Shift-left code review skills for AI coding agents. Bring Qodo's quality standar
 Fetches repository-specific coding rules from the Qodo platform API. Provides your agent with security requirements, coding standards, and team conventions before generating code.
 
 **Features:**
-- 🎯 **Must load before coding**: Agent invokes before any code generation/modification task (if not already loaded)
 - 📚 Hierarchical rule matching (universal, org, repo, path-level)
 - ⚖️ Severity-based enforcement (ERROR, WARNING, RECOMMENDATION)
 - 🔄 Module-specific scope detection (`modules/` directories)


### PR DESCRIPTION
## Summary

- Removes the "Must load before coding" bullet from the qodo-get-rules Features list in README.md
- This is a non-skill PR (no files under `skills/` are touched)
- Intended to verify that the Slack notification workflow does NOT fire for non-skill changes

## Test plan

- [ ] Confirm PR only modifies README.md
- [ ] Verify Slack notification workflow does NOT trigger (since no `skills/` files changed)
- [ ] Confirm the README renders correctly without the removed bullet

> Replaces #29, which was based off the wrong branch and contained unintended changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)