### PR TITLE
Add qodo-rules skill (CRUD + sync rules locally)

### DIFF
--- a/skills/qodo-rules/SKILL.md
+++ b/skills/qodo-rules/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: qodo-rules
+description: "Manage Qodo coding rules — get, sync, create, update, delete. Use only when user explicitly asks to view, add, edit, or remove rules."
+---
+
+# Qodo Rules
+
+CRUD operations for Qodo coding rules.
+
+**Script:** `bash .claude/skills/qodo-rules/scripts/qodo-rules.sh`
+
+**Prerequisites:** `curl`, `jq`, `git` — and authenticated via `/qodo-setup`
+
+---
+
+## Get
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --get
+```
+
+Downloads all active rules and saves them as local IDE rule files:
+
+- **Cursor:** `.cursor/rules/qodo-<slug>.mdc` (with frontmatter: `description`, `alwaysApply: true`)
+- **Claude Code:** `.claude/rules/qodo-<slug>.md` (plain markdown)
+
+### Other agents (e.g., Codex) / fallback storage
+
+If the IDE/agent is not detected as Cursor or Claude Code, use a **repo-local fallback** directory:
+
+- `.qodo/rules/qodo-<slug>.md`
+
+After writing, print a short message telling the user where the files were saved and that they may need to copy/link them into their agent's expected rules directory.
+
+**Location:** saves to the project root if inside a git repo, otherwise falls back to `~/` (user home). Auto-detects the IDE from the workspace (`.cursor/` directory or `CURSOR_TRACE_ID` env var).
+
+All synced files are prefixed with `qodo-` so re-runs clean up old synced rules without affecting manually created ones.
+
+Each rule file includes: name, severity, category, content, and examples (if available).
+
+| Severity | Action |
+|----------|--------|
+| **ERROR** | Must comply. Ask user if can't satisfy. |
+| **WARNING** | Should comply. Explain briefly if skipping. |
+| **RECOMMENDATION** | Consider when appropriate. |
+
+---
+
+## Create
+
+**Always use the two-step flow: preview via `--prompt`, then pipe directly into `--create`.**
+
+### Step 1: Preview rule from prompt
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --prompt "Describe the rule in plain English"
+```
+
+Calls the server-side LLM to generate a complete rule JSON (name, category, content, examples, severity). Returns the generated `RuleBase` JSON. **Never manually construct rule JSON** — always use `--prompt` to avoid escaping issues.
+
+After getting the JSON, show it to the user in this format:
+
+```
+---
+**Name:** <name>
+**Category:** <category>
+**Severity:** <severity>
+
+**Rule:**
+<content>
+
+**Good example:**
+<goodExamples>
+
+**Bad example:**
+<badExamples>
+
+Create this rule?
+```
+
+Wait for user confirmation before proceeding to Step 2.
+
+### Step 2: Create (after user approval)
+
+Re-run `--prompt` and pipe its output directly into `--create`. **Never use `echo '<json>'`** — multi-line JSON fields break shell quoting.
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --prompt "Describe the rule in plain English" \
+  | bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --create
+```
+
+With optional scope override:
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --prompt "Describe the rule in plain English" \
+  | bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --create --scope "/org/repo/src/"
+```
+
+Scope is auto-added from git remote. Returns `{"ruleId": <id>}`. Rule is created as a suggestion needing admin approval. HTTP 409 = name already exists.
+
+---
+
+## Update
+
+Requires the full rule JSON (admin only).
+
+```bash
+echo '<full-rule-json>' | bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --update <rule_id>
+```
+
+HTTP 403 = not an admin.
+
+---
+
+## Delete
+
+**Always confirm with user before deleting.**
+
+```bash
+bash .claude/skills/qodo-rules/scripts/qodo-rules.sh --delete <rule_id>
+```
+
+HTTP 204 = success. HTTP 403 = not an admin.
+
+---
+
+## Auth
+
+Reads `id_token` and `platform_url` from `~/.qodo/skill_auth.json` (written by `/qodo-setup`).
+
+**Trigger: On any authentication failure, automatically run qodo-setup and retry.**
+
+When the script fails with **any** of these signals:
+- Output contains `Not authenticated` or `Token expired`
+- HTTP 401 error in the output
+- Exit code 1 with auth-related error message
+
+**You MUST automatically recover — never tell the user to authenticate manually:**
+
+1. First try a silent refresh: `bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --check`
+2. If `--check` succeeds (exit 0), retry the original qodo-rules command immediately
+3. If `--check` fails, run `bash .claude/skills/qodo-setup/scripts/qodo-setup.sh --login` — do NOT ask the user, just run it
+4. After login completes, retry the original qodo-rules command
+

