### PR TITLE
fix: correct unresolved status for deferred comments in Gerrit docs

### DIFF
--- a/skills/qodo-pr-resolver/resources/gerrit.md
+++ b/skills/qodo-pr-resolver/resources/gerrit.md
@@ -183,7 +183,7 @@ Multiple replies across files can be combined in a single request:
 {
   "comments": {
     "file1.py": [{"in_reply_to": "id1", "message": "Fixed", "unresolved": false}],
-    "file2.py": [{"in_reply_to": "id2", "message": "Deferred", "unresolved": true}]
+    "file2.py": [{"in_reply_to": "id2", "message": "Deferred", "unresolved": false}]
   }
 }
 ```


### PR DESCRIPTION
The batch-reply JSON example in `resources/gerrit.md` set `"unresolved": true` for a deferred reply, contradicting the rule three lines above (and the `SKILL.md` Step 8 resolution rules) requiring `"unresolved": false`. Users copying the example would leave deferred Gerrit threads open. Docs-only fix — the skill's reply logic reads from `SKILL.md`, which was already correct