### PR TITLE
ci: add E2E test suite for qodo-get-rules skill

### DIFF
--- a/.github/e2e/qodo-get-rules/assert.ps1
+++ b/.github/e2e/qodo-get-rules/assert.ps1
@@ -1,0 +1,35 @@
+# E2E assertion script for qodo-get-rules (Windows/PowerShell)
+$ErrorActionPreference = 'Stop'
+
+$OUTPUT = claude -p --dangerously-skip-permissions "/qodo-get-rules implement a JWT login endpoint for our Express API" 2>&1 | Out-String
+
+$PASS = 0
+$FAIL = 0
+
+function Check-Criterion {
+    param([string]$Label, [bool]$Result)
+    if ($Result) {
+        Write-Host "[PASS] $Label"
+        $script:PASS++
+    } else {
+        Write-Host "[FAIL] $Label"
+        $script:FAIL++
+    }
+}
+
+# Criterion 1: Rules loaded header
+Check-Criterion "Rules loaded header" ($OUTPUT -imatch "Qodo Rules Loaded")
+
+# Criterion 2: At least one rule returned
+Check-Criterion "Rules returned (non-empty)" ($OUTPUT -imatch "\bERROR\b|\bWARNING\b|\bRECOMMENDATION\b")
+
+# Criterion 3: Security-relevant rules for JWT/auth prompt
+Check-Criterion "Category relevance (Security/auth terms present)" ($OUTPUT -imatch "Security|Authentication|JWT|Authorization|Credential|Token")
+
+$TOTAL = $PASS + $FAIL
+Write-Host ""
+Write-Host "--- Result: $PASS/$TOTAL criteria passed ---"
+
+if ($FAIL -gt 0) {
+    exit 1
+}

--- a/.github/e2e/qodo-get-rules/assert.sh
+++ b/.github/e2e/qodo-get-rules/assert.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# E2E assertion script for qodo-get-rules (Linux/macOS)
+set -euo pipefail
+
+OUTPUT=$(claude -p --dangerously-skip-permissions "/qodo-get-rules implement a JWT login endpoint for our Express API" 2>&1)
+
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1"
+  local result="$2"
+  if [ "$result" = "true" ]; then
+    echo "[PASS] $label"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Criterion 1: Rules loaded header
+if echo "$OUTPUT" | grep -qi "Qodo Rules Loaded"; then
+  check "Rules loaded header" true
+else
+  check "Rules loaded header" false
+fi
+
+# Criterion 2: At least one rule returned
+if echo "$OUTPUT" | grep -qiE "\bERROR\b|\bWARNING\b|\bRECOMMENDATION\b"; then
+  check "Rules returned (non-empty)" true
+else
+  check "Rules returned (non-empty)" false
+fi
+
+# Criterion 3: Security-relevant rules for JWT/auth prompt
+if echo "$OUTPUT" | grep -qiE "Security|Authentication|JWT|Authorization|Credential|Token"; then
+  check "Category relevance (Security/auth terms present)" true
+else
+  check "Category relevance (Security/auth terms present)" false
+fi
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "--- Result: $PASS/$TOTAL criteria passed ---"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/.github/e2e/qodo-get-rules/config.json
+++ b/.github/e2e/qodo-get-rules/config.json
@@ -1,0 +1,9 @@
+{
+  "skill": "qodo-get-rules",
+  "prompt": "implement a JWT login endpoint for our Express API",
+  "criteria": [
+    { "id": "rules-loaded", "description": "Rules loaded header", "match": "Qodo Rules Loaded", "flags": "i" },
+    { "id": "rules-returned", "description": "Rules returned (non-empty)", "match": "\\bERROR\\b|\\bWARNING\\b|\\bRECOMMENDATION\\b", "flags": "i" },
+    { "id": "category-relevance", "description": "Category relevance (Security/auth terms present)", "match": "Security|Authentication|JWT|Authorization|Credential|Token", "flags": "i" }
+  ]
+}