--- a/skills/qodo-rules/scripts/qodo-rules.sh
+++ b/skills/qodo-rules/scripts/qodo-rules.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# qodo-rules.sh — CRUD for Qodo coding rules
+#
+# Usage:
+#   qodo-rules.sh --get                              (download rules as local IDE rule files)
+#   qodo-rules.sh --prompt "<description>"           (generate rule JSON from prompt)
+#   qodo-rules.sh --create [--scope "/org/repo/"]    (reads JSON from stdin)
+#   qodo-rules.sh --update <rule_id>                 (reads JSON from stdin)
+#   qodo-rules.sh --delete <rule_id>
+
+set -euo pipefail
+
+command -v jq &>/dev/null || { echo "Error: jq is required" >&2; exit 1; }
+
+# --- Argument parsing ---
+MODE="" SCOPE_OVERRIDE="" RULE_ID="" PROMPT_TEXT=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --get)     MODE="get";  shift ;;
+        --prompt)  MODE="prompt"; [ -z "${2:-}" ] && { echo "Error: --prompt requires a description" >&2; exit 1; }; PROMPT_TEXT="$2"; shift 2 ;;
+        --create)  MODE="create"; shift ;;
+        --update)  MODE="update"; [ -z "${2:-}" ] && { echo "Error: --update requires a rule ID" >&2; exit 1; }; RULE_ID="$2"; shift 2 ;;
+        --delete)  MODE="delete"; [ -z "${2:-}" ] && { echo "Error: --delete requires a rule ID" >&2; exit 1; }; RULE_ID="$2"; shift 2 ;;
+        --scope)   [ -z "${2:-}" ] && { echo "Error: --scope requires a path" >&2; exit 1; }; SCOPE_OVERRIDE="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 1 ;;
+    esac
+done
+
+[ -z "$MODE" ] && { echo "Usage: qodo-rules.sh --get | --prompt <desc> | --create | --update <id> | --delete <id>"; exit 1; }
+
+# --- Prerequisites ---
+for cmd in curl git; do
+    command -v "$cmd" &>/dev/null || { echo "Error: $cmd is required" >&2; exit 1; }
+done
+
+# --- Auth ---
+[ -f "$HOME/.qodo/skill_auth.json" ] || { echo "ℹ️  Not authenticated. Run: /qodo-setup --login" >&2; exit 1; }
+_auth=$(cat "$HOME/.qodo/skill_auth.json")
+API_KEY=$(echo "$_auth" | jq -r '.id_token // empty')
+API_URL=$(echo "$_auth" | jq -r '.platform_url // empty')
+[ -z "$API_URL" ] && API_URL="https://qodo-platform.qodo.ai"
+API_URL="${API_URL%/}"
+
+[ -z "$API_KEY" ] && { echo "ℹ️  Not authenticated. Run: /qodo-setup --login" >&2; exit 1; }
+
+# --- API call helper ---
+# call <METHOD> <path> [extra curl args]
+call() {
+    local method="$1" path="$2"; shift 2
+    curl -s -w "\n%{http_code}" -X "$method" -H "Authorization: Bearer $API_KEY" "$@" "${API_URL}${path}" 2>/dev/null
+}
+code() { echo "$1" | tail -n1; }
+body() { echo "$1" | sed '$d'; }
+
+# --- Scope detection ---
+detect_scope() {
+    if [ -n "$SCOPE_OVERRIDE" ]; then
+        QUERY_SCOPE="$SCOPE_OVERRIDE"; SCOPE_CONTEXT="Custom scope"; return
+    fi
+    local remote; remote=$(git config --get remote.origin.url 2>/dev/null || echo "")
+    [ -z "$remote" ] && { echo "Error: No git remote" >&2; return 1; }
+    QUERY_SCOPE=$(echo "$remote" | sed -E 's|\.git$||' | sed -E 's|^.*[:/]([^/]+/[^/]+)$|/\1/|')
+    [ -z "$QUERY_SCOPE" ] || [ "$QUERY_SCOPE" = "$remote" ] && { echo "Error: Could not parse scope from git remote" >&2; return 1; }
+    SCOPE_CONTEXT="Repository"
+    local root; root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    if [ -n "$root" ]; then
+        local rel="${PWD#"$root"/}"
+        if [[ "$rel" == modules/* ]] && [ "$rel" != "$PWD" ]; then
+            local mod; mod=$(echo "$rel" | cut -d'/' -f1-2)
+            QUERY_SCOPE="${QUERY_SCOPE}${mod}/"
+            SCOPE_CONTEXT="Module: \`${mod}\`"
+        fi
+    fi
+}
+
+# --- Get: download rules as local IDE rule files ---
+if [ "$MODE" = "get" ]; then
+    detect_scope || { echo "⚠️  Could not detect scope. Skipping rules get."; exit 0; }
+
+    # Determine rules directory: project root if in a git repo, else user home
+    GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+    BASE_DIR="${GIT_ROOT:-$HOME}"
+
+    RULES_DIR="" RULES_EXT="" IDE_NAME=""
+    if [ -d "${BASE_DIR}/.cursor" ] || [ -n "${CURSOR_TRACE_ID:-}" ]; then
+        RULES_DIR="${BASE_DIR}/.cursor/rules"
+        RULES_EXT=".mdc"
+        IDE_NAME="Cursor"
+    else
+        RULES_DIR="${BASE_DIR}/.claude/rules"
+        RULES_EXT=".md"
+        IDE_NAME="Claude"
+    fi
+
+    ALL_RULES="[]"; PAGE=1; PAGE_SIZE=50
+    while true; do
+        ENC=$(printf '%s' "$QUERY_SCOPE" | jq -Rr @uri)
+        set +e; R=$(call GET "/rules/v1/rules?scopes=${ENC}&state=active&page=${PAGE}&page_size=${PAGE_SIZE}"); EC=$?; set -e
+        [ $EC -ne 0 ] && { echo "⚠️  Network error" >&2; exit 1; }
+        C=$(code "$R"); B=$(body "$R")
+        [ "$C" = "401" ] && { echo "⚠️  Token expired. Run: /qodo-setup --login" >&2; exit 1; }
+        [ "$C" != "200" ] && { echo "⚠️  Failed to get rules (HTTP $C)" >&2; exit 1; }
+        PAGE_RULES=$(echo "$B" | jq '.rules // []')
+        ALL_RULES=$(echo "$ALL_RULES $PAGE_RULES" | jq -s '.[0] + .[1]')
+        COUNT=$(echo "$PAGE_RULES" | jq 'length')
+        [ "$COUNT" -lt "$PAGE_SIZE" ] && break
+        PAGE=$((PAGE + 1))
+    done
+
+    TOTAL=$(echo "$ALL_RULES" | jq 'length')
+    [ "$TOTAL" -eq 0 ] && { echo "ℹ️  No rules for: ${QUERY_SCOPE}"; exit 0; }
+
+    mkdir -p "$RULES_DIR"
+
+    # Remove previously synced qodo rules
+    for old_file in "$RULES_DIR"/qodo-*"${RULES_EXT}"; do
+        [ -f "$old_file" ] && rm "$old_file"
+    done
+
+    echo "$ALL_RULES" | jq -c '.[]' | while IFS= read -r rule; do
+        NAME=$(echo "$rule" | jq -r '.name')
+        SEVERITY=$(echo "$rule" | jq -r '.severity // "recommendation"')
+        CATEGORY=$(echo "$rule" | jq -r '.category // ""')
+        CONTENT=$(echo "$rule" | jq -r '.content // .description // ""')
+        DESCRIPTION=$(echo "$rule" | jq -r '.description // .name')
+        GOOD_EXAMPLES=$(echo "$rule" | jq -r 'if .goodExamples and .goodExamples != "" then .goodExamples else empty end')
+        BAD_EXAMPLES=$(echo "$rule" | jq -r 'if .badExamples and .badExamples != "" then .badExamples else empty end')
+
+        SLUG=$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g')
+        FILEPATH="${RULES_DIR}/qodo-${SLUG}${RULES_EXT}"
+
+        {
+            if [ "$IDE_NAME" = "Cursor" ]; then
+                echo "---"
+                echo "description: ${DESCRIPTION}"
+                echo "alwaysApply: true"
+                echo "---"
+                echo ""
+            fi
+            echo "# ${NAME}"
+            echo ""
+            SEVERITY_UPPER=$(echo "$SEVERITY" | tr '[:lower:]' '[:upper:]')
+            echo "**Severity:** ${SEVERITY_UPPER} | **Category:** ${CATEGORY}"
+            echo ""
+            echo "${CONTENT}"
+            if [ -n "${GOOD_EXAMPLES:-}" ]; then
+                echo ""
+                echo "## Good Examples"
+                echo ""
+                echo "${GOOD_EXAMPLES}"
+            fi
+            if [ -n "${BAD_EXAMPLES:-}" ]; then
+                echo ""
+                echo "## Bad Examples"
+                echo ""
+                echo "${BAD_EXAMPLES}"
+            fi
+        } > "$FILEPATH"
+
+        echo "  ✓ ${NAME} → qodo-${SLUG}${RULES_EXT}"
+    done
+
+    echo ""
+    echo "Synced ${TOTAL} Qodo rules to ${RULES_DIR}/ (${IDE_NAME} format)"
+    exit 0
+fi
+
+# --- Prompt to Rule ---
+if [ "$MODE" = "prompt" ]; then
+    J=$(jq -n --arg p "$PROMPT_TEXT" '{prompt: $p}')
+    R=$(call POST "/rules/v1/prompt-to-rule" -H "Content-Type: application/json" -d "$J")
+    C=$(code "$R"); B=$(body "$R")
+    [ "$C" != "200" ] && { echo "Error: Failed to generate rule (HTTP $C)" >&2; echo "$B" >&2; exit 1; }
+    echo "$B"; exit 0
+fi
+
+# --- Create ---
+if [ "$MODE" = "create" ]; then
+    detect_scope || { echo "Error: Could not detect scope" >&2; exit 1; }
+    J=$(cat | jq --arg s "$QUERY_SCOPE" '. + {scopes: [$s]}')
+    R=$(call POST "/rules/v1/rule" -H "Content-Type: application/json" -d "$J")
+    C=$(code "$R"); B=$(body "$R")
+    [ "$C" != "201" ] && { echo "Error: Failed to create rule (HTTP $C)" >&2; echo "$B" >&2; exit 1; }
+    echo "$B"; exit 0
+fi
+
+# --- Update ---
+if [ "$MODE" = "update" ]; then
+    J=$(cat)
+    [ -n "$SCOPE_OVERRIDE" ] && J=$(echo "$J" | jq --arg s "$SCOPE_OVERRIDE" '. + {scopes: [$s]}')
+    R=$(call PUT "/rules/v1/rule/${RULE_ID}" -H "Content-Type: application/json" -d "$J")
+    C=$(code "$R"); B=$(body "$R")
+    [ "$C" != "200" ] && { echo "Error: Failed to update rule (HTTP $C)" >&2; echo "$B" >&2; exit 1; }
+    echo "$B"; exit 0
+fi
+
+# --- Delete ---
+if [ "$MODE" = "delete" ]; then
+    R=$(call DELETE "/rules/v1/rule/${RULE_ID}")
+    C=$(code "$R")
+    [ "$C" != "204" ] && { echo "Error: Failed to delete rule (HTTP $C)" >&2; body "$R" >&2; exit 1; }
+    echo "Rule ${RULE_ID} deleted"; exit 0
+fi


### PR DESCRIPTION
Add the new qodo-rules skill to manage coding rules (get/sync/create/update/delete) along with its script implementation that calls the platform APIs and writes rule files into IDE-specific locations.