### PR TITLE
fix(get-rules): make repo-scope detection portable on BSD/macOS

### DIFF
--- a/.github/workflows/shell-portability.yml
+++ b/.github/workflows/shell-portability.yml
@@ -1,0 +1,28 @@
+name: Shell Portability
+
+# The skills are prose an agent executes as shell. A GNU-only construct doesn't
+# fail on macOS — it silently no-ops — so macOS must be in the matrix, not just Linux.
+
+on:
+  pull_request:
+    paths:
+      - 'skills/**'
+      - '.github/workflows/shell-portability.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'skills/**'
+
+jobs:
+  scope-parse:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Repository scope parsing
+        run: sh skills/qodo-get-rules/tests/scope-parse.sh

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -50,6 +50,10 @@ Check that the current directory is inside a git repository. If not, inform the 
 
 After confirming a git repository exists, extract the repository scope to pass to the search API. Scope narrows results to rules relevant to this specific repository.
 
+Use only POSIX shell here — no `sed`, no `grep`. Parameter expansion and `case` behave
+identically on macOS (BSD) and Linux (GNU); `sed` does not (see
+[repository scope detection](references/repository-scope.md#portability)).
+
 ```bash
 # 1. Confirm inside a git repository
 git rev-parse --is-inside-work-tree
@@ -58,25 +62,46 @@ git rev-parse --is-inside-work-tree
 REMOTE_URL=$(git remote get-url origin 2>/dev/null)
 
 # 3. Parse the URL into a scope path
+SCOPE=""
 if [ -n "$REMOTE_URL" ]; then
-  # Strip .git suffix if present
-  REMOTE_URL="${REMOTE_URL%.git}"
+  # Strip .git suffix and any trailing slash
+  REPO_PATH="${REMOTE_URL%.git}"
+  REPO_PATH="${REPO_PATH%/}"
 
-  # Handle SSH format: git@github.com:org/repo
-  if echo "$REMOTE_URL" | grep -q "^git@"; then
-    REPO_PATH=$(echo "$REMOTE_URL" | sed 's/^git@[^:]*://')
-  # Handle HTTPS format: https://github.com/org/repo
-  elif echo "$REMOTE_URL" | grep -q "^https\?://"; then
-    REPO_PATH=$(echo "$REMOTE_URL" | sed 's|^https\?://[^/]*/||')
-  else
-    REPO_PATH=""
-  fi
+  case "$REPO_PATH" in
+    # scheme://[user[:pass]@]host/path — https, http, ssh, git
+    *://*)
+      REPO_PATH="${REPO_PATH#*://}"   # drop scheme
+      REPO_PATH="${REPO_PATH#*/}"     # drop [userinfo@]host
+      ;;
+    # scp-like: [user@]host:path — git@github.com:org/repo
+    *:*/*)
+      REPO_PATH="${REPO_PATH#*:}"
+      ;;
+    *)
+      REPO_PATH=""
+      ;;
+  esac
+
+  # Require at least org/repo; reject absolute and Windows paths
+  case "$REPO_PATH" in
+    /*|*\\*) REPO_PATH="" ;;
+    */*)     ;;
+    *)       REPO_PATH="" ;;
+  esac
 
   if [ -n "$REPO_PATH" ]; then
