### PR TITLE
feat: add Slack Block Kit notification for skill changes

### DIFF
--- a/.github/workflows/notify-skill-changes.yml
+++ b/.github/workflows/notify-skill-changes.yml
@@ -36,4 +36,42 @@ jobs:
         if: steps.changed-skills.outputs.any_changed == 'false'
         run: echo "No skills/ changes in this PR — no notification needed"
 
-      # TODO(Phase 3): Add slackapi/slack-github-action step here
+      - name: Format skill names
+        id: format-skills
+        if: steps.changed-skills.outputs.any_changed == 'true'
+        run: |
+          skills=""
+          for dir in ${{ steps.changed-skills.outputs.all_changed_files }}; do
+            name="${dir#skills/}"
+            if [ -z "$skills" ]; then
+              skills="$name"
+            else
+              skills="$skills, $name"
+            fi
+          done
+          echo "names=$skills" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        if: steps.changed-skills.outputs.any_changed == 'true'
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a  # v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_SKILLS_RELEASES_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "Skill update merged: ${{ github.event.pull_request.title }}"
+            blocks:
+              - type: "header"
+                text:
+                  type: "plain_text"
+                  text: "${{ github.event.pull_request.title }}"
+                  emoji: true
+              - type: "section"
+                fields:
+                  - type: "mrkdwn"
+                    text: "*Author:*\n${{ github.event.pull_request.user.login }}"
+                  - type: "mrkdwn"
+                    text: "*Skills changed:*\n${{ steps.format-skills.outputs.names }}"
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "<${{ github.event.pull_request.html_url }}|View pull request on GitHub>"


### PR DESCRIPTION
## Summary

- **SHA-pinned `slack-github-action`**: Uses `slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a` (v2.1.1) for supply-chain security, avoiding floating version tags
- **Block Kit payload**: Structured Slack message with a `header` block (PR title), a `section` block with two fields (author + comma-separated skill names), and a `section` block with a link to the PR on GitHub
- **`format-skills` step**: Strips the `skills/` prefix from each changed directory path and builds a comma-separated list of skill names, exported via `GITHUB_OUTPUT`
- **Both steps gated on skill changes only**: Both `format-skills` and `Send Slack notification` run only when `steps.changed-skills.outputs.any_changed == 'true'`, so PRs that do not touch `skills/**` produce no notification

## Changes

- `.github/workflows/notify-skill-changes.yml`: Added `Format skill names` and `Send Slack notification` steps after the existing skill detection steps
- `.gitignore`: Added `.planning/` to prevent local planning documents from being tracked

## Test plan

- [ ] Merge a PR that touches `skills/**` and verify a Slack notification arrives with the correct PR title, author, skill names, and PR link
- [ ] Merge a PR that does NOT touch `skills/**` and verify no Slack notification is sent
- [ ] Confirm `SLACK_WEBHOOK_SKILLS_RELEASES_URL` secret is configured in the repository settings before merging

Generated with [Claude Code](https://claude.com/claude-code)