### PR TITLE
fix(release): resume tagged draft publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,27 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve the immutable release source commit
+        id: release-source
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./distribution/catalog.json').package.version")"
+          TAG="v${VERSION}"
+          RELEASE_COMMIT="${GITHUB_SHA}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
+            if [[ "$(git cat-file -t "refs/tags/${TAG}")" != 'tag' ]]; then
+              echo "${TAG} is not an annotated tag; refusing recovery." >&2
+              exit 1
+            fi
+            RELEASE_COMMIT="$(git rev-parse "refs/tags/${TAG}^{}")"
+            if ! git merge-base --is-ancestor "${RELEASE_COMMIT}" "${GITHUB_SHA}"; then
+              echo "${TAG} is not an ancestor of current main; refusing recovery." >&2
+              exit 1
+            fi
+          fi
+          echo "commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+
       - name: Install locked validation dependencies
         run: npm ci
 
@@ -82,10 +103,11 @@ jobs:
         run: >-
           node scripts/build-enterprise-bundle.mjs
           --output "${RUNNER_TEMP}/qodo-enterprise-release"
-          --commit "${GITHUB_SHA}"
+          --commit "${{ steps.release-source.outputs.commit }}"
 
       - name: Publish the immutable tag and GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           QODO_ENTERPRISE_RELEASE_DIR: ${{ runner.temp }}/qodo-enterprise-release
+          QODO_RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
         run: scripts/publish-release.sh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -63,7 +63,8 @@ token for that pre-publication check. The checked-in audit, runtime preflight, a
 missing credentials, disabled immutability, duplicate/invalid rulesets, forbidden creation rules,
 draft corruption, draft resume, publication, and immutable retry all fail closed.
 After the compatible CLI release is live and the skills PR is merged, a release owner dispatches
-**Release skills** from the current `main` head. Rerunning it is idempotent. The workflow:
+**Release skills** from the current `main` head. Rerunning it is idempotent, including recovery when
+a prior run created the protected tag and draft but stopped before publication. The workflow:
 
 1. requires the dispatched SHA to be the exact `main` head before and after validation; a merge
    after that final check does not change the validated release SHA;
@@ -76,10 +77,19 @@ After the compatible CLI release is live and the skills PR is merged, a release 
    the compact index, data-only CLI-managed bundle, enterprise manifest, enterprise archive, and
    all four SHA-256 files;
 6. publishes the verified draft, which makes the release immutable;
-7. verifies the published release is immutable, the protected tag is unchanged, and both published
+7. verifies the published release is immutable, the protected tag is unchanged, and all published
    assets still match the validated checkout byte-for-byte;
-8. on an idempotent rerun, downloads both existing assets, verifies their checksum, and compares
+8. on an idempotent rerun, downloads all eight existing assets, verifies their checksums, and compares
    them byte-for-byte with the validated checkout before reporting success.
+
+GitHub's release-by-tag REST endpoint does not expose draft releases. The publisher therefore finds
+both drafts and public releases through the paginated release list, rejects duplicate tag claims,
+and addresses the selected release by immutable numeric id. If reviewed release automation advances
+`main` after a draft was created, recovery may use the older tagged commit only when that tag is an
+ancestor of current `main` and an existing draft for the tag is present. The enterprise manifest is
+rebuilt with the tagged source commit, and every downloaded draft asset must match before the draft
+can become public. An older tag without its draft fails closed; tags and assets are never moved,
+deleted, or overwritten.
 
 After that workflow succeeds, dispatch **release: publish skills compatibility channel** in
 `qodo-ai/qodo-in-cli` with the immutable `v<package-version>` tag. The workflow verifies the public

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:notes": "node scripts/release-notes.mjs",
     "enterprise:build": "node scripts/build-enterprise-bundle.mjs",
     "check": "node scripts/validate.mjs && node scripts/build-release-index.mjs --check && node scripts/build-cli-managed-bundle.mjs --check",
