### PR TITLE
Docs: clarify dual auth models (OIDC vs API key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@ Shift-left code review skills for AI coding agents. Bring Qodo's quality standar
 
 ## Available Skills
 
-### 🔧 qodo-get-rules
+### 🔧 get-qodo-rules
 Fetches repository-specific coding rules from the Qodo platform API. Provides your agent with security requirements, coding standards, and team conventions before generating code.
 
 **Features:**
+- 🎯 **Must load before coding**: Agent invokes before any code generation/modification task (if not already loaded)
 - 📚 Hierarchical rule matching (universal, org, repo, path-level)
 - ⚖️ Severity-based enforcement (ERROR, WARNING, RECOMMENDATION)
 - 🔄 Module-specific scope detection (`modules/` directories)
 - 📄 Pagination support for large rule sets
 - 🪟 **Full Windows support** - Native compatibility without requiring Git Bash/WSL
 
-[View skill details](./skills/qodo-get-rules/SKILL.md)
+[View skill details](./skills/get-qodo-rules/SKILL.md)
 
 ### 🔍 qodo-pr-resolver
 Fetch Qodo review issues for your current branch's PR/MR, fix them interactively or in batch, and reply to each inline comment with the decision.
@@ -39,17 +40,14 @@ Install skills using the standard Agent Skills CLI:
 npx skills add qodo-ai/qodo-skills
 
 # Or install individual skills
-npx skills add qodo-ai/qodo-skills/skills/qodo-get-rules
+npx skills add qodo-ai/qodo-skills/skills/get-qodo-rules
 npx skills add qodo-ai/qodo-skills/skills/qodo-pr-resolver
 ```
 
-**Claude Code Marketplace:**
-```
-/plugin install qodo-skills@claude-plugins-official
-```
+**Claude Code Marketplace:** Coming soon - one-click installation
 
 **Works with:**
-- **Claude Code** - Skills available as `/qodo-get-rules`, `/qodo-pr-resolver`
+- **Claude Code** - Skills available as `/get-qodo-rules`, `/qodo-pr-resolver`
 - **Cursor** - Skills available in command palette
 - **Windsurf** - Skills available in flow menu
 - **Cline** - Skills available via skill invocation
@@ -73,27 +71,46 @@ Skills are automatically installed to the correct location for your agent:
 - **Git** - For repository detection
   - Usually pre-installed on macOS and most Linux distributions
   - Windows: Download from https://git-scm.com/download/win
-- **curl** - For HTTPS API requests (works with system SSL certificates)
-  - Pre-installed on macOS, most Linux distributions, and Windows 10+
-  - If needed, install via package manager or download from https://curl.se
+- **Python 3.6+** - For API requests and cross-platform compatibility
+  - No external dependencies required (uses standard library only)
   ```bash
   # Check installation
-  curl --version
+  python3 --version
+  # or
+  python --version
 
   # Install if needed:
-  # macOS: brew install curl (or use system curl)
-  # Ubuntu/Debian: apt-get install curl
-  # Windows 10+: Included by default
+  # macOS: brew install python3
+  # Ubuntu/Debian: apt-get install python3
+  # Windows: https://www.python.org/downloads/
+  #   (Make sure to check "Add Python to PATH" during installation)
   ```
-- **Python 3.6+** - For JSON parsing and path manipulation only (no API calls)
-  - Pre-installed on macOS and most Linux distributions
-  - Windows: Download from https://www.python.org/downloads/
 
-**Note:** All prerequisites use standard system tools with no external dependencies.
+**Note:** The script automatically detects Python using:
+- **Windows:** `py -3` → `python3` → `python`
+- **Unix/macOS/Linux:** `python3` → `python`
 
 ## Configuration
 
-### qodo-get-rules Skill
+This repo currently supports **two authentication/configuration models**, depending on the skill you use:
+
+- **OIDC login (recommended for new skills)** via `/qodo-setup` → stores a short-lived `id_token` in `~/.qodo/skill_auth.json`
+- **API key configuration** (used by `get-qodo-rules`) → stores `API_KEY` in `~/.qodo/config.json` (or env vars)
+
+### OIDC Login (qodo-setup / qodo-rules)
+
+Some skills (e.g. `qodo-rules`) authenticate using an OIDC browser login flow. Run the setup skill once:
+
+```bash
+/qodo-setup --login
+```
+
+This writes:
+- `~/.qodo/skill_auth.json` (contains `id_token` + `platform_url`)
+
+If a token expires, these skills will attempt to refresh automatically (via `/qodo-setup --check`, then `--login` if needed).
+
+### API Key (get-qodo-rules Skill)
 
 Create `~/.qodo/config.json`:
 
@@ -110,7 +127,7 @@ Create `~/.qodo/config.json`:
   - If empty/omitted: Uses `https://qodo-platform.qodo.ai/rules/v1/`
   - If specified: Uses `https://qodo-platform.<ENVIRONMENT_NAME>.qodo.ai/rules/v1/`
 
-Get your API key at: https://app.qodo.ai/account/api-keys
+Get your API key at: https://app.qodo.ai/settings/api-keys
 
 **Minimal configuration (production):**
 ```json
@@ -142,13 +159,13 @@ After installation, invoke skills directly in your agent:
 
 **Claude Code:**
 ```bash
-/qodo-get-rules      # Fetch coding rules
+/get-qodo-rules      # Fetch coding rules
 /qodo-pr-resolver    # Fix PR review issues
 ```
 
 **Cursor / Windsurf / Cline:**
 - Open command palette
-- Search for "qodo-get-rules" or "qodo-pr-resolver"
+- Search for "get-qodo-rules" or "qodo-pr-resolver"
 - Or invoke via agent command input
 
 ### Managing Skills
@@ -156,7 +173,7 @@ After installation, invoke skills directly in your agent:
 **Update skills:**
 ```bash
 # Update individual skills
-npx skills update qodo-ai/qodo-skills/skills/qodo-get-rules
+npx skills update qodo-ai/qodo-skills/skills/get-qodo-rules
 npx skills update qodo-ai/qodo-skills/skills/qodo-pr-resolver
 ```
 
@@ -167,7 +184,7 @@ npx skills list
 
 **Remove skills:**
 ```bash
-npx skills remove qodo-get-rules
+npx skills remove get-qodo-rules
 ```
 
 ## Repository Structure
@@ -177,7 +194,7 @@ This repository follows the [Agent Skills](https://agentskills.io) standard:
 ```
 qodo-skills/
 ├── skills/
-│   ├── qodo-get-rules/           # Fetch coding rules skill
+│   ├── get-qodo-rules/           # Fetch coding rules skill
 │   │   ├── SKILL.md         # Agent Skills standard
 │   │   └── scripts/
 │   │       ├── fetch-qodo-rules.py   # Main script (cross-platform)
@@ -237,7 +254,7 @@ python3 --version || python --version
 **Manually test the fetch script:**
 ```bash
 # Navigate to your agent's skills directory and run the Python script directly
-cd ~/.claude/skills/qodo-get-rules  # or ~/.cursor/skills/qodo-get-rules, etc.
+cd ~/.claude/skills/get-qodo-rules  # or ~/.cursor/skills/get-qodo-rules, etc.
 python3 scripts/fetch-qodo-rules.py
 
 # Or use the shell wrapper (Unix/macOS/Linux):

--- a/skills/get-qodo-rules/SKILL.md
+++ b/skills/get-qodo-rules/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: get-qodo-rules
+description: "Loads org- and repo-level coding rules from Qodo before code tasks begin, ensuring all generation and modification follows team standards. Use before any code generation or modification task when rules are not already loaded. Invoke when user asks to write, edit, refactor, or review code, or when starting implementation planning."
+version: 2.0.0
+allowed-tools: ["Bash"]
+triggers:
+  - "get.?qodo.?rules"
+  - "get.?rules"
+  - "load.?qodo.?rules"
+  - "load.?rules"
+  - "fetch.?qodo.?rules"
+  - "fetch.?rules"
+  - "qodo.?rules"
+  - "coding.?rules"
+  - "code.?rules"
+  - "before.?cod"
+  - "start.?coding"
+  - "write.?code"
+  - "implement"
+  - "create.*code"
+  - "build.*feature"
+  - "add.*feature"
+  - "fix.*bug"
+  - "refactor"
+  - "modify.*code"
+  - "update.*code"
+---
+
+# Get Qodo Rules Skill
+
+## Description
+
+Fetches repository-specific coding rules from the Qodo platform API before code generation or modification tasks. Rules include security requirements, coding standards, quality guidelines, and team conventions that must be applied during code generation.
+**Use** before any code generation or modification task when rules are not already loaded. Invoke when user asks to write, edit, refactor, or review code, or when starting implementation planning.
+**Skip** if "Qodo Rules Loaded" already appears in conversation context
+
+---
+
+## Workflow
+
+### Step 1: Check if Rules Already Loaded
+
+If rules are already loaded (look for "Qodo Rules Loaded" in recent messages), skip to step 6.
+
+### Step 2: Verify working in a git repository
+
+- Check that the current directory is inside a git repository. If not, inform the user that a git repository is required and exit gracefully.
+- Extract the repository scope from the git `origin` remote URL. If no remote is found, exit silently. If the URL cannot be parsed, inform the user and exit gracefully.
+- Detect module-level scope: if inside a `modules/*` subdirectory, use it as the query scope; otherwise use repository-wide scope.
+
+See [repository scope detection](references/repository-scope.md) for details.
+
+### Step 3: Verify Qodo Configuration
+
+> Note: This skill currently authenticates via **API key** (`~/.qodo/config.json` or `QODO_API_KEY`).
+> Other skills in this repo may use **OIDC login** via `/qodo-setup` and `~/.qodo/skill_auth.json`.
+
+Check that the required Qodo configuration is present. The default location is `~/.qodo/config.json`.
+
+- **API key**: Read from `~/.qodo/config.json` (`API_KEY` field). If not found, inform the user that an API key is required and provide setup instructions, then exit gracefully.
+- **Environment name**: Read from `~/.qodo/config.json` (`ENVIRONMENT_NAME` field), with `QODO_ENVIRONMENT_NAME` environment variable taking precedence. If not found, inform the user that an API key is required and provide setup instructions, then exit gracefully.
+
+### Step 4: Fetch Rules with Pagination
+
+- Fetch all pages from the API (50 rules per page) until no more results are returned.
+- On each page, handle HTTP errors and exit gracefully with a user-friendly message.
+- Accumulate all rules across pages into a single list.
+- Stop after 100 pages maximum (safety limit).
+- If no rules are found after all pages, inform the user and exit gracefully.
+
+See [pagination details](references/pagination.md) for the full algorithm and error handling.
+
+### Step 5: Format and Output Rules
+
+- Print the "📋 Qodo Rules Loaded" header with repository scope, scope context, and total rule count.
+- Group rules by severity and print each non-empty group: ERROR, WARNING, RECOMMENDATION.
+- Each rule is formatted as: `- **{name}** ({category}): {description}`
+- End output with `---`.
+
+See [output format details](references/output-format.md) for the exact format.
+
+### Step 6: Apply Rules by Severity
+
+| Severity | Enforcement | When Skipped |
+|---|---|---|
+| **ERROR** | Must comply, non-negotiable. Add comment documenting compliance (e.g., `# Following Qodo rule: No Hardcoded Credentials`) | Explain to user and ask for guidance |
+| **WARNING** | Should comply by default | Briefly explain why in response |
+| **RECOMMENDATION** | Consider when appropriate | No action needed |
+
+### Step 7: Report
+
+After code generation, inform the user about rule application:
+- **ERROR rules applied**: List which rules were followed
+- **WARNING rules skipped**: Explain why
+- **No rules applicable**: Inform: "No Qodo rules were applicable to this code change"
+- **RECOMMENDATION rules**: Mention only if they influenced a design decision
+
+---
+
+## How Scope Levels Work
+
+Determines scope from git remote and working directory (see [Step 2](#step-2-verify-working-in-a-git-repository)):
+
+**Scope Hierarchy**:
+- **Universal** (`/`) - applies everywhere
+- **Org Level** (`/org/`) - applies to organization
+- **Repo Level** (`/org/repo/`) - applies to repository
+- **Path Level** (`/org/repo/path/`) - applies to specific paths
+
+---
+
+## Configuration
+
+See [README.md](../../README.md#configuration) for full configuration instructions, including API key setup and environment variable options.
+
+---
+
+## Common Mistakes
+
+- **Re-running when rules are loaded** - Check for "Qodo Rules Loaded" in context first
+- **Missing compliance comments on ERROR rules** - ERROR rules require a comment documenting compliance
+- **Forgetting to report when no rules apply** - Always inform the user when no rules were applicable, so they know the rules system is active
+- **Not in git repo** - Inform the user that a git repository is required and exit gracefully; do not attempt code generation
+- **No API key** - Inform the user with setup instructions; set `QODO_API_KEY` or create `~/.qodo/config.json`
+- **No rules found** - Inform the user; set up rules at app.qodo.ai


### PR DESCRIPTION
Update repository documentation to clarify the two supported auth/config models (OIDC via qodo-setup vs API key for get-qodo-rules) and guide users to the appropriate setup steps.