-    # 4. Detect module-level scope: check if cwd is inside modules/<name>/
-    REPO_ROOT=$(git rev-parse --show-toplevel)
-    REL_PATH=$(realpath --relative-to="$REPO_ROOT" "$(pwd)" 2>/dev/null || python3 -c "import os; print(os.path.relpath('$(pwd)', '$REPO_ROOT'))")
-    MODULE=$(echo "$REL_PATH" | sed -n 's|^modules/\([^/]*\).*|\1|p')
+    # 4. Detect module-level scope: is cwd inside modules/<name>/ ?
+    #    --show-prefix is the cwd relative to the repo root, "" at the root,
+    #    with a trailing slash. No realpath, no python3.
+    PREFIX=$(git rev-parse --show-prefix)
+    MODULE=""
+    case "$PREFIX" in
+      modules/*/*)
+        MODULE="${PREFIX#modules/}"
+        MODULE="${MODULE%%/*}"
+        ;;
+    esac
 
     if [ -n "$MODULE" ]; then
       SCOPE="/${REPO_PATH}/modules/${MODULE}/"

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -64,11 +64,16 @@ REMOTE_URL=$(git remote get-url origin 2>/dev/null)
 # 3. Parse the URL into a scope path
 SCOPE=""
 if [ -n "$REMOTE_URL" ]; then
-  # Strip .git suffix and any trailing slash
-  REPO_PATH="${REMOTE_URL%.git}"
-  REPO_PATH="${REPO_PATH%/}"
+  # Trailing slash first, then .git — the other order leaves ".git" on
+  # "https://host/org/repo.git/", because %.git only strips an exact suffix.
+  REPO_PATH="${REMOTE_URL%/}"
+  REPO_PATH="${REPO_PATH%.git}"
 
   case "$REPO_PATH" in
+    # local clone — no rules are scoped to a filesystem path
+    file://*)
+      REPO_PATH=""
+      ;;
     # scheme://[user[:pass]@]host/path — https, http, ssh, git
     *://*)
       REPO_PATH="${REPO_PATH#*://}"   # drop scheme

--- a/skills/qodo-get-rules/references/repository-scope.md
+++ b/skills/qodo-get-rules/references/repository-scope.md
@@ -24,9 +24,37 @@ REMOTE_URL=$(git remote get-url origin 2>/dev/null)
 | Remote format | Example | Parsed `REPO_PATH` |
 |---|---|---|
 | HTTPS | `https://github.com/org/repo.git` | `org/repo` |
-| SSH | `git@github.com:org/repo.git` | `org/repo` |
+| HTTP | `http://git.internal/org/repo` | `org/repo` |
+| SSH (scp-like) | `git@github.com:org/repo.git` | `org/repo` |
+| SSH (URL) | `ssh://git@github.com/org/repo.git` | `org/repo` |
+| Git protocol | `git://host/org/repo` | `org/repo` |
+| With credentials | `https://user:token@github.com/org/repo` | `org/repo` |
+| GitLab subgroup | `https://gitlab.com/group/subgroup/repo` | `group/subgroup/repo` |
+| Azure DevOps | `https://dev.azure.com/org/proj/_git/repo` | `org/proj/_git/repo` |
 
-The `.git` suffix is stripped before parsing. The resulting scope path is `/org/repo/`.
+The `.git` suffix and any trailing slash are stripped before parsing. The resulting scope
+path is `/<REPO_PATH>/`.
+
+**Keep the full path after the host** — do not collapse to two segments. GitLab subgroups and
+Azure DevOps paths are legitimately deeper than `org/repo`.
+
+A path with no `/` (a single segment), an absolute path, or a Windows path yields no scope —
+see [Graceful Degradation](#graceful-degradation).
+
+### Portability
+
+Parse with POSIX parameter expansion and `case`, **not** `sed` or `grep`.
+
+`\?`, `\+`, and `\|` in a basic regex are GNU extensions. BSD `sed` (macOS) does not support
+them and — critically — does not error: the substitution simply matches nothing, exits `0`,
+and passes the input through unchanged. BSD `grep` *does* honor `\?` in a BRE, so a
+`grep -q "^https\?://"` guard in front of a `sed 's|^https\?://[^/]*/||'` passes while the
+`sed` silently no-ops, and the whole remote URL becomes the scope path. That produced a
+nonsense scope like `/https://github.com/org/repo/` on every macOS run and measurably degraded
+retrieval, with no error anywhere.
+
+If a regex is genuinely needed, use `sed -E` (ERE) — `?`, `+`, and `|` are portable there.
+For this parse no regex is needed at all.
 
 ### Module-Level Scope
 
