### PR TITLE
feat: add qodo-manage-rules skill

### DIFF
--- a/skills/qodo-manage-rules/SKILL.md
+++ b/skills/qodo-manage-rules/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: qodo-manage-rules
+description: "Manage Qodo rules: list, get, create (with AI-drafted content), update, and delete rules via the Qodo Rules API. Use when the user wants to view, create, edit, activate, deactivate, or delete coding rules in a Qodo environment."
+allowed-tools: "Bash"
+triggers:
+  - "manage.?rules"
+  - "create.?rule"
+  - "add.?rule"
+  - "new.?rule"
+  - "delete.?rule"
+  - "remove.?rule"
+  - "update.?rule"
+  - "edit.?rule"
+  - "activate.?rule"
+  - "deactivate.?rule"
+  - "list.?rules"
+  - "show.?rules"
+  - "get.?rule"
+  - "view.?rule"
+  - "find.?rule"
+  - "qodo.?manage"
+  - "rules.?management"
+---
+
+# Manage Qodo Rules Skill
+
+## Description
+
+Manages Qodo coding rules via the Rules API. Supports listing, viewing, creating (with AI-drafted content via `prompt-to-rule`), updating, and deleting rules. Admin-only operations (update, delete) detect missing permissions and surface them clearly.
+
+---
+
+## Arguments
+
+The skill accepts an optional argument. Recognized forms:
+
+- **App URL** — e.g. `https://app.qodost.st.qodo.ai` or `https://app.qodost.st.qodo.ai/rules?state=active`
+  Overrides the environment derived from config. The hostname is parsed to build the API URL.
+- **No argument** — uses `~/.qodo/config.json` (`ENVIRONMENT_NAME` / `QODO_API_URL`) to determine the environment.
+
+---
+
+## Workflow
+
+### Step 1: Resolve Auth and API URL
+
+Read the API key and determine the API base URL.
+
+```bash
+# 1. API key — prefer env var, fall back to auth.key file
+if [ -n "${QODO_API_KEY:-}" ]; then
+  API_KEY="$QODO_API_KEY"
+elif [ -f "$HOME/.qodo/auth.key" ]; then
+  API_KEY=$(cat "$HOME/.qodo/auth.key")
+elif [ -f "$HOME/.qodo/config.json" ]; then
+  API_KEY=$(python3 -c "import json,os; c=json.load(open(os.path.expanduser('~/.qodo/config.json'))); print(c.get('API_KEY',''))")
+fi
+
+if [ -z "$API_KEY" ]; then
+  echo "Error: no API key found. Set QODO_API_KEY or create ~/.qodo/auth.key"
+  exit 1
+fi
+
+# 2. API URL — from argument, config file, or production default
+API_URL=""
+
+# If an app URL was passed as argument, extract env name from hostname
+# e.g. https://app.qodost.st.qodo.ai -> qodost.st -> https://qodo-platform.qodost.st.qodo.ai/rules/v1
+if [ -n "${SKILL_ARG:-}" ]; then
+  ENV_FROM_ARG=$(python3 -c "
+from urllib.parse import urlparse
+import sys
+url = sys.argv[1]
+host = urlparse(url if '://' in url else 'https://' + url).hostname or ''
+# host: app.<env>.qodo.ai  -> env is everything between 'app.' and '.qodo.ai'
+import re
+m = re.match(r'^app\.(.+)\.qodo\.ai$', host)
+if m:
+    print(m.group(1))
+" "$SKILL_ARG" 2>/dev/null)
+  if [ -n "$ENV_FROM_ARG" ]; then
+    API_URL="https://qodo-platform.${ENV_FROM_ARG}.qodo.ai/rules/v1"
+  fi
+fi
+
+# Fall back to config file
+if [ -z "$API_URL" ] && [ -f "$HOME/.qodo/config.json" ]; then
+  API_URL=$(python3 -c "
+import json, os
+c = json.load(open(os.path.expanduser('~/.qodo/config.json')))
+qodo_api_url = c.get('QODO_API_URL', '')
+env_name = os.environ.get('QODO_ENVIRONMENT_NAME') or c.get('ENVIRONMENT_NAME', '')
+if qodo_api_url:
+    print(qodo_api_url.rstrip('/') + '/rules/v1')
+elif env_name:
+    print(f'https://qodo-platform.{env_name}.qodo.ai/rules/v1')
+else:
+    print('https://qodo-platform.qodo.ai/rules/v1')
+" 2>/dev/null)
+fi
+
+# Production default
+if [ -z "$API_URL" ]; then
+  API_URL="https://qodo-platform.qodo.ai/rules/v1"
+fi
+
+REQUEST_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
+```
+
+See [auth-and-env.md](references/auth-and-env.md) for full details.
+
+---
+
+### Step 2: Detect Intent
+
+Read the user's message and any skill argument to determine which operation to run:
+
+| User says | Operation |
+|---|---|
+| "list rules", "show me rules", "what rules exist" | **LIST** |
+| "get rule 123", "show rule 123", "view rule 123" | **GET** |
+| "create a rule about X", "add a rule for Y" | **CREATE** |
+| "update rule 123", "edit rule 123", "activate/deactivate rule 123" | **UPDATE** |
+| "delete rule 123", "remove rule 123" | **DELETE** |
+| "find similar rules to …", "check for duplicates" | **SIMILAR** |
+
+Extract any rule ID mentioned. If an ID is needed but not provided, ask the user.
+
+---
+
+### Step 3: Execute Operation
+
+See the relevant section below.
+
+---
+
+## Operations
+
+### LIST — Browse Rules
+
+**Endpoint:** `GET {API_URL}/rules`
+
+**Common filters** (map from user's natural language):
+
+| User says | Query param |
+|---|---|
+| "active rules" | `state=active` |
+| "pending rules" | `state=pending` |
+| "error severity" | `severity=error` |
+| "category Quality" | `categories=Quality` |
+| "from Code Patterns" | `sourceType=Code Patterns` |
+| "containing 'logging'" | `nameContains=logging` |
+
+```bash
+# Build query string from detected filters (add params as needed)
+PARAMS="pageSize=50"
+[ -n "$STATE_FILTER" ]    && PARAMS="${PARAMS}&state=${STATE_FILTER}"
+[ -n "$SEVERITY_FILTER" ] && PARAMS="${PARAMS}&severity=${SEVERITY_FILTER}"
+[ -n "$CATEGORY_FILTER" ] && PARAMS="${PARAMS}&categories=${CATEGORY_FILTER}"
+[ -n "$SOURCE_TYPE" ]     && PARAMS="${PARAMS}&sourceType=${SOURCE_TYPE}"
+[ -n "$NAME_FILTER" ]     && PARAMS="${PARAMS}&nameContains=${NAME_FILTER}"
+
+curl -s "${API_URL}/rules?${PARAMS}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules"
+```
+
+Present results as a concise table. See [output-format.md](references/output-format.md).
+
+---
+
+### GET — View a Rule
+
+**Endpoint:** `GET {API_URL}/rule/{rule_id}`
+
+```bash
+curl -s "${API_URL}/rule/${RULE_ID}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules"
+```
+
+Present the rule concisely. Offer to show full content (examples, scopes) if the user asks.
+
+---
+
+### CREATE — Draft, Review, Confirm, Persist
+
+**Three-step flow:** draft → review → confirm → create.
+
+See [create-flow.md](references/create-flow.md) for the full flow.
+
+**Step A — Draft via prompt-to-rule**
+
+```bash
+PROMPT_BODY=$(python3 -c "import json,sys; print(json.dumps({'prompt': sys.argv[1]}))" "$USER_DESCRIPTION")
+
+curl -s -X POST "${API_URL}/prompt-to-rule" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -d "$PROMPT_BODY"
+```
+
+**Step B — Present draft to user**
+
+Show the drafted rule in a readable format (name, category, severity, content, examples). Ask: _"Does this look right? Reply 'yes' to create, or tell me what to change."_
+
+**Step C — Create on confirmation**
+
+```bash
+CREATE_BODY=$(python3 -c "
+import json, sys
+rule = json.loads(sys.argv[1])
+# Remove fields not accepted by RuleCreateRequest
+for f in ['state', 'extractionReasoningContext', 'sourceUris', 'ruleId', 'workspaceId', 'createdAt', 'updatedAt', 'similaritiesCount', 'url', 'insights']:
+    rule.pop(f, None)
+print(json.dumps(rule))
+" "$DRAFT_JSON")
+
+curl -s -X POST "${API_URL}/rule" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -d "$CREATE_BODY"
+```
+
+Report the created rule ID on success.
+
+---
+
+### UPDATE — Edit an Existing Rule
+
+**Endpoint:** `PUT {API_URL}/rule/{rule_id}` (admin only)
+
+**Flow:**
+
+1. Fetch current rule via `GET /rule/{rule_id}` and display it.
+2. Apply the user's requested changes to the current values.
+3. Show the proposed updated rule and ask for confirmation.
+4. On confirmation, send `PUT` with the full `RuleUpdateRequest` body.
+
+```bash
+# RuleUpdateRequest requires ALL fields (same as RuleCreateRequest + state)
+UPDATE_BODY=$(python3 -c "
+import json, sys
+rule = json.loads(sys.argv[1])
+# Keep only fields accepted by RuleUpdateRequest
+keep = ['name','category','severity','suggestionType','content','goodExamples','badExamples','scopes','source','sourceType','sourceUri','state']
+out = {k: rule[k] for k in keep if k in rule}
+print(json.dumps(out))
+" "$UPDATED_RULE_JSON")
+
+curl -s -X PUT "${API_URL}/rule/${RULE_ID}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -d "$UPDATE_BODY"
+```
+
+See [admin-operations.md](references/admin-operations.md) for 403 handling.
+
+---
+
+### DELETE — Remove a Rule
+
+**Endpoint:** `DELETE {API_URL}/rule/{rule_id}` (admin only)
+
+**Flow:**
+
+1. Fetch the rule via `GET /rule/{rule_id}` and show name + severity to the user.
+2. Ask for explicit confirmation: _"Are you sure you want to delete rule {id} '{name}'? This cannot be undone."_
+3. On confirmation, send `DELETE`.
+
+```bash
+curl -s -X DELETE "${API_URL}/rule/${RULE_ID}" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -o /dev/null -w "%{http_code}"
+```
+
+204 = success. See [admin-operations.md](references/admin-operations.md) for 403 handling.
+
+---
+
+### SIMILAR — Find Similar Rules
+
+**Endpoint:** `POST {API_URL}/rule_similarity`
+
+Use this to check for duplicates before creating, or when the user asks.
+
+```bash
+BODY=$(python3 -c "
+import json, sys
+rule = json.loads(sys.argv[1])
+print(json.dumps({'name': rule['name'], 'category': rule['category'], 'severity': rule['severity'], 'content': rule['content'], 'goodExamples': rule.get('goodExamples',''), 'badExamples': rule.get('badExamples',''), 'state': 'active'}))
+" "$RULE_JSON")
+
+curl -s -X POST "${API_URL}/rule_similarity" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -d "$BODY"
+```
+
+---
+
+## Error Handling
+
+| HTTP status | Meaning | Response |
+|---|---|---|
+| 401 | Invalid/expired API key | Inform user, show setup instructions |
+| 403 | Admin required | "This operation requires admin (org owner or team owner) access." |
+| 404 | Rule not found | "Rule {id} not found." |
+| 409 | Duplicate rule name | "A rule with this name already exists." |
+| 422 | Invalid request body | Show validation error details to user |
+| 429 | Rate limit exceeded | "Rate limit hit. Retry in 1 minute." |
+| 5xx | Server error | "Service temporarily unavailable. Please try again." |
+
+---
+
+## Common Mistakes
+
+- **Sending wrong fields on create** — `POST /rule` uses `RuleCreateRequest` (no `state`). Strip `state`, `ruleId`, `workspaceId`, `createdAt`, `updatedAt` before posting.
+- **Missing required fields** — `name`, `category`, `severity`, `content`, `goodExamples`, `badExamples` are all required on create and update.
+- **Not confirming before destructive actions** — always ask for confirmation before delete and update.
+- **Not showing the draft** — always present the `prompt-to-rule` output to the user before creating.
+- **Skipping admin check** — for 403 responses, explain clearly that admin rights are required rather than showing a raw error.
+- **No pagination** — `GET /rules` returns 50 per page. If user asks "how many rules", paginate to get `totalCount`.

--- a/skills/qodo-manage-rules/references/admin-operations.md
+++ b/skills/qodo-manage-rules/references/admin-operations.md
@@ -23,7 +23,7 @@ This operation (update/delete rule) is only available to organization owners
 and team owners. Your current API key does not have admin rights on this workspace.
 
 If you believe this is wrong, check your role at:
-  {APP_URL}/settings/members
+  {APP_URL}/account/members
 ```
 
 Where `APP_URL` is derived from the API URL (reverse the env extraction:

--- a/skills/qodo-manage-rules/references/admin-operations.md
+++ b/skills/qodo-manage-rules/references/admin-operations.md
@@ -1,0 +1,69 @@
+# Admin-Only Operations
+
+`PUT /rule/{id}` (update) and `DELETE /rule/{id}` (delete) require admin access.
+Admin = organization owner or team owner.
+
+## Admin Check
+
+There is no dedicated `/me/is-admin` endpoint. The server returns **HTTP 403** when a non-admin calls these endpoints.
+
+**Strategy:** attempt the operation and handle the response:
+
+- **2xx** → success, show result.
+- **403** → inform the user clearly (see below). Do not retry.
+
+## 403 Response
+
+When you receive a 403, show:
+
+```
+⛔ Admin access required.
+
+This operation (update/delete rule) is only available to organization owners
+and team owners. Your current API key does not have admin rights on this workspace.
+
+If you believe this is wrong, check your role at:
+  {APP_URL}/settings/members
+```
+
+Where `APP_URL` is derived from the API URL (reverse the env extraction:
+`https://qodo-platform.<env>.qodo.ai` → `https://app.<env>.qodo.ai`).
+
+## Update Flow
+
+1. `GET /rule/{id}` — fetch current rule, display it concisely.
+2. Identify what the user wants to change (name, content, severity, state, scopes, etc.).
+3. Build the updated rule by merging changes into the current values.
+4. Display the proposed update and ask: _"Apply these changes to rule {id}?"_
+5. On confirmation, `PUT /rule/{id}` with the full `RuleUpdateRequest` body.
+
+**`RuleUpdateRequest` = `RuleCreateRequest` + `state`**
+
+All fields required:
+- `name`, `category`, `severity`, `content`, `goodExamples`, `badExamples` (from RuleCreateRequest)
+- `state` — one of: `active`, `pending`, `inactive`
+
+Optional:
+- `scopes`, `source`, `sourceType`, `sourceUri`, `suggestionType`
+
+**Common state changes:**
+
+| User says | Set `state` to |
+|---|---|
+| "activate rule 123" | `active` |
+| "deactivate rule 123" | `inactive` |
+| "mark as pending" | `pending` |
+
+## Delete Flow
+
+1. `GET /rule/{id}` — fetch rule to confirm it exists and show the user what will be deleted.
+2. Ask: _"Are you sure you want to permanently delete rule {id} '{name}'? This cannot be undone."_
+3. Only proceed on explicit confirmation ("yes", "confirm", "delete it", etc.).
+4. `DELETE /rule/{id}` — expect HTTP 204 on success.
+
+## HTTP Status on Success
+
+| Operation | Success status |
+|---|---|
+| PUT (update) | 200 — returns updated `Rule` object |
+| DELETE | 204 — empty body |

--- a/skills/qodo-manage-rules/references/auth-and-env.md
+++ b/skills/qodo-manage-rules/references/auth-and-env.md
@@ -12,7 +12,7 @@ If no key is found, exit with:
 ```
 Error: Qodo API key not found.
 Set QODO_API_KEY or create ~/.qodo/auth.key with your key.
-Get your key at https://app.qodo.ai/settings/api-keys
+Get your key at https://app.qodo.ai/account/api-keys
 ```
 
 ## API URL

--- a/skills/qodo-manage-rules/references/auth-and-env.md
+++ b/skills/qodo-manage-rules/references/auth-and-env.md
@@ -1,0 +1,58 @@
+# Auth and Environment Resolution
+
+## API Key
+
+Resolution order (first found wins):
+
+1. `QODO_API_KEY` environment variable
+2. `~/.qodo/auth.key` file (single line, no newline trimming needed)
+3. `API_KEY` field in `~/.qodo/config.json`
+
+If no key is found, exit with:
+```
+Error: Qodo API key not found.
+Set QODO_API_KEY or create ~/.qodo/auth.key with your key.
+Get your key at https://app.qodo.ai/settings/api-keys
+```
+
+## API URL
+
+Resolution order (first found wins):
+
+1. **Skill argument** — if the argument looks like a Qodo app URL (`https://app.<env>.qodo.ai`), extract `<env>` and build:
+   `https://qodo-platform.<env>.qodo.ai/rules/v1`
+
+2. **`QODO_API_URL` in config** — `~/.qodo/config.json` field `QODO_API_URL`:
+   `{QODO_API_URL}/rules/v1`
+
+3. **`ENVIRONMENT_NAME` in config** — `~/.qodo/config.json` field `ENVIRONMENT_NAME` (also overridable via `QODO_ENVIRONMENT_NAME` env var):
+   `https://qodo-platform.{ENVIRONMENT_NAME}.qodo.ai/rules/v1`
+
+4. **Production default:**
+   `https://qodo-platform.qodo.ai/rules/v1`
+
+## App URL → API URL Examples
+
+| App URL (user provides) | API Base URL |
+|---|---|
+| `https://app.qodo.ai` | `https://qodo-platform.qodo.ai/rules/v1` |
+| `https://app.staging.qodo.ai` | `https://qodo-platform.staging.qodo.ai/rules/v1` |
+| `https://app.qodost.st.qodo.ai` | `https://qodo-platform.qodost.st.qodo.ai/rules/v1` |
+
+The path after the hostname (e.g. `/rules?state=active`) is ignored — only the hostname matters.
+
+## Request Headers
+
+Every API call must include:
+
+```
+Authorization: Bearer {API_KEY}
+request-id: {REQUEST_ID}      # UUID, generated once per skill invocation
+qodo-client-type: skill-qodo-manage-rules
+Content-Type: application/json   # only for POST/PUT requests
+```
+
+Generate `REQUEST_ID`:
+```bash
+REQUEST_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
+```

--- a/skills/qodo-manage-rules/references/create-flow.md
+++ b/skills/qodo-manage-rules/references/create-flow.md
@@ -1,0 +1,111 @@
+# Create Rule Flow
+
+Creating a rule is a three-step interactive flow: draft → review → confirm → persist.
+
+## Step 1: Draft via prompt-to-rule
+
+Call `POST {API_URL}/prompt-to-rule` with the user's description. This returns a fully structured `RuleBase` object with all required fields filled in.
+
+```bash
+PROMPT_BODY=$(python3 -c "import json,sys; print(json.dumps({'prompt': sys.argv[1]}))" "$USER_DESCRIPTION")
+
+DRAFT=$(curl -s -X POST "${API_URL}/prompt-to-rule" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -d "$PROMPT_BODY")
+```
+
+The response is a `RuleBase` object (camelCase JSON):
+
+```json
+{
+  "name": "...",
+  "category": "...",
+  "severity": "error|warning|recommendation",
+  "content": "...",
+  "goodExamples": "...",
+  "badExamples": "...",
+  "state": "active",
+  "scopes": ["/"],
+  "source": "",
+  "sourceType": null,
+  "sourceUri": null
+}
+```
+
+## Step 2: Present Draft to User
+
+Display the draft clearly and ask for approval. Format:
+
+```
+Here's the drafted rule:
+
+**Name:** {name}
+**Category:** {category}
+**Severity:** {severity}
+**Scopes:** {scopes or "universal (/)"}
+
+**Rule content:**
+{content}
+
+**Good examples:**
+{goodExamples}
+
+**Bad examples:**
+{badExamples}
+
+---
+Does this look right? Reply **yes** to create it, or tell me what to change.
+```
+
+If the user requests changes, update the draft fields accordingly and re-present before proceeding.
+
+## Step 3: Create on Confirmation
+
+When the user confirms, strip response-only fields and POST:
+
+```bash
+CREATE_BODY=$(python3 -c "
+import json, sys
+rule = json.loads(sys.argv[1])
+# Strip fields not in RuleCreateRequest
+for f in ['state', 'extractionReasoningContext', 'sourceUris', 'ruleId', 'workspaceId', 'createdAt', 'updatedAt', 'similaritiesCount', 'url', 'insights']:
+    rule.pop(f, None)
+# Ensure required fields have values (prompt-to-rule may return empty strings)
+rule.setdefault('goodExamples', '')
+rule.setdefault('badExamples', '')
+print(json.dumps(rule))
+" "$DRAFT_JSON")
+
+RESULT=$(curl -s -X POST "${API_URL}/rule" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${API_KEY}" \
+  -H "request-id: ${REQUEST_ID}" \
+  -H "qodo-client-type: skill-qodo-manage-rules" \
+  -d "$CREATE_BODY")
+```
+
+On success (HTTP 201), the response is `{"ruleId": <id>}`. Report: _"Rule created with ID {id}."_
+
+## RuleCreateRequest Required Fields
+
+All of these must be present and non-null:
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | max 128 chars |
+| `category` | string | e.g. Quality, Security, Reliability |
+| `severity` | enum | `error`, `warning`, `recommendation` |
+| `content` | string | the rule body |
+| `goodExamples` | string | can be empty string `""` |
+| `badExamples` | string | can be empty string `""` |
+
+Optional:
+- `scopes` — list of path strings, defaults to `["/"]` (universal) if omitted
+- `source`, `sourceType`, `sourceUri` — auto-set by server from user token if omitted
+
+## Duplicate Check (Optional)
+
+Before creating, optionally call `POST {API_URL}/rule_similarity` with the draft to surface any similar existing rules. If high-similarity rules exist (score > 0.85), show them to the user and ask if they want to proceed.

--- a/skills/qodo-manage-rules/references/output-format.md
+++ b/skills/qodo-manage-rules/references/output-format.md
@@ -1,0 +1,86 @@
+# Output Format
+
+## Rule List (LIST operation)
+
+Show a compact table followed by a count line. Only include columns that add value for the user's query.
+
+```
+**{totalCount} rules** (page {page}/{totalPages})
+
+| ID | Name | Severity | Category | State | Source |
+|----|------|----------|----------|-------|--------|
+| 123 | No hardcoded credentials | ERROR | Security | active | Code Patterns |
+| 456 | Use structured logging | WARNING | Observability | active | ofer@qodo.ai |
+...
+
+_Show `get rule <id>` for full content, or ask to filter/sort._
+```
+
+- Severity in UPPERCASE.
+- Truncate long names at 60 chars with `…`.
+- If `totalCount` > `pageSize`, note how to get the next page.
+
+## Single Rule (GET / after CREATE or UPDATE)
+
+**Concise view (default):**
+
+```
+**Rule {id}: {name}**
+Severity: {SEVERITY} | Category: {category} | State: {state}
+Source: {sourceType} — {source}
+Scopes: {scopes joined by ", " or "universal (/)"}
+
+{content — first 3 lines, then "… (truncated, ask to expand)"}
+```
+
+**Expanded view (on request):**
+
+Show the full rule including `goodExamples` and `badExamples`, formatted as separate blocks.
+
+## After CREATE
+
+```
+✅ Rule created — ID: {ruleId}
+
+**{name}** [{SEVERITY}]
+{first line of content}
+```
+
+## After UPDATE
+
+```
+✅ Rule {id} updated.
+
+**{name}** [{SEVERITY}] — {state}
+```
+
+## After DELETE
+
+```
+✅ Rule {id} ("{name}") deleted.
+```
+
+## Similarity Results
+
+```
+**Similar rules found:**
+
+| Score | ID | Name | Relationship |
+|-------|----|------|--------------|
+| 0.92  | 77 | Avoid logging secrets | DUPLICATE |
+| 0.78  | 88 | Sanitize log output   | OVERLAPPING |
+```
+
+Show scores as percentages rounded to 0 decimal places (e.g. `92%`).
+
+## Severities
+
+Always display severity in UPPERCASE: `ERROR`, `WARNING`, `RECOMMENDATION`.
+
+## Empty Results
+
+```
+No rules found matching your filters.
+```
+
+Never error on empty — it is a valid state.


### PR DESCRIPTION
## Summary

- Adds a new `qodo-manage-rules` skill for managing Qodo coding rules via the Rules API
- Supports **list**, **get**, **create** (AI-drafted via `prompt-to-rule` → user review → confirm), **update**, and **delete** operations
- Admin-only operations (update/delete) detect 403 and surface a clear message with a link to settings

## Operations

| Operation | Endpoint | Notes |
|---|---|---|
| List rules | `GET /v1/rules` | Filterable by state, severity, category, source type |
| Get rule | `GET /v1/rule/{id}` | Concise by default, expand on request |
| Create rule | `POST /v1/prompt-to-rule` → `POST /v1/rule` | Drafts content via AI, user reviews before creating |
| Update rule | `PUT /v1/rule/{id}` | Admin only, shows current → proposes diff → confirm |
| Delete rule | `DELETE /v1/rule/{id}` | Admin only, requires explicit confirmation |
| Find similar | `POST /v1/rule_similarity` | Duplicate check before creating |

## File Structure

```
skills/qodo-manage-rules/
├── SKILL.md
└── references/
    ├── auth-and-env.md       # API key + URL resolution (app URL → API URL)
    ├── create-flow.md        # 3-step draft→review→confirm→create
    ├── output-format.md      # Concise list table, single-rule view
    └── admin-operations.md   # Update/delete flows, 403 handling
```

## Test plan

- [ ] List active rules in a staging env by passing app URL as argument
- [ ] Get a specific rule by ID
- [ ] Create a rule from a natural language description — verify draft is shown before posting
- [ ] Attempt update/delete as non-admin — verify 403 is surfaced clearly
- [ ] Delete a rule with confirmation flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)