--- a/.github/scripts/build-matrix.py
+++ b/.github/scripts/build-matrix.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+build-matrix.py -- Build GitHub Actions test matrix for qodo-skills CI
+
+Two modes:
+
+  PR mode (detect changed skills from a changed-files list):
+    python3 build-matrix.py pr "skills/qodo-get-rules/SKILL.md skills/qodo-pr-resolver/support.yml"
+
+  On-demand mode (test a specific skill):
+    python3 build-matrix.py skill qodo-get-rules
+    python3 build-matrix.py skill qodo-get-rules --os ubuntu
+    python3 build-matrix.py skill qodo-get-rules --os all
+
+Output is written to $GITHUB_OUTPUT in the format expected by GitHub Actions:
+  matrix={"include": [{"skill": "...", "os": "..."}, ...]}
+  has_matrix=true|false
+
+When $GITHUB_OUTPUT is not set (local dev), output is printed to stdout.
+"""
+
+import sys
+import json
+import pathlib
+import os
+
+# Maps declared OS names (in support.yml) to GitHub Actions runner labels
+OS_TO_RUNNER = {
+    "ubuntu": "ubuntu-latest",
+    "macos": "macos-latest",
+    "windows": "windows-latest",
+}
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML parser -- duplicated from validate-skill.py to keep scripts
+# self-contained with zero dependencies.
+# ---------------------------------------------------------------------------
+
+def parse_simple_yaml(text):
+    result = {}
+    current_list_key = None
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("- "):
+            if current_list_key is not None:
+                result[current_list_key].append(stripped[2:].strip().strip("\"'"))
+            continue
+        if ":" in stripped:
+            key, _, rest = stripped.partition(":")
+            key = key.strip()
+            rest = rest.strip()
+            if rest == "[]":
+                result[key] = []
+                current_list_key = None
+            elif rest == "":
+                result[key] = []
+                current_list_key = key
+            else:
+                result[key] = rest.strip("\"'")
+                current_list_key = None
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def read_support_yml(skill_dir):
+    """Parse support.yml for a skill directory. Returns None if not found."""
+    support_file = pathlib.Path(skill_dir) / "support.yml"
+    if not support_file.exists():
+        return None
+    return parse_simple_yaml(support_file.read_text(encoding="utf-8"))
+
+
+def runners_for_skill(skill_name, requested_os="all"):
+    """Return a list of GitHub Actions runner labels for the given skill.
+
+    Uses declared os list from support.yml when available.
+    Falls back to all three runners if support.yml is missing.
+    """
+    skill_dir = pathlib.Path("skills") / skill_name
+    support = read_support_yml(skill_dir)
+
+    if support and isinstance(support.get("os"), list) and support["os"]:
+        declared_os = support["os"]
+    else:
+        # Missing or invalid support.yml -- run on all OSes so the validator
+        # can report the missing file on each platform.
+        declared_os = list(OS_TO_RUNNER.keys())
+
+    if requested_os != "all":
+        # Honor explicit override even if not in declared list
+        if requested_os in OS_TO_RUNNER:
+            return [OS_TO_RUNNER[requested_os]]
+        else:
+            print(f"Warning: unknown OS '{requested_os}', using all", file=sys.stderr)
+            return list(OS_TO_RUNNER.values())
+
+    return [OS_TO_RUNNER[o] for o in declared_os if o in OS_TO_RUNNER]
+
+
+def extract_skills_from_changed_files(changed_files_str):
+    """Extract unique skill names from a space-separated list of changed paths.
+
+    e.g. "skills/qodo-get-rules/SKILL.md skills/qodo-get-rules/support.yml"
+    yields {"qodo-get-rules"}
+    """
+    skills = set()
+    for path_str in changed_files_str.split():
+        parts = pathlib.PurePosixPath(path_str).parts
+        if len(parts) >= 2 and parts[0] == "skills":
+            skills.add(parts[1])
+    return sorted(skills)
+
+
+# ---------------------------------------------------------------------------
+# Matrix builders
+# ---------------------------------------------------------------------------
+
+def build_pr_matrix(changed_files_str):
+    """Build include matrix from changed files detected in a PR."""
+    skills = extract_skills_from_changed_files(changed_files_str)
+    includes = []
+    for skill in skills:
+        for runner in runners_for_skill(skill):
+            includes.append({"skill": skill, "os": runner})
+    return includes
+
+
+def build_skill_matrix(skill_name, requested_os="all"):
+    """Build include matrix for a single named skill."""
+    includes = []
+    for runner in runners_for_skill(skill_name, requested_os):
+        includes.append({"skill": skill_name, "os": runner})
+    return includes
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+def write_output(includes):
+    """Write matrix and has_matrix to $GITHUB_OUTPUT or stdout."""
+    matrix_json = json.dumps({"include": includes})
+    has_matrix = "true" if includes else "false"
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"matrix={matrix_json}\n")
+            fh.write(f"has_matrix={has_matrix}\n")
+    else:
+        # Local development -- print to stdout
+        print(f"matrix={matrix_json}")
+        print(f"has_matrix={has_matrix}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 2:
+        _usage()
+
+    mode = sys.argv[1]
+
+    if mode == "pr":
+        changed_files = sys.argv[2] if len(sys.argv) > 2 else ""
+        includes = build_pr_matrix(changed_files)
+
+    elif mode == "skill":
+        if len(sys.argv) < 3:
+            print("Error: 'skill' mode requires a skill name", file=sys.stderr)
+            _usage()
+        skill_name = sys.argv[2]
+        requested_os = "all"
+        if "--os" in sys.argv:
+            idx = sys.argv.index("--os")
+            if idx + 1 < len(sys.argv):
+                requested_os = sys.argv[idx + 1]
+        includes = build_skill_matrix(skill_name, requested_os)
+
+    else:
+        print(f"Error: unknown mode '{mode}'", file=sys.stderr)
+        _usage()
+
+    write_output(includes)
+
+
+def _usage():
+    prog = pathlib.Path(sys.argv[0]).name
+    print(f"Usage:", file=sys.stderr)
+    print(f"  {prog} pr \"<space-separated changed file paths>\"", file=sys.stderr)
+    print(f"  {prog} skill <skill-name> [--os all|ubuntu|macos|windows]", file=sys.stderr)
+    sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate-skill.py
+++ b/.github/scripts/validate-skill.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+validate-skill.py -- Structural validator for qodo-skills
+
+Verifies that a skill directory meets all requirements:
+  - support.yml exists and is schema-valid
+  - SKILL.md exists with valid frontmatter
+  - Names match across support.yml, SKILL.md frontmatter, and directory name
+  - All markdown files are within the 500-line size limit
+  - All relative links in SKILL.md resolve to existing files
+  - Declared agent/OS/git_provider values use the known controlled vocabulary
+  - Python scripts (if any) have valid syntax
+
+Usage:
+  python3 validate-skill.py <skill-dir>
+  python3 validate-skill.py skills/qodo-get-rules
+
+Exit code: 0 on success, 1 on failure, 2 on usage error
+"""
+
+import sys
+import re
+import pathlib
+import subprocess
+
+# Controlled vocabulary -- must stay in sync with SKILL_SUPPORT.md
+KNOWN_AGENTS = {"claude-code", "cursor", "windsurf", "cline", "copilot", "codex"}
+KNOWN_OS = {"ubuntu", "macos", "windows"}
+KNOWN_GIT_PROVIDERS = {"github", "gitlab", "bitbucket", "azure-devops"}
+
+MAX_FILE_LINES = 500
+
+
+# ---------------------------------------------------------------------------
+# Minimal YAML parser (stdlib only -- no PyYAML dependency)
+# Handles the simple YAML subset used in support.yml and SKILL.md frontmatter:
+#   scalar fields:  key: value
+#   empty lists:    key: []
+#   block lists:    key:\n  - item
+# ---------------------------------------------------------------------------
+
+def parse_simple_yaml(text):
+    """Parse a simple YAML subset. Returns a dict of scalars and lists."""
+    result = {}
+    current_list_key = None
+
+    for line in text.splitlines():
+        stripped = line.strip()
+
+        if not stripped or stripped.startswith("#"):
+            continue
+
+        if stripped.startswith("- "):
+            if current_list_key is not None:
+                result[current_list_key].append(stripped[2:].strip().strip("\"'"))
+            continue
+
+        if ":" in stripped:
+            key, _, rest = stripped.partition(":")
+            key = key.strip()
+            rest = rest.strip()
+
+            if rest == "[]":
+                result[key] = []
+                current_list_key = None
+            elif rest == "":
+                result[key] = []
+                current_list_key = key
+            else:
+                result[key] = rest.strip("\"'")
+                current_list_key = None
+
+    return result
+
+
+def parse_frontmatter(text):
+    """Extract and parse YAML frontmatter between --- delimiters.
+
+    Returns (dict, None) on success, (None, error_string) on failure.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None, "no opening '---' delimiter found"
+
+    end_idx = None
+    for i, line in enumerate(lines[1:], 1):
+        if line.strip() == "---":
+            end_idx = i
+            break
+
+    if end_idx is None:
+        return None, "no closing '---' delimiter found"
+
+    fm_text = "\n".join(lines[1:end_idx])
+    return parse_simple_yaml(fm_text), None
+
+
+def extract_relative_links(text):
+    """Return relative file paths from Markdown links, excluding http(s) and anchor links."""
+    links = re.findall(r"\[([^\]]+)\]\(([^)#]+)\)", text)
+    return [
+        target.strip()
+        for _, target in links
+        if not target.startswith("http://")
+        and not target.startswith("https://")
+        and not target.startswith("#")
+        and not target.startswith("mailto:")
+        and target.strip()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Validator
+# ---------------------------------------------------------------------------
+
+class Validator:
+    def __init__(self, skill_dir):
+        self.skill_dir = pathlib.Path(skill_dir)
+        self.skill_name = self.skill_dir.name
+        self.passed = 0
+        self.failed = 0
+        self.errors = []
+
+    def check(self, label, condition, error_msg):
+        if condition:
+            print(f"  [PASS] {label}")
+            self.passed += 1
+            return True
+        else:
+            print(f"  [FAIL] {label}")
+            print(f"         {error_msg}")
+            self.failed += 1
+            self.errors.append(f"{label}: {error_msg}")
+            return False
+
+    def info(self, msg):
+        print(f"  [INFO] {msg}")
+
+    # --- individual check groups ---
+
+    def check_skill_dir(self):
+        return self.check(
+            "Skill directory exists",
+            self.skill_dir.is_dir(),
+            f"Directory not found: {self.skill_dir}",
+        )
+
+    def check_support_yml(self):
+        support_file = self.skill_dir / "support.yml"
+
+        exists = self.check(
+            "support.yml exists",
+            support_file.exists(),
+            (
+                "Missing support.yml -- create this file to declare supported environments.\n"
+                "         See SKILL_SUPPORT.md for the format."
+            ),
+        )
+        if not exists:
+            return None
+
+        content = support_file.read_text(encoding="utf-8")
+        data = parse_simple_yaml(content)
+
+        self.check(
+            "support.yml: schema_version present",
+            "schema_version" in data,
+            "Missing required field: schema_version",
+        )
+        self.check(
+            "support.yml: skill field present",
+            "skill" in data,
+            "Missing required field: skill",
+        )
+        has_agents = self.check(
+            "support.yml: agents field present",
+            "agents" in data,
+            "Missing required field: agents",
+        )
+        has_os = self.check(
+            "support.yml: os field present",
+            "os" in data,
+            "Missing required field: os",
+        )
+
+        if "skill" in data:
+            self.check(
+                f"support.yml: skill name matches directory ('{data['skill']}')",
+                data["skill"] == self.skill_name,
+                f"skill: '{data['skill']}' does not match directory name '{self.skill_name}'",
+            )
+
+        if has_agents and isinstance(data.get("agents"), list):
+            agents = data["agents"]
+            invalid = [a for a in agents if a not in KNOWN_AGENTS]
+            self.check(
+                f"support.yml: agents use known vocabulary ({', '.join(agents) or 'none'})",
+                not invalid,
+                f"Unknown agent(s): {', '.join(invalid)}. Known: {', '.join(sorted(KNOWN_AGENTS))}",
+            )
+            self.check(
+                "support.yml: agents list is not empty",
+                len(agents) > 0,
+                "agents must declare at least one supported agent",
+            )
+
+        if has_os and isinstance(data.get("os"), list):
+            os_list = data["os"]
+            invalid = [o for o in os_list if o not in KNOWN_OS]
+            self.check(
+                f"support.yml: os uses known vocabulary ({', '.join(os_list) or 'none'})",
+                not invalid,
+                f"Unknown OS(es): {', '.join(invalid)}. Known: {', '.join(sorted(KNOWN_OS))}",
+            )
+            self.check(
+                "support.yml: os list is not empty",
+                len(os_list) > 0,
+                "os must declare at least one supported OS",
+            )
+
+        git_providers = data.get("git_providers")
+        if git_providers is None:
+            self.info("git_providers: not declared (no git provider dependency assumed)")
+        elif isinstance(git_providers, list) and git_providers:
+            invalid = [gp for gp in git_providers if gp not in KNOWN_GIT_PROVIDERS]
+            self.check(
+                f"support.yml: git_providers use known vocabulary ({', '.join(git_providers)})",
+                not invalid,
+                f"Unknown provider(s): {', '.join(invalid)}. Known: {', '.join(sorted(KNOWN_GIT_PROVIDERS))}",
+            )
+        else:
+            self.info("git_providers: [] (no git provider CLI dependency)")
+
+        return data
+
+    def check_skill_md(self):
+        skill_md = self.skill_dir / "SKILL.md"
+        exists = self.check(
+            "SKILL.md exists",
+            skill_md.exists(),
+            "Missing SKILL.md -- every skill requires a SKILL.md file",
+        )
+        if not exists:
+            return
+
+        content = skill_md.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        self.check(
+            f"SKILL.md within {MAX_FILE_LINES}-line limit ({len(lines)} lines)",
+            len(lines) <= MAX_FILE_LINES,
+            f"SKILL.md has {len(lines)} lines (max {MAX_FILE_LINES}). Extract sections to references/",
+        )
+
+        fm, fm_err = parse_frontmatter(content)
+        fm_ok = self.check(
+            "SKILL.md: valid YAML frontmatter",
+            fm is not None,
+            f"Frontmatter parse error: {fm_err}",
+        )
+
+        if fm_ok:
+            self.check(
+                "SKILL.md frontmatter: 'name' field present",
+                "name" in fm,
+                "Missing required frontmatter field: name",
+            )
+            self.check(
+                "SKILL.md frontmatter: 'description' field present",
+                "description" in fm,
+                "Missing required frontmatter field: description",
+            )
+            if "name" in fm:
+                self.check(
+                    f"SKILL.md frontmatter: name matches directory ('{fm['name']}')",
+                    fm["name"] == self.skill_name,
+                    f"frontmatter name: '{fm['name']}' does not match directory '{self.skill_name}'",
+                )
+
+        # Check relative links
+        links = extract_relative_links(content)
+        if links:
+            broken = [lnk for lnk in links if not (self.skill_dir / lnk).exists()]
+            self.check(
+                f"SKILL.md: all relative links resolve ({len(links)} checked)",
+                not broken,
+                f"Broken link(s): {', '.join(broken)}",
+            )
+        else:
+            self.info("SKILL.md: no relative links to check")
+
+    def check_file_sizes(self):
+        md_files = [
+            f for f in self.skill_dir.rglob("*.md") if f.name != "SKILL.md"
+        ]
+        if not md_files:
+            return
+
+        oversized = []
+        for md_file in md_files:
+            try:
+                lines = md_file.read_text(encoding="utf-8").splitlines()
+                if len(lines) > MAX_FILE_LINES:
+                    rel = md_file.relative_to(self.skill_dir)
+                    oversized.append(f"{rel} ({len(lines)} lines)")
+            except Exception:
+                pass
+
+        self.check(
+            f"Reference/resource files within {MAX_FILE_LINES}-line limit ({len(md_files)} checked)",
+            not oversized,
+            f"Oversized: {', '.join(oversized)}",
+        )
+
+    def check_python_syntax(self):
+        scripts_dir = self.skill_dir / "scripts"
+        if not scripts_dir.is_dir():
+            return
+
+        py_scripts = list(scripts_dir.glob("*.py"))
+        if not py_scripts:
+            return
+
+        failed = []
+        for script in py_scripts:
+            result = subprocess.run(
+                [sys.executable, "-m", "py_compile", str(script)],
+                capture_output=True,
+            )
+            if result.returncode != 0:
+                failed.append(script.name)
+
+        self.check(
+            f"Python scripts valid syntax ({len(py_scripts)} checked)",
+            not failed,
+            f"Syntax errors in: {', '.join(failed)}",
+        )
+
+    # --- main entry point ---
+
+    def run(self):
+        print(f"\nValidating skill: {self.skill_name}")
+        print(f"  Path: {self.skill_dir}")
+        print()
+
+        if not self.check_skill_dir():
+            print("\n[ERROR] Skill directory not found -- cannot continue.")
+            return False
+
+        self.check_support_yml()
+        self.check_skill_md()
+        self.check_file_sizes()
+        self.check_python_syntax()
+
+        total = self.passed + self.failed
+        print()
+        if self.failed == 0:
+            print(f"All checks passed! ({self.passed}/{total})")
+        else:
+            print(f"{self.failed} check(s) FAILED ({self.passed}/{total} passed)")
+            print()
+            print("Failures:")
+            for err in self.errors:
+                print(f"  - {err}")
+
+        return self.failed == 0
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <skill-dir>", file=sys.stderr)
+        print(f"  e.g. {sys.argv[0]} skills/qodo-get-rules", file=sys.stderr)
+        sys.exit(2)
+
+    validator = Validator(sys.argv[1])
+    success = validator.run()
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/e2e-qodo-get-rules.yml
+++ b/.github/workflows/e2e-qodo-get-rules.yml
@@ -1,0 +1,94 @@
+name: E2E Test — qodo-get-rules
+
+# Runs a live end-to-end test of the qodo-get-rules skill against the Qodo
+# rules API whenever a PR touches the skill's source files. Verifies that the
+# skill loads, returns rules, and returns topically relevant results for a
+# known security/auth prompt.
+#
+# Runs on Linux, macOS, and Windows using each platform's native shell to
+# validate real cross-platform support (not Git Bash on Windows).
+#
+# Requires the `ci` environment which holds QODO_API_KEY, QODO_API_URL, and
+# ANTHROPIC_API_KEY. Secrets are never exposed to fork PRs.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "skills/qodo-get-rules/**"
+
+jobs:
+  e2e:
+    name: E2E test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    environment: ci
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+      fail-fast: false
+
+    # Never run for fork PRs — secrets are already withheld by GitHub by default,
+    # but this makes intent explicit and avoids noisy failures on forks.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure Qodo API key (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p ~/.qodo
+          printf '{"API_KEY":"%s","QODO_API_URL":"%s"}' "$QODO_API_KEY" "$QODO_API_URL" > ~/.qodo/config.json
+        env:
+          QODO_API_KEY: ${{ secrets.QODO_API_KEY }}
+          QODO_API_URL: ${{ secrets.QODO_API_URL }}
+
+      - name: Configure Qodo API key (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -Force -ItemType Directory "$HOME/.qodo" | Out-Null
+          $config = '{"API_KEY":"' + $env:QODO_API_KEY + '","QODO_API_URL":"' + $env:QODO_API_URL + '"}'
+          Set-Content -Path "$HOME/.qodo/config.json" -Value $config
+        env:
+          QODO_API_KEY: ${{ secrets.QODO_API_KEY }}
+          QODO_API_URL: ${{ secrets.QODO_API_URL }}
+
+      - name: Install skill from PR branch (Unix)
+        # Copy the skill from the PR's source tree into the Claude skills directory
+        # so claude -p picks up the version being tested, not any cached install.
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p .claude/skills
+          rm -rf .claude/skills/qodo-get-rules
+          cp -r skills/qodo-get-rules .claude/skills/qodo-get-rules
+
+      - name: Install skill from PR branch (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -Force -ItemType Directory ".claude/skills" | Out-Null
+          Remove-Item -Recurse -Force ".claude/skills/qodo-get-rules" -ErrorAction SilentlyContinue
+          Copy-Item -Recurse "skills/qodo-get-rules" ".claude/skills/qodo-get-rules"
+
+      - name: Run skill and assert criteria (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash .github/e2e/qodo-get-rules/assert.sh
+
+      - name: Run skill and assert criteria (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: .github/e2e/qodo-get-rules/assert.ps1

--- a/.github/workflows/skill-pr-validation.yml
+++ b/.github/workflows/skill-pr-validation.yml
@@ -1,0 +1,94 @@
+name: Skill PR Validation
+
+# Runs on every PR that touches the skills/ directory.
+# Reads each affected skill's support.yml to determine the OS test matrix,
+# then runs structural validation on each (skill, OS) combination.
+# The `check-passed` job is the required status check to configure in branch protection.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "skills/**"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1: Detect which skills changed and build the test matrix
+  # ---------------------------------------------------------------------------
+  setup:
+    name: Detect changed skills
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      has_matrix: ${{ steps.build.outputs.has_matrix }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Get changed skill files
+        id: changed
+        uses: tj-actions/changed-files@7dee1b0c1557f278e5c7dc244927139d78c0e22a  # v47.0.4
+        with:
+          files: skills/**
+
+      - name: Build test matrix
+        id: build
+        run: |
+          python3 .github/scripts/build-matrix.py pr "${{ steps.changed.outputs.all_changed_files }}"
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Validate each (skill, OS) combination from the matrix
+  # ---------------------------------------------------------------------------
+  validate:
+    name: Validate ${{ matrix.skill }} on ${{ matrix.os }}
+    needs: setup
+    if: needs.setup.outputs.has_matrix == 'true'
+    strategy:
+      fail-fast: false  # Run all combinations so all failures are visible at once
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Validate skill
+        run: python3 .github/scripts/validate-skill.py skills/${{ matrix.skill }}
+
+  # ---------------------------------------------------------------------------
+  # Job 3: Summary gate -- configure this as the required status check
+  #
+  # Branch protection rule: require "Skill validation passed" to pass.
+  # This single job absorbs the dynamic matrix so you only need one required check.
+  # ---------------------------------------------------------------------------
+  check-passed:
+    name: Skill validation passed
+    needs: [setup, validate]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Evaluate results
+        run: |
+          setup="${{ needs.setup.result }}"
+          validate="${{ needs.validate.result }}"
+          has_matrix="${{ needs.setup.outputs.has_matrix }}"
+
+          if [ "$setup" != "success" ]; then
+            echo "Setup job failed (result: $setup)"
+            exit 1
+          fi
+
+          if [ "$has_matrix" = "false" ]; then
+            echo "No skills affected by this PR -- validation skipped"
+            exit 0
+          fi
+
+          if [ "$validate" = "failure" ] || [ "$validate" = "cancelled" ]; then
+            echo "One or more skill validations FAILED (result: $validate)"
+            exit 1
+          fi
+
+          echo "All skill validations passed"

--- a/.github/workflows/skill-test-on-demand.yml
+++ b/.github/workflows/skill-test-on-demand.yml
@@ -1,0 +1,97 @@
+name: Test Skill On-Demand
+
+# Manually trigger validation for any skill, optionally on a specific OS.
+# Useful for maintenance, debugging, and verifying skills without opening a PR.
+#
+# Trigger via GitHub Actions UI: Actions > Test Skill On-Demand > Run workflow
+# Or via CLI: gh workflow run skill-test-on-demand.yml -f skill=qodo-get-rules
+
+on:
+  workflow_dispatch:
+    inputs:
+      skill:
+        description: "Skill name (e.g. qodo-get-rules)"
+        required: true
+        type: string
+      os:
+        description: "Operating system to test on (all = use skill's declared OS list)"
+        required: false
+        default: "all"
+        type: choice
+        options:
+          - all
+          - ubuntu
+          - macos
+          - windows
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Job 1: Build the test matrix for the requested skill
+  # ---------------------------------------------------------------------------
+  setup:
+    name: Build matrix for ${{ inputs.skill }}
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build.outputs.matrix }}
+      has_matrix: ${{ steps.build.outputs.has_matrix }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Build test matrix
+        id: build
+        run: |
+          python3 .github/scripts/build-matrix.py skill "${{ inputs.skill }}" --os "${{ inputs.os }}"
+
+  # ---------------------------------------------------------------------------
+  # Job 2: Run validation on each OS in the matrix
+  # ---------------------------------------------------------------------------
+  validate:
+    name: Validate ${{ matrix.skill }} on ${{ matrix.os }}
+    needs: setup
+    if: needs.setup.outputs.has_matrix == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Validate skill
+        run: python3 .github/scripts/validate-skill.py skills/${{ matrix.skill }}
+
+  # ---------------------------------------------------------------------------
+  # Job 3: Summary
+  # ---------------------------------------------------------------------------
+  summary:
+    name: Test summary
+    needs: [setup, validate]
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report
+        run: |
+          validate="${{ needs.validate.result }}"
+          has_matrix="${{ needs.setup.outputs.has_matrix }}"
+
+          if [ "$has_matrix" = "false" ]; then
+            echo "No matrix entries were generated for skill '${{ inputs.skill }}'."
+            echo "Check that the skill directory exists at skills/${{ inputs.skill }}"
+            exit 1
+          fi
+
+          if [ "$validate" = "failure" ]; then
+            echo "Validation FAILED for ${{ inputs.skill }} (os: ${{ inputs.os }})"
+            exit 1
+          fi
+
+          if [ "$validate" = "cancelled" ]; then
+            echo "Validation was cancelled"
+            exit 1
+          fi
+
+          echo "Validation passed for ${{ inputs.skill }} (os: ${{ inputs.os }})"

--- a/SKILL_SUPPORT.md
+++ b/SKILL_SUPPORT.md
@@ -1,0 +1,241 @@
+# Skill Support Declaration
+
+Every skill in this repository must include a `support.yml` file declaring which coding agents, operating systems, and git providers it has been tested against. This file drives CI validation and feeds future analytics.
+
+---
+
+## Why This Exists
+
+Skills run on different agents (Claude Code, Cursor, Windsurf), different OSes (macOS, Ubuntu, Windows), and may depend on provider-specific CLIs (`gh`, `glab`, etc.). Without explicit declarations:
+
+- There is no way to know which combinations are actually supported
+- CI cannot enforce quality on new contributions
+- Users cannot discover compatibility at a glance
+
+The `support.yml` file makes these declarations explicit, machine-readable, and enforced on every PR.
+
+---
+
+## Quick Start
+
+Add a `support.yml` to your skill directory:
+
+```yaml
+schema_version: "1"
+skill: qodo-my-skill
+
+agents:
+  - claude-code
+  - cursor
+
+os:
+  - ubuntu
+  - macos
+  - windows
+
+git_providers: []   # omit or leave empty if no provider CLI dependency
+
+tests: []           # optional custom test commands (see below)
+```
+
+That's it. CI will pick it up automatically.
+
+---
+
+## File Location
+
+```
+skills/
+  qodo-my-skill/
+    SKILL.md          # required: skill instructions
+    support.yml       # required: this file
+    references/       # optional: progressive disclosure docs
+    scripts/          # optional: helper scripts
+```
+
+---
+
+## Schema Reference
+
+### `schema_version` (required)
+
+Always `"1"` for the current format. Will increment if the schema changes in a backwards-incompatible way.
+
+```yaml
+schema_version: "1"
+```
+
+### `skill` (required)
+
+Must exactly match the directory name.
+
+```yaml
+skill: qodo-get-rules
+```
+
+### `agents` (required)
+
+List of coding agents this skill has been tested with and is declared to support. Must not be empty.
+
+```yaml
+agents:
+  - claude-code
+  - cursor
+  - windsurf
+  - cline
+```
+
+**Known values:**
+
+| Value | Agent |
+|-------|-------|
+| `claude-code` | Anthropic Claude Code |
+| `cursor` | Cursor IDE |
+| `windsurf` | Windsurf (Codeium) |
+| `cline` | Cline (VS Code extension) |
+| `copilot` | GitHub Copilot |
+| `codex` | OpenAI Codex |
+
+### `os` (required)
+
+List of operating systems this skill has been tested on and is declared to support. Must not be empty.
+
+```yaml
+os:
+  - ubuntu
+  - macos
+  - windows
+```
+
+**Known values:**
+
+| Value | Meaning | CI Runner |
+|-------|---------|-----------|
+| `ubuntu` | Ubuntu/Debian Linux | `ubuntu-latest` |
+| `macos` | macOS | `macos-latest` |
+| `windows` | Windows | `windows-latest` |
+
+### `git_providers` (optional)
+
+List of git providers this skill explicitly depends on. Only declare a provider if the skill invokes provider-specific CLI tools (`gh`, `glab`, `bb`, `az devops`).
+
+Skills that only read the git remote URL (e.g. for scope detection) do **not** need a git provider declaration.
+
+```yaml
+# Skill with no provider CLI dependency:
+git_providers: []
+
+# Skill that uses gh and glab:
+git_providers:
+  - github
+  - gitlab
+```
+
+**Known values:**
+
+| Value | Provider | CLI Tool |
+|-------|----------|----------|
+| `github` | GitHub | `gh` |
+| `gitlab` | GitLab | `glab` |
+| `bitbucket` | Bitbucket | `bb` |
+| `azure-devops` | Azure DevOps | `az devops` |
+
+### `tests` (optional)
+
+Custom test commands to run after structural checks. Commands run from the skill root directory. Leave empty if structural checks are sufficient.
+
+```yaml
+tests:
+  - python3 scripts/validate-something.py
+```
+
+> **Note:** Custom test execution is planned for a future version. For now, the field is validated for correct YAML structure but commands are not executed in CI. Structural checks (see below) always run.
+
+---
+
+## What CI Validates
+
+On every PR that touches `skills/**`, the [skill-pr-validation workflow](.github/workflows/skill-pr-validation.yml):
+
+1. Detects which skills were changed
+2. Reads each skill's `support.yml` to determine the OS matrix
+3. Runs `validate-skill.py` on each (skill, OS) combination
+
+**Structural checks run on every skill:**
+
+| Check | Description |
+|-------|-------------|
+| `support.yml` exists | File must be present |
+| Schema valid | Required fields present and correct |
+| Skill name matches directory | `skill:` field = directory name |
+| `agents` vocabulary | Only known agent values |
+| `os` vocabulary | Only known OS values |
+| `git_providers` vocabulary | Only known provider values (if declared) |
+| `SKILL.md` exists | Required for every skill |
+| Frontmatter valid | YAML between `---` delimiters, with `name` and `description` |
+| `SKILL.md` name matches directory | Frontmatter `name:` = directory name |
+| File size limits | All `.md` files ≤ 500 lines |
+| Relative links resolve | All `[text](path)` links in `SKILL.md` point to existing files |
+| Python script syntax | All `scripts/*.py` files compile without errors |
+
+A PR cannot merge if any check fails on any declared OS.
+
+---
+
+## On-Demand Testing
+
+To test a skill outside of a PR (maintenance, debugging, or before opening a PR):
+
+**GitHub Actions UI:**
+> Actions → Test Skill On-Demand → Run workflow → enter skill name
+
+**GitHub CLI:**
+```bash
+gh workflow run skill-test-on-demand.yml -f skill=qodo-get-rules
+gh workflow run skill-test-on-demand.yml -f skill=qodo-get-rules -f os=ubuntu
+```
+
+**Locally:**
+```bash
+python3 .github/scripts/validate-skill.py skills/qodo-get-rules
+```
+
+---
+
+## Adding a New Skill
+
+1. Create `skills/qodo-my-skill/`
+2. Add `SKILL.md` with valid YAML frontmatter (`name`, `description`)
+3. Add `support.yml` using the template above
+4. Run local validation: `python3 .github/scripts/validate-skill.py skills/qodo-my-skill`
+5. Open a PR — CI will validate on each declared OS
+
+---
+
+## Reference Implementation
+
+[`skills/qodo-get-rules/support.yml`](skills/qodo-get-rules/support.yml) is the canonical example. It declares support for all four coding agents, all three OSes, and no git provider dependency.
+
+---
+
+## Design Rationale
+
+**Why `support.yml` instead of extending `SKILL.md` frontmatter?**
+
+Adding support metadata to `SKILL.md` frontmatter would mix agent-execution instructions with CI metadata. A separate file keeps concerns isolated: `SKILL.md` is for agents to read and execute; `support.yml` is for CI and tooling to parse. It also allows validators to parse the declaration without needing to understand Markdown structure.
+
+**Why a controlled vocabulary instead of free-form strings?**
+
+Controlled vocabularies (known agent names, OS names, provider names) make the data usable for future analytics — tracking which agents a skill supports, which OS has the most coverage gaps, etc. Free-form strings would make aggregation error-prone. New values can be added to the vocabulary in `validate-skill.py` and this document.
+
+**Why structural validation rather than runtime testing?**
+
+Skills are AI agent instructions, not executable code. Their "runtime" is an LLM interpreting Markdown. Structural checks (file integrity, schema validity, link resolution, script syntax) are what can be mechanically verified in CI. Runtime behavior is verified manually by the skill author against the test matrix declared in `support.yml`. The declaration serves as an attestation.
+
+**Why an OS matrix in CI?**
+
+Even though skills are Markdown documents, helper scripts in `scripts/` can have OS-specific issues (path separators, command availability, Python invocation). Running structural validation on all declared OS runners catches these before they reach users.
+
+**Why `fail-fast: false` in the matrix strategy?**
+
+So all combinations run on every PR and all failures are visible at once, rather than stopping after the first failure. This makes it faster to fix all issues in a single iteration.

--- a/skills/qodo-get-rules/support.yml
+++ b/skills/qodo-get-rules/support.yml
@@ -1,0 +1,28 @@
+schema_version: "1"
+skill: qodo-get-rules
+
+# Supported coding agents
+# Vocabulary: claude-code | cursor | windsurf | cline | copilot | codex
+agents:
+  - claude-code
+  - cursor
+  - windsurf
+  - cline
+
+# Supported operating systems
+# Vocabulary: ubuntu | macos | windows
+os:
+  - ubuntu
+  - macos
+  - windows
+
+# Git provider dependency
+# List providers only if the skill invokes provider-specific CLIs (gh, glab, bb, az devops).
+# This skill only reads git remote URL — no provider CLI dependency. Leave empty.
+# Vocabulary: github | gitlab | bitbucket | azure-devops
+git_providers: []
+
+# Custom test commands (optional)
+# Shell commands run from the skill root directory after structural checks pass.
+# Use cross-platform Python where possible. Leave empty if structural checks are sufficient.
+tests: []

--- a/tools/scaffold-e2e-ci/SKILL.md
+++ b/tools/scaffold-e2e-ci/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: scaffold-e2e-ci
+description: "Scaffold E2E CI assets for a skill — interviews the skill builder to define a test prompt and observable criteria, then generates workflow yml, assert scripts, and config"
+triggers:
+  - "scaffold.?e2e"
+  - "scaffold.?ci"
+  - "generate.?e2e"
+  - "create.?e2e.?ci"
+---
+
+# scaffold-e2e-ci
+
+Generates E2E CI infrastructure for a skill in this repository by interviewing the skill builder. The interview is the core of this skill — it guides the builder to define a meaningful test, not just a passing one.
+
+## Step 1 — Identify the skill
+
+Ask the skill builder which skill to scaffold if not provided:
+> "Which skill are we scaffolding E2E CI for?"
+
+Then read `skills/<skill>/support.yml` and extract:
+- `os` list — drives the GitHub Actions matrix
+- `skill` field — used for file naming
+
+**OS → GitHub Actions runner:**
+| `support.yml` | runner |
+|---------------|--------|
+| `ubuntu`      | `ubuntu-latest` |
+| `macos`       | `macos-latest`  |
+| `windows`     | `windows-latest` |
+
+Determine groups needed:
+- **unix** — `ubuntu` or `macos` is declared
+- **windows** — `windows` is declared
+
+## Step 2 — Interview: define the test prompt
+
+Ask the builder to describe a real task a user would bring to this skill:
+
+> "What's a realistic prompt a user would give this skill? Describe the scenario — what are they trying to do, and what context would they provide?"
+
+Listen to their answer, then push back with one of these if the answer is too generic:
+- If it's a one-liner with no context: "Can you make it more concrete? A real user prompt usually includes what they're building, not just the action."
+- If it's abstract: "What would a developer actually type? Give me the messy real version, not a clean description of it."
+- If it's perfect: proceed.
+
+Once you have a good prompt, confirm: "I'll use this as the E2E test input: `<prompt>`. Does that look right?"
+
+## Step 3 — Interview: define observable criteria
+
+This is the most important part. Guide the builder to define what *observable evidence* in the skill's output would prove it worked correctly. Not "it ran" — proof that the right thing happened.
+
+Ask:
+> "If this skill ran successfully on that prompt, what would you expect to see in the output? Think about: what text, headers, or terms would only appear if the skill actually did its job?"
+
+For each thing they describe, ask a follow-up:
+- "Is that something we could grep for? What exact text or pattern?"
+- If they say something that's not grep-able (e.g., "the code would be correct"): "That's important but hard to verify mechanically. What *observable text in the output* would signal that? For example: a header, a label, a category name?"
+- If they're stuck: "Think about it this way — if someone broke the skill so it returned nothing useful, what would be *missing* from the output?"
+
+Push for 2–4 concrete, grep-able criteria. Each must be:
+1. **Observable** — visible as text in stdout
+2. **Specific** — would only match if the skill actually did its job (not just "any output")
+3. **Grep-able** — matchable with a case-insensitive regex
+
+Once the builder has described all criteria, summarize them back:
+> "Here's what I'll check for:
+> 1. `<pattern>` — <what it proves>
+> 2. `<pattern>` — <what it proves>
+> ...
+> Does this capture what you're looking for? Anything missing or wrong?"
+
+Revise until confirmed.
+
+## Step 4 — Write config.json
+
+Write `.github/e2e/<skill>/config.json`:
+
+```json
+{
+  "skill": "<skill>",
+  "prompt": "<confirmed prompt>",
+  "criteria": [
+    { "id": "<slug>", "description": "<what it proves>", "match": "<regex>", "flags": "i" }
+  ]
+}
+```
+
+Use a short kebab-case `id` (e.g., `rules-loaded`, `topic-relevance`).
+
+## Step 5 — Write assert.sh (Unix)
+
+Only write if the skill declares `ubuntu` or `macos` support.
+
+Write `.github/e2e/<skill>/assert.sh`:
+
+```bash
+#!/usr/bin/env bash
+# E2E assertion script for <skill> (Linux/macOS)
+set -euo pipefail
+
+OUTPUT=$(claude -p --dangerously-skip-permissions "/<skill> <prompt>" 2>&1)
+
+PASS=0
+FAIL=0
+
+check() {
+  local label="$1"
+  local result="$2"
+  if [ "$result" = "true" ]; then
+    echo "[PASS] $label"
+    PASS=$((PASS + 1))
+  else
+    echo "[FAIL] $label"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Criterion N: <description>
+if echo "$OUTPUT" | grep -qi "<match>"; then
+  check "<description>" true
+else
+  check "<description>" false
+fi
+# ... one block per criterion
+
+TOTAL=$((PASS + FAIL))
+echo ""
+echo "--- Result: $PASS/$TOTAL criteria passed ---"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+```
+
+**Grep flag:** use `-qi` for plain strings, `-qiE` for patterns with `|`, `\b`, `+`, etc.
+
+## Step 6 — Write assert.ps1 (Windows)
+
+Only write if the skill declares `windows` support.
+
+Write `.github/e2e/<skill>/assert.ps1`:
+
+```powershell
+# E2E assertion script for <skill> (Windows/PowerShell)
+$ErrorActionPreference = 'Stop'
+
+$OUTPUT = claude -p --dangerously-skip-permissions "/<skill> <prompt>" 2>&1 | Out-String
+
+$PASS = 0
+$FAIL = 0
+
+function Check-Criterion {
+    param([string]$Label, [bool]$Result)
+    if ($Result) {
+        Write-Host "[PASS] $Label"
+        $script:PASS++
+    } else {
+        Write-Host "[FAIL] $Label"
+        $script:FAIL++
+    }
+}
+
+# Criterion N: <description>
+Check-Criterion "<description>" ($OUTPUT -imatch "<match>")
+# ... one line per criterion
+
+$TOTAL = $PASS + $FAIL
+Write-Host ""
+Write-Host "--- Result: $PASS/$TOTAL criteria passed ---"
+
+if ($FAIL -gt 0) {
+    exit 1
+}
+```
+
+## Step 7 — Write workflow yml
+
+Write `.github/workflows/e2e-<skill>.yml`. Build the `os` matrix from the declared OSes only.
+
+```yaml
+name: E2E Test — <skill>
+
+# Runs a live end-to-end test of the <skill> skill whenever a PR touches
+# the skill's source files.
+#
+# Requires the `ci` environment which holds QODO_API_KEY, QODO_API_URL, and
+# ANTHROPIC_API_KEY. Secrets are never exposed to fork PRs.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "skills/<skill>/**"
+
+jobs:
+  e2e:
+    name: E2E test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    environment: ci
+
+    strategy:
+      matrix:
+        os: [<comma-separated runners>]
+      fail-fast: false
+
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
+    env:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install Claude Code CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Configure Qodo API key (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p ~/.qodo
+          printf '{"API_KEY":"%s","QODO_API_URL":"%s"}' "$QODO_API_KEY" "$QODO_API_URL" > ~/.qodo/config.json
+        env:
+          QODO_API_KEY: ${{ secrets.QODO_API_KEY }}
+          QODO_API_URL: ${{ secrets.QODO_API_URL }}
+
+      - name: Configure Qodo API key (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -Force -ItemType Directory "$HOME/.qodo" | Out-Null
+          $config = '{"API_KEY":"' + $env:QODO_API_KEY + '","QODO_API_URL":"' + $env:QODO_API_URL + '"}'
+          Set-Content -Path "$HOME/.qodo/config.json" -Value $config
+        env:
+          QODO_API_KEY: ${{ secrets.QODO_API_KEY }}
+          QODO_API_URL: ${{ secrets.QODO_API_URL }}
+
+      - name: Install skill from PR branch (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p .claude/skills
+          rm -rf .claude/skills/<skill>
+          cp -r skills/<skill> .claude/skills/<skill>
+
+      - name: Install skill from PR branch (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -Force -ItemType Directory ".claude/skills" | Out-Null
+          Remove-Item -Recurse -Force ".claude/skills/<skill>" -ErrorAction SilentlyContinue
+          Copy-Item -Recurse "skills/<skill>" ".claude/skills/<skill>"
+
+      - name: Run skill and assert criteria (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: bash .github/e2e/<skill>/assert.sh
+
+      - name: Run skill and assert criteria (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: .github/e2e/<skill>/assert.ps1
+```
+
+Omit Windows-specific steps entirely if `windows` is not declared. Omit Unix-specific steps entirely if neither `ubuntu` nor `macos` is declared.
+
+## Step 8 — Report
+
+After writing all files:
+
+```
+Generated E2E CI for <skill>:
+  .github/e2e/<skill>/config.json      — test prompt + <N> criteria
+  .github/e2e/<skill>/assert.sh        — bash assertions (Linux/macOS)
+  .github/e2e/<skill>/assert.ps1       — PowerShell assertions (Windows)
+  .github/workflows/e2e-<skill>.yml    — CI workflow (matrix: <runners>)
+
+Next steps:
+  1. Review the criteria in config.json — these are what CI will enforce on every PR
+  2. git add and commit the 4 files
+  3. Open a PR to trigger the workflow
+```
+
+Omit any file that was skipped from the report.


### PR DESCRIPTION
## Summary

- Adds a live end-to-end workflow (`e2e-qodo-get-rules.yml`) that runs on Ubuntu, macOS, and Windows against the real Qodo rules API
- Verifies the skill loads, returns rules, and returns topically relevant results for a known security/auth prompt
- Only fires on PRs that touch `skills/qodo-get-rules/**` (plus `workflow_dispatch` for manual runs)
- Skips fork PRs to keep secrets safe

Also adds shared CI infrastructure used by all skill E2E suites:
- `skill-pr-validation.yml` — validates skill structure on every PR
- `skill-test-on-demand.yml` — manual skill testing workflow
- `.github/scripts/` — `build-matrix.py` and `validate-skill.py` helpers
- `skills/qodo-get-rules/support.yml` — supported runner/provider matrix
- `SKILL_SUPPORT.md` — human-readable support matrix docs

## Secrets required (`ci` environment)

| Secret | Purpose |
|--------|---------|
| `ANTHROPIC_API_KEY` | Runs Claude Code CLI |
| `QODO_API_KEY` | Authenticates against Qodo rules API |
| `QODO_API_URL` | Qodo API endpoint |

## Test plan

- [x] Workflow dispatched manually on qodo-ai/qodo-skills-dev — all 3 OS runners passed
- [x] Verified against latest main (post Gerrit support merge)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)