-    "test": "npm run check && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
+    "test": "npm run check && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-release-tag-protection.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/fixtures/fake-release-gh.mjs
+++ b/scripts/fixtures/fake-release-gh.mjs
@@ -27,17 +27,27 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
   const valid = process.env.FAKE_RULESET_VALID !== 'false'
     && (process.env.FAKE_RULESET_HAS_CREATION !== 'true' || creationRejected === false);
   process.stdout.write(`${valid}\n`);
-} else if (args[0] === 'api' && endpoint.includes('/releases/tags/')) {
+} else if (args[0] === 'api' && endpoint.endsWith('/releases?per_page=100')) {
   const state = readState();
-  if (args.includes('--include')) {
-    if (process.env.FAKE_RELEASE_LOOKUP_ERROR === 'true') {
-      process.stderr.write('HTTP/2.0 503 Service Unavailable\n');
-      process.exit(1);
-    }
-    process.stdout.write(`HTTP/2.0 ${state.exists ? '200 OK' : '404 Not Found'}\n`);
-    if (!state.exists) process.exit(1);
-  } else if (!state.exists) process.exit(1);
-  else if (query === '.draft') process.stdout.write(`${state.draft}\n`);
+  if (process.env.FAKE_RELEASE_LOOKUP_ERROR === 'true') {
+    process.stderr.write('release list unavailable\n');
+    process.exit(1);
+  }
+  if (state.exists) process.stdout.write(`123\t${state.draft}\n`);
+} else if (args[0] === 'api' && /\/releases\/123$/.test(endpoint)) {
+  const state = readState();
+  if (!state.exists) process.exit(1);
+  if (args[args.indexOf('--method') + 1] === 'PATCH') {
+    const publishing = args.includes('draft=false');
+    const containing = args.includes('draft=true');
+    if (publishing === containing) throw new Error('Release patch must set exactly one draft state');
+    writeState({
+      ...state,
+      draft: containing,
+      immutable: publishing && process.env.FAKE_PUBLISHED_MUTABLE !== 'true',
+      edits: state.edits + 1,
+    });
+  } else if (query === '.draft') process.stdout.write(`${state.draft}\n`);
   else if (query === '.immutable') process.stdout.write(`${state.immutable}\n`);
   else if (query === '.assets[].name') process.stdout.write(`${state.assets.join('\n')}\n`);
   else if (query.includes('.assets[].name')) process.stdout.write(`${[...state.assets].sort().join(' ')}\n`);
@@ -98,19 +108,6 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
     writeFileSync(join(dir, 'qodo-skills-index.json'), 'corrupt\n');
   }
   writeState({ ...state, downloads });
-} else if (args[0] === 'release' && args[1] === 'edit') {
-  const publishing = args.includes('--draft=false');
-  const containing = args.includes('--draft=true');
-  if (!/^v\d+\.\d+\.\d+$/.test(args[2] ?? '') || publishing === containing) {
-    throw new Error('Release edit must specify a valid tag and exactly one draft state');
-  }
-  const state = readState();
-  writeState({
-    ...state,
-    draft: containing,
-    immutable: publishing && process.env.FAKE_PUBLISHED_MUTABLE !== 'true',
-    edits: state.edits + 1,
-  });
 } else {
   throw new Error(`Unsupported fake gh call: ${args.join(' ')}`);
 }

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -4,7 +4,7 @@
 #   RUNNER_TEMP=<dir> QODO_ENTERPRISE_RELEASE_DIR=<prepared-assets-dir> scripts/publish-release.sh
 set -euo pipefail
 
