### PR TITLE
fix(release): authenticate App installation audit correctly

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
-    "version": "1.0.7"
+    "version": "1.0.8"
   },
   "plugins": [
     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,14 +64,13 @@ jobs:
           [[ "${RELEASE_APP_ID}" =~ ^[0-9]+$ ]] || { echo 'QODO_SKILLS_RELEASE_APP_ID must be configured in marketplace-kiro.' >&2; exit 1; }
           test -n "${RELEASE_APP_PRIVATE_KEY}" || { echo 'QODO_SKILLS_RELEASE_APP_PRIVATE_KEY must be configured in marketplace-kiro.' >&2; exit 1; }
 
-      - name: Mint repository-scoped release preflight token
+      - name: Mint installation-wide read-only release preflight token
         id: release-preflight-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
           app-id: ${{ vars.QODO_SKILLS_RELEASE_APP_ID }}
           private-key: ${{ secrets.QODO_SKILLS_RELEASE_APP_PRIVATE_KEY }}
           owner: qodo-ai
-          repositories: qodo-skills
           permission-administration: read
 
       - name: Verify runtime release prerequisites

--- a/.github/workflows/ship-marketplaces.yml
+++ b/.github/workflows/ship-marketplaces.yml
@@ -219,6 +219,22 @@ jobs:
           [[ "${RELEASE_APP_ID}" =~ ^[0-9]+$ ]] || { echo 'QODO_SKILLS_RELEASE_APP_ID must be configured in marketplace-kiro.' >&2; exit 1; }
           test -n "${RELEASE_APP_PRIVATE_KEY}" || { echo 'QODO_SKILLS_RELEASE_APP_PRIVATE_KEY must be configured in marketplace-kiro.' >&2; exit 1; }
 
+      - name: Mint installation-wide read-only Kiro audit token
+        if: matrix.provider == 'kiro'
+        id: kiro-installation-audit-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ vars.QODO_SKILLS_RELEASE_APP_ID }}
+          private-key: ${{ secrets.QODO_SKILLS_RELEASE_APP_PRIVATE_KEY }}
+          owner: qodo-ai
+          permission-administration: read
+
+      - name: Verify Kiro release App installation scope
+        if: matrix.provider == 'kiro'
+        env:
+          GH_TOKEN: ${{ steps.kiro-installation-audit-token.outputs.token }}
+        run: scripts/verify-release-prerequisites.sh
+
       - name: Mint repository-scoped Kiro release token
         if: matrix.provider == 'kiro'
         id: kiro-release-token

