### PR TITLE
docs: tessl score was failing

### DIFF
--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qodo-get-rules
-description: "Loads org- and repo-level coding rules from Qodo before code tasks begin, ensuring all generation and modification follows team standards. Use before any code generation or modification task when rules are not already loaded. Invoke when user asks to write, edit, refactor, or review code, or when starting implementation planning."
-allowed-tools: ["Bash"]
+description: "Loads org- and repo-level coding rules from Qodo (security requirements, naming conventions, architectural patterns, style guidelines) before code tasks begin, ensuring all generation and modification follows team standards. Use when Qodo is configured and the user asks to write, edit, refactor, or review code, or when starting implementation planning. Skip if rules are already loaded."
+allowed-tools: "Bash"
 triggers:
   - "get.?qodo.?rules"
   - "get.?rules"
@@ -29,9 +29,7 @@ triggers:
 
 ## Description
 
-Fetches repository-specific coding rules from the Qodo platform API before code generation or modification tasks. Rules include security requirements, coding standards, quality guidelines, and team conventions that must be applied during code generation.
-**Use** before any code generation or modification task when rules are not already loaded. Invoke when user asks to write, edit, refactor, or review code, or when starting implementation planning.
-**Skip** if "Qodo Rules Loaded" already appears in conversation context
+Fetches repository-specific coding rules from the Qodo platform API before code generation or modification tasks. Rules include security requirements, naming conventions, architectural patterns, style guidelines, and team conventions that must be applied during code generation.
 
 ---
 
@@ -57,6 +55,13 @@ Check that the required Qodo configuration is present. The default location is `
 - **Environment name**: Read from `~/.qodo/config.json` (`ENVIRONMENT_NAME` field), with `QODO_ENVIRONMENT_NAME` environment variable taking precedence. If not found, inform the user that an API key is required and provide setup instructions, then exit gracefully.
 - **Request ID**: Generate a UUID (e.g. via `uuidgen` or `python3 -c "import uuid; print(uuid.uuid4())"`) to use as `request-id` for all API calls in this invocation. This correlates all page fetches for a single rules load on the platform side.
 
+Example config parsing:
+```bash
+API_KEY=$(python3 -c "import json,os; c=json.load(open(os.path.expanduser('~/.qodo/config.json'))); print(c['API_KEY'])")
+ENV_NAME=$(python3 -c "import json,os; c=json.load(open(os.path.expanduser('~/.qodo/config.json'))); print(c.get('ENVIRONMENT_NAME',''))")
+REQUEST_ID=$(uuidgen || python3 -c "import uuid; print(uuid.uuid4())")
+```
+
 ### Step 4: Fetch Rules with Pagination
 
 - Fetch all pages from the API (50 rules per page) until no more results are returned.
@@ -65,7 +70,16 @@ Check that the required Qodo configuration is present. The default location is `
 - Stop after 100 pages maximum (safety limit).
 - If no rules are found after all pages, inform the user and exit gracefully.
 
-See [pagination details](references/pagination.md) for the full algorithm and error handling.
+Example API request (page 1):
+```bash
+curl -s \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "request-id: $REQUEST_ID" \
+  -H "qodo-client-type: skill-qodo-get-rules" \
+  "$API_URL/rules?scopes=$ENCODED_SCOPE&state=active&page=1&page_size=50"
+```
+
+See [pagination details](references/pagination.md) for the full algorithm, URL construction, and error handling.
 
 ### Step 5: Format and Output Rules
 


### PR DESCRIPTION
Tessl score was failing due to malformed tools required being an object and not strings.
I've gone ahead and fixed a few other linting errors it suggested:
https://linear.app/qodo/issue/EB-44/fix-tessl-validation-errors-for-qodo-skills

before:
```
  ✘ allowed_tools_field - 'allowed-tools' must be a string, got object
  ...
  Average Score: 0%
```

After:
```
tessl skill review

Validation Checks

  ✔ skill_md_line_count - SKILL.md line count is 137 (<= 500)
  ✔ frontmatter_valid - YAML frontmatter is valid
  ✔ name_field - 'name' field is valid: 'qodo-get-rules'
  ✔ description_field - 'description' field is valid (388 chars)
  ✔ compatibility_field - 'compatibility' field not present (optional)
  ✔ allowed_tools_field - 'allowed-tools' contains 1 token(s)
  ✔ metadata_version - 'metadata' field not present (optional)
  ✔ metadata_field - 'metadata' field not present (optional)
  ✔ license_field - 'license' field not present (optional)
  ⚠ frontmatter_unknown_keys - Unknown frontmatter key(s) found; consider removing or moving to metadata
  ✔ body_present - SKILL.md body is present

Overall: PASSED (0 errors, 1 warnings)

Judge Evaluation

  Description: 100%
    specificity: 3/3 - Lists multiple specific concrete actions: 'Loads org- and repo-level coding rules', specifies rule types (security requirements, naming conventions, architectural patterns, style guidelines), and describes the purpose (ensuring generation and modification follows team standards).
    trigger_term_quality: 3/3 - Includes natural keywords users would say: 'write', 'edit', 'refactor', 'review code', 'implementation planning', 'Qodo'. These are terms developers naturally use when requesting code-related tasks.
    completeness: 3/3 - Clearly answers both what (loads coding rules from Qodo for various rule types) AND when (explicit 'Use when...' clause with specific triggers like code tasks and Qodo configuration). Also includes helpful 'Skip if' guidance.
    distinctiveness_conflict_risk: 3/3 - Clear niche with distinct triggers - specifically tied to 'Qodo' as a prerequisite and focuses on loading rules before code tasks. The Qodo-specific context and rule-loading purpose make it unlikely to conflict with general coding skills.

    Assessment: This is a well-crafted skill description that excels across all dimensions. It clearly specifies what the skill does (loads Qodo coding rules), provides concrete examples of rule types, includes explicit trigger conditions with natural user language, and has a distinct niche that prevents conflicts with other coding-related skills. The 'Skip if' clause adds helpful context for avoiding redundant activation.

  Content: 85%
    conciseness: 2/3 - The skill is mostly efficient but includes some redundancy - the description section repeats information that appears in the workflow, and some explanations could be tighter (e.g., the scope hierarchy section restates what's already covered in Step 2).
    actionability: 3/3 - Provides fully executable bash and Python code examples for config parsing, API requests, and UUID generation. The curl command is copy-paste ready with clear variable substitution, and the enforcement table gives concrete guidance on rule application.
    workflow_clarity: 3/3 - Clear 7-step sequence with explicit validation checkpoints (check if rules loaded, verify git repo, verify config). Each step has clear exit conditions ('exit gracefully', 'inform user'), and the workflow includes feedback loops for error handling throughout.
    progressive_disclosure: 3/3 - Excellent structure with a clear overview workflow and well-signaled one-level-deep references to detailed materials (repository-scope.md, pagination.md, output-format.md, README.md). Content is appropriately split between overview and reference files.

    Assessment: This is a well-structured skill with clear, actionable workflows and excellent progressive disclosure. The main weakness is minor redundancy between the description and workflow sections, and some content that could be tightened. The executable code examples and explicit validation checkpoints make this highly actionable.

    Suggestions:
      - Remove the Description section at the top since it duplicates information already present in the workflow steps and skill metadata

Average Score: 93%

✔ Skill evaluation completed successfully!
```