-for tool in gh git node mktemp cmp grep cat rm basename; do
+for tool in gh git node mktemp cmp rm basename; do
   command -v "${tool}" >/dev/null 2>&1 || {
     echo "Release publication requires '${tool}', but it is not available." >&2
     exit 1
@@ -36,6 +36,11 @@ require_exact_release_checkout
 
 VERSION="$(node -p "require('./distribution/catalog.json').package.version")"
 TAG="v${VERSION}"
+RELEASE_COMMIT="${QODO_RELEASE_COMMIT:-${GITHUB_SHA}}"
+if [[ ! "${RELEASE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'QODO_RELEASE_COMMIT must be a full lowercase commit SHA.' >&2
+  exit 1
+fi
 NOTES="${RUNNER_TEMP}/qodo-release-notes.md"
 ENTERPRISE_DIR="${QODO_ENTERPRISE_RELEASE_DIR:?QODO_ENTERPRISE_RELEASE_DIR is required}"
 ARCHIVE_NAME="qodo-enterprise-bundle-v${VERSION}.tar.gz"
@@ -91,34 +96,58 @@ require_annotated_release_tag() {
     echo "${TAG} is not an annotated tag; refusing to publish." >&2
     exit 1
   fi
-  if [[ "$(git rev-parse "refs/tags/${TAG}^{}")" != "${GITHUB_SHA}" ]]; then
+  if [[ "$(git rev-parse "refs/tags/${TAG}^{}")" != "${RELEASE_COMMIT}" ]]; then
     echo "${TAG} does not resolve to the validated release commit; refusing to publish." >&2
     exit 1
   fi
 }
 
+load_release() {
+  local releases release_count candidate_id candidate_draft
+  if ! releases="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+    --jq ".[] | select(.tag_name == \"${TAG}\") | [.id, .draft] | @tsv")"; then
+    echo "Could not determine whether ${TAG} already exists; refusing to create a release." >&2
+    exit 1
+  fi
+  release_count=0
+  RELEASE_ID=''
+  RELEASE_DRAFT=''
+  while IFS=$'\t' read -r candidate_id candidate_draft; do
+    if [[ -n "${candidate_id:-}" ]]; then
+      release_count=$((release_count + 1))
+      RELEASE_ID="${candidate_id}"
+      RELEASE_DRAFT="${candidate_draft}"
+    fi
+  done <<< "${releases}"
+  if [[ "${release_count}" -gt 1 ]]; then
+    echo "Multiple releases claim ${TAG}; refusing to choose one." >&2
+    exit 1
+  fi
+  if [[ "${release_count}" -eq 1 ]]; then
+    RELEASE_EXISTS=true
+    RELEASE_ENDPOINT="repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"
+  else
+    RELEASE_EXISTS=false
+    RELEASE_ENDPOINT=''
+  fi
+}
+
 require_current_main
 
-RELEASE_EXISTS=false
-RELEASE_LOOKUP="$(mktemp "${RUNNER_TEMP}/qodo-release-lookup.XXXXXX")"
-if gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" >"${RELEASE_LOOKUP}" 2>&1; then
-  RELEASE_EXISTS=true
-elif ! grep -Eq '^HTTP/[0-9.]+ 404([[:space:]]|$)' "${RELEASE_LOOKUP}"; then
-  cat "${RELEASE_LOOKUP}" >&2
-  rm -f -- "${RELEASE_LOOKUP}"
-  echo "Could not determine whether ${TAG} already exists; refusing to create a release." >&2
+load_release
+if [[ "${RELEASE_COMMIT}" != "${GITHUB_SHA}" && "${RELEASE_EXISTS}" != 'true' ]]; then
+  echo 'A release commit behind current main may only resume an existing draft.' >&2
   exit 1
 fi
-rm -f -- "${RELEASE_LOOKUP}"
 if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
   git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
   require_annotated_release_tag
-  if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.draft')" != 'true' ]]; then
-    if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.immutable')" != 'true' ]]; then
+  if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" != 'true' ]]; then
+    if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
       echo "Existing public release ${TAG} is mutable; refusing to overwrite its assets." >&2
       exit 1
     fi
-    test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '[.assets[].name] | sort | join(" ")')" = \
+    test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
       "${EXPECTED_ASSETS}"
     VERIFY_DIR="$(mktemp -d "${RUNNER_TEMP}/qodo-release-verify.XXXXXX")"
     trap 'rm -rf -- "${VERIFY_DIR}"' EXIT
@@ -133,7 +162,7 @@ if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
 else
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  git tag --no-sign -a "${TAG}" "${GITHUB_SHA}" -m "Qodo skills ${TAG}"
+  git tag --no-sign -a "${TAG}" "${RELEASE_COMMIT}" -m "Qodo skills ${TAG}"
 fi
 require_annotated_release_tag
 
@@ -144,14 +173,14 @@ require_current_main
 git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
 
 if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
-  if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.draft')" != 'true' ]]; then
+  if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" != 'true' ]]; then
     echo "Existing release ${TAG} left draft state before asset verification; refusing to mutate it." >&2
     exit 1
   fi
   EXISTING_ASSETS=()
   while IFS= read -r existing_asset; do
     [[ -n "${existing_asset}" ]] && EXISTING_ASSETS+=("${existing_asset}")
-  done < <(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.assets[].name')
+  done < <(gh api "${RELEASE_ENDPOINT}" --jq '.assets[].name')
   for existing_asset in "${EXISTING_ASSETS[@]}"; do
     expected=false
     for release_asset in "${RELEASE_ASSETS[@]}"; do
@@ -181,10 +210,15 @@ if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
 else
   gh release create "${TAG}" --draft --verify-tag --title "Qodo skills ${TAG}" --notes-file "${NOTES}" \
     "${RELEASE_ASSETS[@]}"
+  load_release
+  if [[ "${RELEASE_EXISTS}" != 'true' || "${RELEASE_DRAFT}" != 'true' ]]; then
+    echo "GitHub did not expose the newly created ${TAG} draft; refusing to continue." >&2
+    exit 1
+  fi
 fi
 
-test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.draft')" = 'true'
-test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '[.assets[].name] | sort | join(" ")')" = \
+test "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" = 'true'
+test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
   "${EXPECTED_ASSETS}"
 VERIFY_DIR="$(mktemp -d "${RUNNER_TEMP}/qodo-release-verify.XXXXXX")"
 trap 'rm -rf -- "${VERIFY_DIR}"' EXIT
@@ -193,15 +227,15 @@ verify_release_assets "${VERIFY_DIR}"
 
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag
-gh release edit "${TAG}" --draft=false
-if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.immutable')" != 'true' ]]; then
+gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=false >/dev/null
+if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
   echo 'Published release is mutable. Enable repository release immutability before any consumer rollout.' >&2
-  if ! gh release edit "${TAG}" --draft=true; then
+  if ! gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=true >/dev/null; then
     echo 'CRITICAL: could not return the mutable release to draft; stop all consumer rollout.' >&2
   fi
   exit 1
 fi
-test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '[.assets[].name] | sort | join(" ")')" = \
+test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
   "${EXPECTED_ASSETS}"
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag

--- a/scripts/test-release-tag-protection.mjs
+++ b/scripts/test-release-tag-protection.mjs
@@ -1,0 +1,78 @@
+/** Verify that the remote repository rejects release-tag movement. */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const fixture = mkdtempSync(join(tmpdir(), 'qodo-release-lease-'));
+const origin = join(fixture, 'origin.git');
+const seed = join(fixture, 'seed');
+const runner = join(fixture, 'runner');
+const git = (cwd, args) => execFileSync('git', [
+  '-c', 'commit.gpgsign=false',
+  '-c', 'tag.gpgSign=false',
+  ...args,
+], { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+
+try {
+  git(fixture, ['init', '--bare', '--initial-branch=main', origin]);
+  const preReceive = join(origin, 'hooks', 'pre-receive');
+  writeFileSync(preReceive, [
+    '#!/usr/bin/env bash',
+    '# Description: reject updates and deletions of release tags in this bare-repository fixture.',
+    '# Usage: Git pre-receive hook; reads "<old-sha> <new-sha> <ref>" records from stdin.',
+    'set -euo pipefail',
+    'while read -r old_sha new_sha ref_name; do',
+    '  case "${ref_name}" in',
+    '    refs/tags/*)',
+    '      if [[ "${old_sha}" == *[!0]* ]]; then',
+    '        echo "immutable release tag update rejected: ${ref_name}" >&2',
+    '        exit 1',
+    '      fi',
+    '      ;;',
+    '  esac',
+    'done',
+    '',
+  ].join('\n'));
+  chmodSync(preReceive, 0o755);
+  git(fixture, ['clone', origin, seed]);
+  git(seed, ['config', 'user.name', 'Release Test']);
+  git(seed, ['config', 'user.email', 'release-test@qodo.invalid']);
+  writeFileSync(join(seed, 'release.txt'), 'v1\n');
+  git(seed, ['add', 'release.txt']);
+  git(seed, ['commit', '-m', 'release v1']);
+  const releaseSha = git(seed, ['rev-parse', 'HEAD']);
+  git(seed, ['push', 'origin', 'main']);
+
+  git(fixture, ['clone', origin, runner]);
+  git(runner, ['config', 'user.name', 'Release Test']);
+  git(runner, ['config', 'user.email', 'release-test@qodo.invalid']);
+  git(runner, ['tag', '-a', 'v1', '-m', 'v1']);
+  git(runner, ['push', 'origin', 'refs/tags/v1:refs/tags/v1']);
+  assert.equal(
+    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
+    releaseSha,
+  );
+
+  writeFileSync(join(seed, 'release.txt'), 'v2\n');
+  git(seed, ['add', 'release.txt']);
+  git(seed, ['commit', '-m', 'advance main']);
+  git(seed, ['push', 'origin', 'main']);
+
+  git(runner, ['fetch', 'origin', 'main']);
+  assert.notEqual(git(runner, ['rev-parse', 'origin/main']), releaseSha,
+    'the final release guard must observe an intervening main advance');
+  git(runner, ['tag', '-f', '-a', 'v1', '-m', 'moved v1', 'origin/main']);
+  assert.throws(() => git(runner, [
+    'push', '--force', 'origin', 'refs/tags/v1:refs/tags/v1',
+  ]), /immutable release tag update rejected/);
+  assert.equal(
+    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
+    releaseSha,
+  );
+} finally {
+  rmSync(fixture, { recursive: true, force: true });
+}
+
+console.log('Release tag protection test passed.');

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -51,7 +51,7 @@ const validationRun = releaseSource.indexOf('npm test');
 const existingReleaseBranch = releaseSource.indexOf('if [[ "${RELEASE_EXISTS}"');
 const toolChecks = releaseSource.indexOf('for tool in gh git node npm mktemp sha256sum cmp rm; do');
 const firstMainGuard = releaseSource.indexOf('require_current_main');
-const publisherReleaseLookup = publisher.indexOf('RELEASE_LOOKUP=');
+const publisherReleaseLookup = publisher.indexOf('load_release');
 const publisherTagCreation = publisher.indexOf('git tag --no-sign -a');
 const publisherFinalMainGuard = publisher.lastIndexOf('require_current_main');
 const publisherTagPush = publisher.indexOf('git push origin "refs/tags/${TAG}:refs/tags/${TAG}"');
@@ -63,7 +63,7 @@ const releaseVerificationHelper = releaseSource.indexOf('verify_release_assets()
 const releaseDownload = releaseSource.indexOf('gh release download');
 const downloadedVerification = releaseSource.indexOf('verify_release_assets "${VERIFY_DIR}"', releaseDownload);
 const draftCreation = releaseSource.indexOf('gh release create "${TAG}" --draft');
-const draftPublish = releaseSource.indexOf('gh release edit "${TAG}" --draft=false');
+const draftPublish = releaseSource.indexOf('gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=false');
 const draftAssetCheck = releaseSource.indexOf('.assets[].name', draftCreation);
 const draftDownload = releaseSource.indexOf('gh release download', draftCreation);
 const draftVerification = releaseSource.indexOf('verify_release_assets "${VERIFY_DIR}"', draftDownload);
@@ -106,7 +106,7 @@ assert.match(publisher, /shasum -a 256 --check/);
 assert.match(publisher, /verify_sha256 qodo-skills-index\.json\.sha256/g);
 assert.doesNotMatch(releaseSource, /"\$GITHUB_SHA"/,
   'scalar shell variables must use braced expansion');
-assert.match(publisher, /releases\/tags\/\$\{TAG\}" --jq '\.immutable'/,
+assert.match(publisher, /gh api "\$\{RELEASE_ENDPOINT\}" --jq '\.immutable'/,
   'publication must verify the provider reports an immutable release');
 assert.ok(firstAssetCheck >= 0 && firstAssetCheck < existingReleaseExit,
   'an existing release must be accepted only after its assets are verified');
@@ -156,8 +156,14 @@ assert.ok(publishedDownload > draftPublish,
 assert.ok(publishedVerification > publishedDownload,
   'published immutable assets must still match their checksums and validated bytes');
 assert.match(releaseSource, /RELEASE_EXISTS=false/);
-assert.match(releaseSource, /gh api --include/);
-assert.match(releaseSource, /HTTP\/\[0-9\.\]\+ 404/);
+assert.match(releaseSource, /releases\?per_page=100/,
+  'draft discovery must use the release list because GitHub release-by-tag returns 404 for drafts');
+assert.doesNotMatch(publisher, /releases\/tags\/\$\{TAG\}/,
+  'draft reads must use the release ID returned by the list endpoint');
+assert.match(workflow, /id: release-source/);
+assert.match(workflow, /git merge-base --is-ancestor/);
+assert.match(workflow, /QODO_RELEASE_COMMIT: \$\{\{ steps\.release-source\.outputs\.commit \}\}/);
+assert.match(publisher, /A release commit behind current main may only resume an existing draft/);
 assert.match(releaseSource, /gh release upload "\$\{TAG\}"/,
   'a partial draft publication must be resumable without abandoning the version');
 assert.doesNotMatch(releaseSource, /gh release upload[^\n]*--clobber/,
@@ -306,6 +312,52 @@ try {
     { draft: false, immutable: true, edits: 1, downloads: 2 },
   );
 
+  // A reviewed automation-only main advance can resume an already-tagged
+  // draft, but all downloaded assets must still match the tagged release.
+  writeFileSync(fakeGhState, `${JSON.stringify({
+    ...published,
+    draft: true,
+    immutable: false,
+    downloads: 0,
+    edits: 0,
+  })}\n`);
+  run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-m', 'release recovery automation']);
+  const recoverySha = run(checkout, 'git', ['rev-parse', 'HEAD']).trim();
+  run(checkout, 'git', ['push', 'origin', 'main']);
+  runShell(checkout, publishPath, {
+    ...publishEnv,
+    GITHUB_SHA: recoverySha,
+    QODO_RELEASE_COMMIT: releaseSha,
+  });
+  const recovered = JSON.parse(readFileSync(fakeGhState, 'utf8'));
+  assert.deepEqual(
+    { draft: recovered.draft, immutable: recovered.immutable, edits: recovered.edits, downloads: recovered.downloads },
+    { draft: false, immutable: true, edits: 1, downloads: 2 },
+  );
+  run(checkout, 'git', ['reset', '--hard', releaseSha]);
+  run(checkout, 'git', ['push', '--force', 'origin', 'main']);
+
+  // An older tag without a matching draft can never borrow current-main bytes.
+  writeFileSync(fakeGhState, `${JSON.stringify({
+    exists: false,
+    draft: false,
+    immutable: false,
+    assets: [],
+    downloads: 0,
+    edits: 0,
+  })}\n`);
+  run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-m', 'unsafe untagged recovery']);
+  const unsafeRecoverySha = run(checkout, 'git', ['rev-parse', 'HEAD']).trim();
+  run(checkout, 'git', ['push', 'origin', 'main']);
+  assert.throws(() => runShell(checkout, publishPath, {
+    ...publishEnv,
+    GITHUB_SHA: unsafeRecoverySha,
+    QODO_RELEASE_COMMIT: releaseSha,
+  }), /may only resume an existing draft/);
+  run(checkout, 'git', ['reset', '--hard', releaseSha]);
+  run(checkout, 'git', ['push', '--force', 'origin', 'main']);
+  writeFileSync(fakeGhState, `${JSON.stringify(recovered)}\n`);
+
   // A lightweight tag at the correct commit is still not the release object
   // promised by the publication contract.
   run(checkout, 'git', ['tag', '-d', releaseTag]);
@@ -424,76 +476,6 @@ try {
   );
 } finally {
   rmSync(harness, { recursive: true, force: true });
-}
-
-const fixture = mkdtempSync(join(tmpdir(), 'qodo-release-lease-'));
-const origin = join(fixture, 'origin.git');
-const seed = join(fixture, 'seed');
-const runner = join(fixture, 'runner');
-const git = (cwd, args) => execFileSync('git', [
-  '-c', 'commit.gpgsign=false',
-  '-c', 'tag.gpgSign=false',
-  ...args,
-], { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
-
-try {
-  git(fixture, ['init', '--bare', '--initial-branch=main', origin]);
-  const preReceive = join(origin, 'hooks', 'pre-receive');
-  writeFileSync(preReceive, [
-    '#!/usr/bin/env bash',
-    '# Description: reject updates and deletions of release tags in this bare-repository fixture.',
-    '# Usage: Git pre-receive hook; reads "<old-sha> <new-sha> <ref>" records from stdin.',
-    'set -euo pipefail',
-    'while read -r old_sha new_sha ref_name; do',
-    '  case "${ref_name}" in',
-    '    refs/tags/*)',
-    '      if [[ "${old_sha}" == *[!0]* ]]; then',
-    '        echo "immutable release tag update rejected: ${ref_name}" >&2',
-    '        exit 1',
-    '      fi',
-    '      ;;',
-    '  esac',
-    'done',
-    '',
-  ].join('\n'));
-  chmodSync(preReceive, 0o755);
-  git(fixture, ['clone', origin, seed]);
-  git(seed, ['config', 'user.name', 'Release Test']);
-  git(seed, ['config', 'user.email', 'release-test@qodo.invalid']);
-  writeFileSync(join(seed, 'release.txt'), 'v1\n');
-  git(seed, ['add', 'release.txt']);
-  git(seed, ['commit', '-m', 'release v1']);
-  const releaseSha = git(seed, ['rev-parse', 'HEAD']);
-  git(seed, ['push', 'origin', 'main']);
-
-  git(fixture, ['clone', origin, runner]);
-  git(runner, ['config', 'user.name', 'Release Test']);
-  git(runner, ['config', 'user.email', 'release-test@qodo.invalid']);
-  git(runner, ['tag', '-a', 'v1', '-m', 'v1']);
-  git(runner, ['push', 'origin', 'refs/tags/v1:refs/tags/v1']);
-  assert.equal(
-    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
-    releaseSha,
-  );
-
-  writeFileSync(join(seed, 'release.txt'), 'v2\n');
-  git(seed, ['add', 'release.txt']);
-  git(seed, ['commit', '-m', 'advance main']);
-  git(seed, ['push', 'origin', 'main']);
-
-  git(runner, ['fetch', 'origin', 'main']);
-  assert.notEqual(git(runner, ['rev-parse', 'origin/main']), releaseSha,
-    'the final release guard must observe an intervening main advance');
-  git(runner, ['tag', '-f', '-a', 'v1', '-m', 'moved v1', 'origin/main']);
-  assert.throws(() => git(runner, [
-    'push', '--force', 'origin', 'refs/tags/v1:refs/tags/v1',
-  ]), /immutable release tag update rejected/);
-  assert.equal(
-    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
-    releaseSha,
-  );
-} finally {
-  rmSync(fixture, { recursive: true, force: true });
 }
 
 console.log('Release workflow safety test passed.');


### PR DESCRIPTION
## Summary
- discover draft releases through the paginated release-list API and address them by numeric release ID
- safely resume the existing `v1.0.8` draft from its immutable tagged commit after release automation advances `main`
- fail closed unless the tag is an ancestor, the draft already exists, and all eight downloaded assets match the tagged release bytes

`v1.0.8` is intentionally not bumped: the protected tag already exists at `674f0e30a0c9c64bbc8fa72d5212532da810521d`, and draft release `380586543` already contains the eight validated assets. This PR neither moves the tag nor replaces those assets.

## Validation
- `npm test`
- `git diff --check`
- `shellcheck scripts/publish-release.sh`
- `actionlint .github/workflows/release.yml`
- live read-only verification of draft ID `380586543`, exact eight-asset inventory, and tag target