@@ -41,10 +69,16 @@ Otherwise the repository-wide scope `/org/repo/` is used.
 Detection:
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-REL_PATH=$(realpath --relative-to="$REPO_ROOT" "$(pwd)" 2>/dev/null \
-  || python3 -c "import os; print(os.path.relpath('$(pwd)', '$REPO_ROOT'))")
-MODULE=$(echo "$REL_PATH" | sed -n 's|^modules/\([^/]*\).*|\1|p')
+# --show-prefix is the cwd relative to the repo root: "" at the root,
+# "modules/billing/src/" deeper in. Portable, and no subprocess beyond git.
+PREFIX=$(git rev-parse --show-prefix)
+MODULE=""
+case "$PREFIX" in
+  modules/*/*)
+    MODULE="${PREFIX#modules/}"
+    MODULE="${MODULE%%/*}"
+    ;;
+esac
 
 if [ -n "$MODULE" ]; then
   SCOPE="/${REPO_PATH}/modules/${MODULE}/"
@@ -53,13 +87,18 @@ else
 fi
 ```
 
+`git rev-parse --show-prefix` replaces `realpath --relative-to=` here. That flag is GNU
+coreutils only — BSD `realpath` rejects it — so the old snippet fell through to a `python3`
+subprocess on every macOS invocation, with the real error hidden by `2>/dev/null`.
+
 ## Graceful Degradation
 
 Scope is **optional**. If scope cannot be determined for any reason, the skill proceeds without it — org-wide semantic search still returns relevant results.
 
 Skip scope and proceed without error when:
 - No `origin` remote is configured
-- Remote URL cannot be parsed into an org/repo path
+- Remote URL cannot be parsed into an org/repo path — no `/` after the host (a single
+  segment), a local absolute path, or a Windows path
 - Any other unexpected failure during extraction
 
 Do not send `"scopes": null` or `"scopes": []` — omit the `scopes` field entirely from the request body.

--- a/skills/qodo-get-rules/references/repository-scope.md
+++ b/skills/qodo-get-rules/references/repository-scope.md
@@ -32,8 +32,11 @@ REMOTE_URL=$(git remote get-url origin 2>/dev/null)
 | GitLab subgroup | `https://gitlab.com/group/subgroup/repo` | `group/subgroup/repo` |
 | Azure DevOps | `https://dev.azure.com/org/proj/_git/repo` | `org/proj/_git/repo` |
 
-The `.git` suffix and any trailing slash are stripped before parsing. The resulting scope
-path is `/<REPO_PATH>/`.
+A trailing slash is stripped first, then a `.git` suffix — in that order, since
+`${url%.git}` only removes an exact final suffix and would leave `.git` in place on
+`https://host/org/repo.git/`. The resulting scope path is `/<REPO_PATH>/`.
+
+A `file://` remote is a local clone with no hosted org/repo path, so it yields no scope.
 
 **Keep the full path after the host** — do not collapse to two segments. GitLab subgroups and
 Azure DevOps paths are legitimately deeper than `org/repo`.
@@ -98,7 +101,7 @@ Scope is **optional**. If scope cannot be determined for any reason, the skill p
 Skip scope and proceed without error when:
 - No `origin` remote is configured
 - Remote URL cannot be parsed into an org/repo path — no `/` after the host (a single
-  segment), a local absolute path, or a Windows path
+  segment), a local absolute path, a `file://` clone, or a Windows path
 - Any other unexpected failure during extraction
 
 Do not send `"scopes": null` or `"scopes": []` — omit the `scopes` field entirely from the request body.

--- a/skills/qodo-get-rules/tests/scope-parse.sh
+++ b/skills/qodo-get-rules/tests/scope-parse.sh
@@ -23,10 +23,13 @@ fail() {
 # below fails if either doc drifts back to sed/grep, which is the failure mode that
 # actually bit us.
 parse_repo_path() {
-  REPO_PATH="${1%.git}"
-  REPO_PATH="${REPO_PATH%/}"
+  REPO_PATH="${1%/}"
+  REPO_PATH="${REPO_PATH%.git}"
 
   case "$REPO_PATH" in
+    file://*)
+      REPO_PATH=""
+      ;;
     *://*)
       REPO_PATH="${REPO_PATH#*://}"
       REPO_PATH="${REPO_PATH#*/}"
@@ -79,6 +82,10 @@ expect_path 'ssh://git@github.com/org/repo.git'               'org/repo'
 expect_path 'git://host/org/repo'                             'org/repo'
 expect_path 'https://user:token@github.com/org/repo.git'      'org/repo'
 expect_path 'https://github.com/org/repo/'                    'org/repo'
