### PR TITLE
docs: add Gerrit to supported providers in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ Fetches the most relevant coding rules from Qodo for the current coding task. Ge
 Fetch Qodo review issues for your current branch's PR/MR, fix them interactively or in batch, and reply to each inline comment with the decision.
 
 **Features:**
-- Multi-provider support (GitHub, GitLab, Bitbucket, Azure DevOps)
+- Multi-provider support (GitHub, GitLab, Bitbucket, Azure DevOps, Gerrit)
 - Interactive issue review and auto-fix modes
 - Per-issue inline comment replies and git commits
+- Gerrit-native workflow: amend + push instead of per-fix commits
 - Severity mapping from Qodo's action levels
-- Automatic PR/MR summary comments
+- Automatic PR/MR/change summary comments
 
 [View skill details](./skills/qodo-pr-resolver/SKILL.md)
 
@@ -146,6 +147,7 @@ Requires CLI tools for your git provider:
 - **GitLab**: `glab` CLI ([install guide](https://glab.readthedocs.io/))
 - **Bitbucket**: `bb` CLI
 - **Azure DevOps**: `az` CLI with DevOps extension ([install guide](https://docs.microsoft.com/cli/azure/))
+- **Gerrit**: `curl` + SSH access to the Gerrit server (see [Gerrit setup guide](./skills/qodo-pr-resolver/resources/gerrit.md))
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Add Gerrit to the multi-provider list in qodo-pr-resolver features
- Add Gerrit-native workflow bullet (amend + push)
- Add Gerrit CLI prerequisites with link to the gerrit.md setup guide

Follows up on #45 which added full Gerrit provider support.