--- a/codex-packages/qodo-standards/.codex-plugin/plugin.json
+++ b/codex-packages/qodo-standards/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo-standards/plugin.json
+++ b/codex-packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/.codex-plugin/plugin.json
+++ b/codex-packages/qodo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/plugin.json
+++ b/codex-packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/distribution/catalog.json
+++ b/distribution/catalog.json
@@ -5,7 +5,7 @@
   "package": {
     "name": "qodo",
     "displayName": "Qodo for coding agents",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
     "repository": "https://github.com/qodo-ai/qodo-skills",
     "homepage": "https://www.qodo.ai",

--- a/distribution/qodo-cli-managed-bundle.json
+++ b/distribution/qodo-cli-managed-bundle.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "distribution": "qodo-cli-managed",
   "instructionMode": "embedded",
-  "packageVersion": "1.0.7",
+  "packageVersion": "1.0.8",
   "minimumCliVersion": "0.1.0-next.37",
   "source": {
     "repository": "https://github.com/qodo-ai/qodo-skills",
-    "tag": "v1.0.7"
+    "tag": "v1.0.8"
   },
   "aliases": {
     "codebase-wisdom": "qodo-codebase-wisdom",

--- a/distribution/qodo-cli-managed-bundle.json.sha256
+++ b/distribution/qodo-cli-managed-bundle.json.sha256
@@ -1,1 +1,1 @@
-b43c12acaecd7f62c281c4d09f934607236b9816340673c8586a4ed4aadd8282  qodo-cli-managed-bundle.json
+b54f97b417219ce8c87c6edc030c45690354af7e9e831807ae9d277b9bdb682d  qodo-cli-managed-bundle.json

--- a/distribution/qodo-skills-index.json
+++ b/distribution/qodo-skills-index.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "instructionMode": "embedded",
-  "packageVersion": "1.0.7",
+  "packageVersion": "1.0.8",
   "minimumCliVersion": "0.1.0-next.37",
   "repository": "https://github.com/qodo-ai/qodo-skills",
   "skills": {

--- a/distribution/qodo-skills-index.json.sha256
+++ b/distribution/qodo-skills-index.json.sha256
@@ -1,1 +1,1 @@
-ab17de7fed50a88a8df7336e6003c17d7cace04ccf42034d0650753804520f26  qodo-skills-index.json
+7775b96dd9803f7c33caff0bbd7d63ad8fdfbb9653e022ad8e2a1533e71e87e6  qodo-skills-index.json

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -76,8 +76,11 @@ rollback.
   cutover, admin bypass remains enabled, self-review is allowed, and protected branches may deploy;
   the team accepts this weaker approval posture and can harden it independently later.
 - Run `GITHUB_REPOSITORY=qodo-ai/qodo-skills scripts/audit-release-protections.sh` with a repository
-  administrator's existing `gh` session before release. The audit verifies hidden bypass actors;
-  no administrator or shared QAR credential is stored in this public repository.
+  administrator's existing `gh` session before release. The audit verifies hidden bypass actors and
+  one active selected-repository App installation. The protected release preflight then uses a
+  short-lived, installation-wide read-only token to require the App's exact repository list to be
+  only `qodo-ai/qodo-skills`; the normal administrator token cannot query that App-token-only API.
+  No administrator or shared QAR credential is stored in this public repository.
 - Keep exactly one active, no-exclusion, no-bypass **Immutable release tags** ruleset on
   `refs/tags/v*`; tag creation is allowed, but updates and deletion are blocked. Release preflight
   searches every ruleset page and rejects duplicate matches or a creation restriction.
@@ -129,7 +132,9 @@ copy and recoverable predecessor; marketplace skills remain owned by their host.
 
 - Merge the canonical/provider PR, then rebase and merge its stacked distribution PR containing
   both the CLI-managed and enterprise release assets. Do not publish the intermediate package
-  version: the first cutover release is the complete `v1.0.7` tag.
+  versions: the first cutover release is the complete `v1.0.8` tag. Candidate `v1.0.7` was not
+  published because its administrator audit used an endpoint unavailable to normal admin tokens;
+  `v1.0.8` splits hidden-setting checks from exact App-token repository-scope verification.
 - Release validation derives changes from both canonical files and the catalog: packaging-only
   changes require a package release, every semantic-version delta must match its release record,
   catalog-only bumps cannot disappear from release notes, `initial` cannot target an existing

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -44,8 +44,12 @@ GITHUB_REPOSITORY=qodo-ai/qodo-skills scripts/audit-release-protections.sh
 ```
 
 The audit uses the administrator's existing `gh` session to verify otherwise hidden bypass actors,
-the dedicated App identity, permissions, and active installation on this repository, presence of an environment reviewer, release
-immutability, and exact ruleset shapes. No administrator credential is stored in Actions.
+the dedicated App identity and permissions, one active selected-repository installation, presence of
+an environment reviewer, release immutability, and exact ruleset shapes. The protected release and
+Kiro workflows separately mint an installation-wide token narrowed to read-only Administration and
+require its complete repository list to be exactly `qodo-ai/qodo-skills`; GitHub exposes that list
+only to an App installation token, not to the administrator's normal OAuth/PAT session. The token is
+revoked by the action after the job. No administrator credential is stored in Actions.
 Protect creation, update, deletion, and force-push on `refs/heads/marketplace-kiro`, with the release
 App as the sole always-bypass actor. This prevents another repository writer from claiming the
 provider-visible branch before the first promotion while still allowing the approved release job to

--- a/kiro-power-standards/plugin.json
+++ b/kiro-power-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qodo/agent-skills",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "MIT",
       "devDependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "description": "Canonical Qodo skills and local coding-agent marketplace adapters.",
   "type": "module",

--- a/packages/qodo-standards/.claude-plugin/plugin.json
+++ b/packages/qodo-standards/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo-standards/plugin.json
+++ b/packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/.claude-plugin/plugin.json
+++ b/packages/qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/plugin.json
+++ b/packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/releases/v1.0.8.json
+++ b/releases/v1.0.8.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.8",
+  "summary": "Fix release App installation scope audit",
+  "package": {
+    "change": "patch"
+  },
+  "runtimeProtocolVersion": 2,
+  "minimumCliVersion": "0.1.0-next.37",
+  "skills": []
+}

--- a/scripts/audit-release-protections.sh
+++ b/scripts/audit-release-protections.sh
@@ -57,29 +57,27 @@ if [[ "$(jq --argjson release_app_id "${RELEASE_APP_ID}" '
   exit 1
 fi
 
-INSTALLATION_IDS="$(gh api --paginate "orgs/qodo-ai/installations?per_page=100" --jq ".installations[] | select(
+INSTALLATIONS="$(gh api --paginate "orgs/qodo-ai/installations?per_page=100" --jq ".installations[] | select(
   .app_id == ${RELEASE_APP_ID} and .suspended_at == null
-) | .id")"
+) | [.id, .repository_selection, .permissions.administration, .permissions.contents, .permissions.metadata] | @tsv")"
 INSTALLATION_COUNT=0
-INSTALLATION_ID=''
-while IFS= read -r candidate; do
-  if [[ -n "${candidate}" ]]; then
+INSTALLATION_SELECTION=''
+while IFS=$'\t' read -r candidate selection administration contents metadata; do
+  if [[ -n "${candidate:-}" ]]; then
     INSTALLATION_COUNT=$((INSTALLATION_COUNT + 1))
-    INSTALLATION_ID="${candidate}"
+    INSTALLATION_SELECTION="${selection}"
+    if [[ "${administration}" != 'read' || "${contents}" != 'write' || "${metadata}" != 'read' ]]; then
+      echo 'The active qodo-skills-release-bot installation permissions do not match its registration.' >&2
+      exit 1
+    fi
   fi
-done <<< "${INSTALLATION_IDS}"
+done <<< "${INSTALLATIONS}"
 if [[ "${INSTALLATION_COUNT}" -ne 1 ]]; then
   echo 'qodo-skills-release-bot must have exactly one active qodo-ai installation.' >&2
   exit 1
 fi
-if ! INSTALLATION_REPOSITORIES="$(gh api --paginate \
-  "user/installations/${INSTALLATION_ID}/repositories?per_page=100" \
-  --jq '.repositories[].full_name')"; then
-  echo 'Could not inspect the release App installation; authenticate gh with read:user and retry.' >&2
-  exit 1
-fi
-if ! grep -Fxq "${GITHUB_REPOSITORY}" <<< "${INSTALLATION_REPOSITORIES}"; then
-  echo 'qodo-skills-release-bot is not installed on qodo-ai/qodo-skills.' >&2
+if [[ "${INSTALLATION_SELECTION}" != 'selected' ]]; then
+  echo 'qodo-skills-release-bot must use selected-repository access, never all repositories.' >&2
   exit 1
 fi
 

--- a/scripts/fixtures/fake-release-gh.mjs
+++ b/scripts/fixtures/fake-release-gh.mjs
@@ -11,11 +11,14 @@ const readState = () => existsSync(statePath)
   ? JSON.parse(readFileSync(statePath, 'utf8'))
   : { exists: false, draft: false, immutable: false, assets: [], downloads: 0, edits: 0 };
 const writeState = (state) => writeFileSync(statePath, `${JSON.stringify(state)}\n`);
-const endpoint = args.find((arg) => arg.startsWith('repos/')) ?? '';
+const endpoint = args.find((arg) =>
+  arg.startsWith('repos/') || arg.startsWith('installation/')) ?? '';
 const jqIndex = args.indexOf('--jq');
 const query = jqIndex >= 0 ? args[jqIndex + 1] ?? '' : '';
 
-if (args[0] === 'api' && endpoint.endsWith('/immutable-releases')) {
+if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
+  process.stdout.write(`${process.env.FAKE_INSTALLATION_REPOSITORIES ?? 'qodo-ai/qodo-skills'}\n`);
+} else if (args[0] === 'api' && endpoint.endsWith('/immutable-releases')) {
   process.stdout.write(`${process.env.FAKE_IMMUTABLE_RELEASES ?? 'true'}\n`);
 } else if (args[0] === 'api' && endpoint.includes('/rulesets?')) {
   process.stdout.write(`${process.env.FAKE_RULESET_IDS ?? '21488082'}\n`);

--- a/scripts/test-enterprise-bundle.mjs
+++ b/scripts/test-enterprise-bundle.mjs
@@ -3,7 +3,8 @@ import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { gunzipSync } from 'node:zlib';
 import {
   assertNoPrivateKeyPayload,
@@ -11,6 +12,8 @@ import {
 } from './build-enterprise-bundle.mjs';
 
 const commit = '0123456789abcdef0123456789abcdef01234567';
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
 
 function sha256(payload) {
   return createHash('sha256').update(payload).digest('hex');
@@ -43,8 +46,8 @@ const secondRoot = mkdtempSync(join(tmpdir(), 'qodo-enterprise-second-'));
 try {
   const first = buildEnterpriseBundle({ output: firstRoot, commit });
   const second = buildEnterpriseBundle({ output: secondRoot, commit });
-  assert.equal(first.version, '1.0.7');
-  assert.equal(first.archiveName, 'qodo-enterprise-bundle-v1.0.7.tar.gz');
+  assert.equal(first.version, packageVersion);
+  assert.equal(first.archiveName, `qodo-enterprise-bundle-v${packageVersion}.tar.gz`);
 
   const firstArchive = readFileSync(join(firstRoot, first.archiveName));
   const secondArchive = readFileSync(join(secondRoot, second.archiveName));
@@ -57,12 +60,12 @@ try {
 
   const manifestPayload = readFileSync(join(firstRoot, first.manifestName));
   const manifest = JSON.parse(manifestPayload);
-  assert.equal(manifest.packageVersion, '1.0.7');
+  assert.equal(manifest.packageVersion, packageVersion);
   assert.equal(manifest.minimumCliVersion, '0.1.0-next.37');
   assert.deepEqual(manifest.source, {
     repository: 'https://github.com/qodo-ai/qodo-skills',
     commit,
-    tag: 'v1.0.7',
+    tag: `v${packageVersion}`,
   });
   assert.deepEqual(manifest.archive, { name: first.archiveName, sha256: first.archiveSha256 });
   assert.deepEqual(manifest.installation, {

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -14,6 +14,7 @@ import {
 } from './marketplace-release.mjs';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const releasePreflight = readFileSync(join(root, 'scripts', 'verify-release-prerequisites.sh'), 'utf8');
 const context = {
   tag: 'v1.0.2',
   version: '1.0.2',
@@ -191,6 +192,9 @@ assert.match(workflow, /owner: qodo-ai/);
 assert.match(workflow, /repositories: qodo-skills/);
 assert.match(workflow, /permission-administration: read/);
 assert.match(workflow, /permission-contents: write/);
+assert.match(workflow, /id: kiro-installation-audit-token/);
+assert.match(workflow, /steps\.kiro-installation-audit-token\.outputs\.token/);
+assert.match(workflow, /Verify Kiro release App installation scope/);
 assert.match(workflow, /steps\.kiro-release-token\.outputs\.token/);
 assert.match(workflow, /verify-kiro-release-source\.sh/);
 assert.match(workflow, /-F force=false/);
@@ -216,7 +220,9 @@ assert.match(protectionAudit, /\.type == "required_reviewers"/);
 assert.match(protectionAudit, /QODO_SKILLS_RELEASE_APP_PRIVATE_KEY/);
 assert.match(protectionAudit, /\.permissions == \{"administration":"read","contents":"write","metadata":"read"\}/);
 assert.match(protectionAudit, /orgs\/qodo-ai\/installations\?per_page=100/);
-assert.match(protectionAudit, /user\/installations\/\$\{INSTALLATION_ID\}\/repositories\?per_page=100/);
+assert.match(protectionAudit, /repository_selection/);
+assert.doesNotMatch(protectionAudit, /user\/installations/);
+assert.match(releasePreflight, /installation\/repositories\?per_page=100/);
 assert.match(protectionAudit, /\.bypass_actors == \[\{"actor_id":\$release_app_id,"actor_type":"Integration","bypass_mode":"always"\}\]/);
 assert.match(readFileSync(join(root, 'scripts', 'audit-release-protections.cmd'), 'utf8'),
   /bash "%~dp0audit-release-protections\.sh"/);
@@ -250,13 +256,11 @@ elif [[ "$*" == *"variables/QODO_SKILLS_RELEASE_APP_ID --jq .value"* ]]; then
 elif [[ "$*" == *"environments/marketplace-kiro/secrets --jq"* ]]; then
   printf 'true\\n'
 elif [[ "$*" == *"orgs/qodo-ai/installations?per_page=100"* ]]; then
-  if [[ "\${QODO_TEST_MISSING_INSTALLATION:-}" != 1 ]]; then printf '%s\\n' 99; fi
-elif [[ "$*" == *"user/installations/99/repositories?per_page=100"* ]]; then
-  if [[ "\${QODO_TEST_INSTALLATION_MISSES_REPO:-}" == 1 ]]; then
-    printf 'qodo-ai/other\\n'
-  else
-    printf 'qodo-ai/qodo-skills\\n'
+  if [[ "\${QODO_TEST_MISSING_INSTALLATION:-}" != 1 ]]; then
+    printf '99\\t%s\\tread\\twrite\\tread\\n' "\${QODO_TEST_INSTALLATION_SELECTION:-selected}"
   fi
+elif [[ "$*" == *"installation/repositories?per_page=100"* ]]; then
+  printf '%s\\n' "\${QODO_TEST_INSTALLATION_REPOSITORIES:-qodo-ai/qodo-skills}"
 elif [[ "$*" == *"rulesets?per_page=100"* ]]; then
   if [[ "$*" == *"Immutable release tags"* ]]; then printf '%s\\n' 78; else printf '%s\\n' 77; fi
 elif [[ "$*" == "api repos/qodo-ai/qodo-skills/rulesets/78" ]]; then
@@ -344,11 +348,16 @@ fi
       });
       assert.equal(missingInstallationAudit.status, 1, missingInstallationAudit.stderr);
       assert.match(missingInstallationAudit.stderr, /exactly one active qodo-ai installation/);
-      const wrongRepositoryAudit = spawnSync('bash', [join(root, 'scripts', 'audit-release-protections.sh')], {
-        encoding: 'utf8', env: { ...auditEnvironment, QODO_TEST_INSTALLATION_MISSES_REPO: '1' }, timeout: 5_000,
+      const allRepositoriesAudit = spawnSync('bash', [join(root, 'scripts', 'audit-release-protections.sh')], {
+        encoding: 'utf8', env: { ...auditEnvironment, QODO_TEST_INSTALLATION_SELECTION: 'all' }, timeout: 5_000,
       });
-      assert.equal(wrongRepositoryAudit.status, 1, wrongRepositoryAudit.stderr);
-      assert.match(wrongRepositoryAudit.stderr, /not installed on qodo-ai\/qodo-skills/);
+      assert.equal(allRepositoriesAudit.status, 1, allRepositoriesAudit.stderr);
+      assert.match(allRepositoriesAudit.stderr, /selected-repository access/);
+      const wrongRepositoryPreflight = spawnSync('bash', [join(root, 'scripts', 'verify-release-prerequisites.sh')], {
+        encoding: 'utf8', env: { ...preflightEnvironment, QODO_TEST_INSTALLATION_REPOSITORIES: 'qodo-ai/other' }, timeout: 5_000,
+      });
+      assert.equal(wrongRepositoryPreflight.status, 1, wrongRepositoryPreflight.stderr);
+      assert.match(wrongRepositoryPreflight.stderr, /installed on qodo-ai\/qodo-skills and no other repository/);
       const missingReviewerAudit = spawnSync('bash', [join(root, 'scripts', 'audit-release-protections.sh')], {
         encoding: 'utf8', env: { ...auditEnvironment, QODO_TEST_MISSING_REVIEWER: '1' }, timeout: 5_000,
       });

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -55,7 +55,7 @@ const publisherReleaseLookup = publisher.indexOf('RELEASE_LOOKUP=');
 const publisherTagCreation = publisher.indexOf('git tag --no-sign -a');
 const publisherFinalMainGuard = publisher.lastIndexOf('require_current_main');
 const publisherTagPush = publisher.indexOf('git push origin "refs/tags/${TAG}:refs/tags/${TAG}"');
-const releaseTokenCheck = releaseSource.indexOf('repository-scoped GitHub App token with Administration:read is required');
+const releaseTokenCheck = releaseSource.indexOf('installation-wide, read-only GitHub App token with Administration:read is required');
 const checkoutGuard = publisher.indexOf('\nrequire_exact_release_checkout\n');
 const catalogRead = publisher.indexOf('require(\'./distribution/catalog.json\')');
 const tagRulesetCheck = releaseSource.indexOf('Immutable release tags ruleset is required');
@@ -78,7 +78,11 @@ assert.match(preflight, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/,
 assert.match(workflow, /environment:\s*\n\s*name: marketplace-kiro/);
 assert.match(workflow, /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
 assert.match(workflow, /permission-administration: read/);
+assert.match(workflow, /Mint installation-wide read-only release preflight token/);
+assert.doesNotMatch(workflow, /repositories: qodo-skills/,
+  'the read-only preflight token must see the complete installation repository set');
 assert.match(workflow, /GH_TOKEN: \$\{\{ steps\.release-preflight-token\.outputs\.token \}\}/);
+assert.match(preflight, /installation\/repositories\?per_page=100/);
 assert.ok(exactMainGuard >= 0 && exactMainGuard < tagCreation,
   'release workflow must require the exact merged main commit before creating a tag');
 assert.match(releaseSource, /git fetch origin main --no-tags/);
@@ -113,7 +117,7 @@ assert.ok(releaseVerificationHelper >= 0 && releaseVerificationHelper < existing
 assert.ok(downloadedVerification > releaseDownload && downloadedVerification < existingReleaseExit,
   'downloaded immutable assets must be checksum- and byte-verified before success');
 assert.ok(releaseTokenCheck > validationRun && releaseTokenCheck < existingReleaseBranch,
-  'runtime preflight must require a repository-scoped App token before tagging');
+  'runtime preflight must require an installation-wide read-only App token before tagging');
 assert.ok(tagRulesetCheck > releaseTokenCheck && tagRulesetCheck < existingReleaseBranch,
   'release-tag update/deletion protection must be verified before tagging');
 assert.match(releaseSource, /\.conditions\.ref_name\.include/);
@@ -214,7 +218,15 @@ try {
   const preflightPath = join(root, 'scripts', 'verify-release-prerequisites.sh');
   runShell(root, preflightPath, fakeGhEnv);
   assert.throws(() => runShell(root, preflightPath, { ...fakeGhEnv, GH_TOKEN: '' }),
-    /repository-scoped GitHub App token with Administration:read is required/);
+    /installation-wide, read-only GitHub App token with Administration:read is required/);
+  assert.throws(() => runShell(root, preflightPath, {
+    ...fakeGhEnv,
+    FAKE_INSTALLATION_REPOSITORIES: 'qodo-ai/other',
+  }), /installed on qodo-ai\/qodo-skills and no other repository/);
+  assert.throws(() => runShell(root, preflightPath, {
+    ...fakeGhEnv,
+    FAKE_INSTALLATION_REPOSITORIES: 'qodo-ai/qodo-skills\nqodo-ai/other',
+  }), /installed on qodo-ai\/qodo-skills and no other repository/);
   assert.throws(() => runShell(root, preflightPath, {
     ...fakeGhEnv,
     FAKE_IMMUTABLE_RELEASES: 'false',

--- a/scripts/verify-release-prerequisites.sh
+++ b/scripts/verify-release-prerequisites.sh
@@ -10,7 +10,14 @@ command -v gh >/dev/null 2>&1 || {
 }
 
 if [[ -z "${GH_TOKEN:-}" ]]; then
-  echo 'A repository-scoped GitHub App token with Administration:read is required for release preflight.' >&2
+  echo 'An installation-wide, read-only GitHub App token with Administration:read is required for release preflight.' >&2
+  exit 1
+fi
+
+INSTALLATION_REPOSITORIES="$(gh api --paginate 'installation/repositories?per_page=100' \
+  --jq '.repositories[].full_name')"
+if [[ "${INSTALLATION_REPOSITORIES}" != "${GITHUB_REPOSITORY}" ]]; then
+  echo 'qodo-skills-release-bot must be installed on qodo-ai/qodo-skills and no other repository.' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- split administrator-only protection checks from App-token-only repository-scope verification
- require the release App installation to contain exactly `qodo-ai/qodo-skills` before tagging or Kiro promotion
- prepare the unpublished first cutover package as `v1.0.8` and document why `v1.0.7` must not ship

## Validation
- `npm test`
- `git diff --check`
- `GITHUB_REPOSITORY=qodo-ai/qodo-skills scripts/audit-release-protections.sh`