+# .git AND a trailing slash together — strip order matters here
+expect_path 'https://github.com/org/repo.git/'                'org/repo'
+expect_path 'git@github.com:org/repo.git/'                    'org/repo'
+expect_path 'https://gitlab.com/group/subgroup/repo.git/'     'group/subgroup/repo'
 
 # deeper paths must survive — do not collapse to two segments
 expect_path 'https://gitlab.com/group/subgroup/repo.git'      'group/subgroup/repo'
@@ -88,6 +95,10 @@ expect_path 'git@ssh.dev.azure.com:v3/org/proj/repo'          'v3/org/proj/repo'
 # --- must degrade to no scope rather than emit a nonsense one -----------------
 expect_path 'https://github.com/onlyorg' ''
 expect_path '/Users/me/local-repo'       ''
+# a local clone has no hosted org/repo path, in any spelling
+expect_path 'file:///Users/me/local-repo'    ''
+expect_path 'file://localhost/Users/me/repo' ''
+expect_path 'file:///c/repos/foo'            ''
 expect_path 'C:\repos\foo'               ''
 expect_path 'C:/repos/foo'               ''
 expect_path ''                           ''

--- a/skills/qodo-get-rules/tests/scope-parse.sh
+++ b/skills/qodo-get-rules/tests/scope-parse.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# Regression test for repository scope detection (Step 2 of SKILL.md).
+#
+# Guards the bug where `sed 's|^https\?://[^/]*/||'` silently no-opped on BSD sed
+# (macOS): `\?` is a GNU BRE extension, so the substitution matched nothing, exited 0,
+# and the entire remote URL became the scope path — halving retrieval quality with no
+# error. Run this on macOS *and* Linux; POSIX sh only, no frameworks.
+#
+# Usage: sh skills/qodo-get-rules/tests/scope-parse.sh
+
+set -eu
+
+DOC_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+failures=0
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+# --- the parse under test: must stay in sync with SKILL.md Step 2 -------------
+# Mirrors the snippet in SKILL.md / references/repository-scope.md. check_no_gnuisms
+# below fails if either doc drifts back to sed/grep, which is the failure mode that
+# actually bit us.
+parse_repo_path() {
+  REPO_PATH="${1%.git}"
+  REPO_PATH="${REPO_PATH%/}"
+
+  case "$REPO_PATH" in
+    *://*)
+      REPO_PATH="${REPO_PATH#*://}"
+      REPO_PATH="${REPO_PATH#*/}"
+      ;;
+    *:*/*)
+      REPO_PATH="${REPO_PATH#*:}"
+      ;;
+    *)
+      REPO_PATH=""
+      ;;
+  esac
+
+  case "$REPO_PATH" in
+    /*|*\\*) REPO_PATH="" ;;
+    */*)     ;;
+    *)       REPO_PATH="" ;;
+  esac
+
+  printf '%s' "$REPO_PATH"
+}
+
+parse_module() {
+  MODULE=""
+  case "$1" in
+    modules/*/*)
+      MODULE="${1#modules/}"
+      MODULE="${MODULE%%/*}"
+      ;;
+  esac
+  printf '%s' "$MODULE"
+}
+
+expect_path() {
+  got=$(parse_repo_path "$1")
+  [ "$got" = "$2" ] || fail "remote '$1' -> '$got', expected '$2'"
+}
+
+expect_module() {
+  got=$(parse_module "$1")
+  [ "$got" = "$2" ] || fail "prefix '$1' -> module '$got', expected '$2'"
+}
+
+# --- remote URL formats -------------------------------------------------------
+expect_path 'https://github.com/qodo-se/acme-billing-service' 'qodo-se/acme-billing-service'
+expect_path 'https://github.com/org/repo.git'                 'org/repo'
+expect_path 'http://git.internal/org/repo'                    'org/repo'
+expect_path 'git@github.com:org/repo.git'                     'org/repo'
+expect_path 'git@github.com:org/repo'                         'org/repo'
+expect_path 'ssh://git@github.com/org/repo.git'               'org/repo'
+expect_path 'git://host/org/repo'                             'org/repo'
+expect_path 'https://user:token@github.com/org/repo.git'      'org/repo'
+expect_path 'https://github.com/org/repo/'                    'org/repo'
+
+# deeper paths must survive — do not collapse to two segments
+expect_path 'https://gitlab.com/group/subgroup/repo.git'      'group/subgroup/repo'
+expect_path 'https://dev.azure.com/org/proj/_git/repo'        'org/proj/_git/repo'
+expect_path 'git@ssh.dev.azure.com:v3/org/proj/repo'          'v3/org/proj/repo'
+
+# --- must degrade to no scope rather than emit a nonsense one -----------------
+expect_path 'https://github.com/onlyorg' ''
+expect_path '/Users/me/local-repo'       ''
+expect_path 'C:\repos\foo'               ''
+expect_path 'C:/repos/foo'               ''
+expect_path ''                           ''
+
+# --- module narrowing (git rev-parse --show-prefix output) --------------------
+expect_module ''                     ''
+expect_module 'modules/'             ''
+expect_module 'modules/billing/'     'billing'
+expect_module 'modules/billing/src/' 'billing'
+expect_module 'modulesfoo/bar/'      ''
+expect_module 'src/'                 ''
+
+# --- the docs must not reintroduce the non-portable constructs ----------------
+# These skills are prose an agent executes, so the shell to guard lives in the
+# fenced code blocks. Prose *about* the bad constructs (the Portability section)
+# is fine and must not trip this.
+check_no_gnuisms() {
+  doc="$DOC_DIR/$1"
+  [ -f "$doc" ] || { fail "missing doc: $doc"; return; }
+
+  code=$(awk '/^```/ { inblock = !inblock; next } inblock' "$doc")
+
+  # GNU BRE extensions: silently no-op on BSD sed instead of erroring.
+  # \( \) \1 are valid BRE and stay allowed; only \? \+ \| are GNU-only.
+  # `sed -E` opts into ERE, where ? + | are bare and portable, so skip those lines.
+  if printf '%s\n' "$code" | grep 'sed ' | grep -v 'sed -[A-Za-z]*E' \
+       | grep -q '\\[?+|]'; then
+    fail "$1 uses GNU-only BRE (\\? \\+ \\|) in sed — use sed -E, or no sed at all"
+  fi
+  # GNU coreutils only; BSD realpath rejects it
+  if printf '%s\n' "$code" | grep -q 'realpath --relative-to'; then
+    fail "$1 uses realpath --relative-to (GNU only) — use git rev-parse --show-prefix"
+  fi
+}
+
+check_no_gnuisms 'SKILL.md'
+check_no_gnuisms 'references/repository-scope.md'
+
+# --- end-to-end against a real repo, so the parse is exercised as written -----
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT INT TERM
+mkdir -p "$tmp/modules/billing/src"
+(
+  cd "$tmp"
+  git init -q
+  git remote add origin 'https://github.com/qodo-se/acme-billing-service.git'
+)
+
+# NB: not named `path` — in zsh that is tied to $PATH and assigning to it
+# would wipe the command search path.
+live_scope() (
+  cd "$1"
+  repo_path=$(parse_repo_path "$(git remote get-url origin 2>/dev/null)")
+  [ -n "$repo_path" ] || return 0
+  module=$(parse_module "$(git rev-parse --show-prefix)")
+  if [ -n "$module" ]; then
+    printf '/%s/modules/%s/' "$repo_path" "$module"
+  else
+    printf '/%s/' "$repo_path"
+  fi
+)
+
+got=$(live_scope "$tmp")
+[ "$got" = '/qodo-se/acme-billing-service/' ] \
+  || fail "repo-root scope -> '$got', expected '/qodo-se/acme-billing-service/'"
+
+got=$(live_scope "$tmp/modules/billing/src")
+[ "$got" = '/qodo-se/acme-billing-service/modules/billing/' ] \
+  || fail "module scope -> '$got', expected '/qodo-se/acme-billing-service/modules/billing/'"
+
+# ------------------------------------------------------------------------------
+if [ "$failures" -ne 0 ]; then
+  printf '\n%s check(s) failed\n' "$failures" >&2
+  exit 1
+fi
+
+printf 'ok — scope parsing portable on %s\n' "$(uname -s)"

--- a/skills/qodo-get-rules/tests/scope-parse.sh
+++ b/skills/qodo-get-rules/tests/scope-parse.sh
@@ -10,7 +10,7 @@
 
 set -eu
 
-DOC_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+DOC_DIR=$(CDPATH= cd "$(dirname "$0")/.." && pwd)
 failures=0
 
 fail() {


### PR DESCRIPTION
## What's wrong

`qodo-get-rules` Step 2 parses the git remote into a scope path with:

```sh
elif echo "$REMOTE_URL" | grep -q "^https\?://"; then
  REPO_PATH=$(echo "$REMOTE_URL" | sed 's|^https\?://[^/]*/||')
```

`\?` is a **GNU BRE extension**. BSD `sed` (macOS) doesn't support it — and doesn't say so:

```console
$ echo 'https://github.com/qodo-se/acme-billing-service' | sed 's|^https\?://[^/]*/||'
https://github.com/qodo-se/acme-billing-service     # unchanged
$ echo $?
0
```

The substitution matches nothing, exits `0`, writes nothing to stderr, and passes the input
through whole.

## Why it degrades silently rather than failing

The guard on the line above uses the *same* `\?` — but with `grep`, and **BSD grep BRE does
honor `\?`**. So the guard passes, control enters the HTTPS branch, and only the `sed` no-ops.
There is no branch that can report an error, because from the shell's point of view nothing
failed.

The result is a well-formed but meaningless scope:

```
/https://github.com/qodo-se/acme-billing-service/     ← sent to /rules/search
/qodo-se/acme-billing-service/                        ← intended
```

The API accepts it, matches almost nothing, and returns a short list. Every macOS user has been
in this state, and the only symptom is fewer rules.

Retrieval measured by the reporter on the same repo and query:

| Scope sent | Rules returned |
|---|---|
| Correct | 17 |
| Omitted entirely | 20 |
| **Broken (live macOS run)** | **9** |

## Before / after on macOS

```console
$ git remote get-url origin
https://github.com/qodo-se/acme-billing-service.git

# before
SCOPE=/https://github.com/qodo-se/acme-billing-service/

# after
SCOPE=/qodo-se/acme-billing-service/
```

## The fix

**Drop `sed` and `grep` from this parse entirely** — POSIX parameter expansion and `case`
behave identically on BSD and GNU, so the portability question stops existing rather than
being answered. (`sed -E` would also work; not reaching for a regex at all is one fewer thing
to get wrong in a file that is prose an agent executes, where a silent no-op has nothing to
catch it.)

Two other things fixed in the same code path, both surfaced while tracing it:

- **`ssh://` and `git://` remotes matched neither guard.** The old `if git@ / elif https?://`
  chain dropped `ssh://git@host/org/repo` and `git://host/org/repo` to `REPO_PATH=""`, so the
  scope was omitted entirely. That one degrades silently on Linux too, not just macOS.
- **`realpath --relative-to=` is GNU coreutils only.** Worth being precise: this one was *not*
  broken in practice — BSD `realpath` rejects the flag and exits `1`, so the existing
  `|| python3` fallback did fire and returned the right path. But `2>/dev/null` hid a real
  error and it spawned a `python3` subprocess on every macOS invocation for something git
  answers natively. Replaced with `git rev-parse --show-prefix`. **Cleanup, not a second bug.**

Deeper paths are preserved rather than collapsed to two segments — GitLab subgroups
(`group/subgroup/repo`) and Azure DevOps (`org/proj/_git/repo`) are legitimately longer.
Single-segment paths, absolute paths, and Windows paths now degrade to *no scope*, which is
the documented graceful-degradation behavior, instead of producing a nonsense one.

## Blast radius

Swept every `sed`, `grep`, and GNU long-flag in the repo:

- `skills/qodo-get-rules/SKILL.md` — the reported bug. **Fixed.**
- `skills/qodo-get-rules/references/repository-scope.md` — same snippet, same bug. **Fixed.**
- `skills/qodo-pr-resolver/**` — already uses `sed -E`; verified all five substitutions run
  correctly under BSD sed. No change.
- `kiro-power/steering/get-rules.md` — describes scope in prose, no shell, and is already
  correct about subgroups/ADO. No change.

Two files, so no shared helper is introduced — a third indirection for two prose documents
would cost more than it saves.

## Test

`skills/qodo-get-rules/tests/scope-parse.sh` — POSIX `sh`, no framework:

```console
$ sh skills/qodo-get-rules/tests/scope-parse.sh
ok — scope parsing portable on Darwin
```

Covers https / http / `ssh://` / `git://` / scp-like / `userinfo@` / `.git` suffix / trailing
slash / GitLab subgroup / ADO, the paths that must degrade to no scope, the `modules/`
narrowing, and an end-to-end run against a real throwaway git repo at both the root and inside
`modules/billing/src`.

It also greps the **fenced code blocks** of both docs and fails if `\?`/`\+`/`\|` in a
non-`-E` `sed`, or `realpath --relative-to`, reappears — the prose *about* those constructs in
the new Portability section deliberately doesn't trip it. Since SKILL.md is markdown rather
than a sourceable library, the test necessarily restates the parse; that grep is what catches
the resulting drift.

Verified: passes under `sh`, `bash`, and `zsh` on macOS, and under Alpine/BusyBox (GNU
userland) via Docker. Confirmed it **fails** when either GNU-ism is reintroduced, and does
**not** false-positive on a legitimate `sed -E`.

`.github/workflows/shell-portability.yml` runs it on **`macos-latest` and `ubuntu-latest`**
(`fail-fast: false`, so a macOS-only break can't hide behind a green Linux job). macOS in the
matrix is the point — this class of bug is invisible on Linux CI by construction, which is how
it shipped. The repo had no test workflow before, so this adds one rather than extending
`notify-skill-changes.yml`, which only runs post-merge.

## Pre-PR `qodo review` did not run — read this before approving

**`qodo review` could not complete on this diff, so this PR has had no pre-PR review pass.**
Four attempts:

| # | Run | Outcome |
|---|---|---|
| 1 | `--deep`, backgrounded | killed when its launcher shell exited |
| 2 | `--deep`, foreground | **backend failure** — `a2a_passthrough_failed: remote terminal_state=failed`, trace `1f912f0a600fdd8ccaa8536a4b2f2dc3` |
| 3 | default depth | killed by the agent harness task lifecycle |
| 4 | fully detached (`nohup`) | died ~25 min in, empty result, no exit code |

Only #2 is an actual review failure, and it's a backend one. The other three are a
multi-minute run being killed by the tooling around it. **A killed run is not a passing run** —
none of these should be read as "the review found nothing."

What stands in for it, honestly stated:

- **`skills/qodo-get-rules/tests/scope-parse.sh`** — 27 assertions, green on macOS
  (`sh`/`bash`/`zsh`) and Linux (Alpine/BusyBox via Docker).
- **The new CI matrix runs on this PR** — `macos-latest` + `ubuntu-latest`. That's the durable
  guard going forward, and it's the thing that would have caught this bug originally.
- **Independent verification by a second party**, including two mutation tests against an
  isolated copy: reintroducing the original `sed 's|^https\?://[^/]*/||'` fails the suite with
  the right message, and so does reintroducing `realpath --relative-to`. The guard bites rather
  than merely existing. Also confirmed the fenced-block extraction does *not* false-positive on
  the new Portability prose, which legitimately discusses `\?` and `realpath`.

Reviewer judgment still applies here in the normal way — there just isn't an automated pre-PR
pass behind it.

## Out of scope

The severity rendering and enforcement table in the same `SKILL.md` are a separate tracked
issue with a different owner — untouched here to avoid a conflict.

## Follow-up worth someone's attention (not addressed here)

The reporter's numbers say **omitting the scope beat the correct scope — 20 rules vs 17**.
This PR takes macOS users from 9 → 17, which is unambiguously the right direction, but it does
not answer whether repository scoping helps retrieval at all. That deserves its own look;
flagging rather than solving it, and it shouldn't block this fix.

Fixes WF-787
