### PR TITLE
fix(release): resume tagged draft from immutable source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,15 +99,32 @@ jobs:
           GH_TOKEN: ${{ steps.release-preflight-token.outputs.token }}
         run: scripts/verify-release-prerequisites.sh
 
-      - name: Build the deterministic enterprise bundle
-        run: >-
-          node scripts/build-enterprise-bundle.mjs
-          --output "${RUNNER_TEMP}/qodo-enterprise-release"
-          --commit "${{ steps.release-source.outputs.commit }}"
+      - name: Materialize the immutable release source
+        env:
+          RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
+        run: |
+          set -euo pipefail
+          RELEASE_SOURCE_DIR="${RUNNER_TEMP}/qodo-release-source"
+          git worktree add --detach "${RELEASE_SOURCE_DIR}" "${RELEASE_COMMIT}"
+          test "$(git -C "${RELEASE_SOURCE_DIR}" rev-parse HEAD)" = "${RELEASE_COMMIT}"
+          test -z "$(git -C "${RELEASE_SOURCE_DIR}" status --porcelain --untracked-files=all)"
+
+      - name: Build the deterministic enterprise bundle from the immutable source
+        env:
+          RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
+        run: |
+          set -euo pipefail
+          node "${RUNNER_TEMP}/qodo-release-source/scripts/build-enterprise-bundle.mjs" \
+            --output "${RUNNER_TEMP}/qodo-enterprise-release" \
+            --commit "${RELEASE_COMMIT}"
+          node "${RUNNER_TEMP}/qodo-release-source/scripts/release-notes.mjs" \
+            "${RUNNER_TEMP}/qodo-release-notes.md"
 
       - name: Publish the immutable tag and GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           QODO_ENTERPRISE_RELEASE_DIR: ${{ runner.temp }}/qodo-enterprise-release
           QODO_RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
+          QODO_RELEASE_NOTES_FILE: ${{ runner.temp }}/qodo-release-notes.md
+          QODO_RELEASE_SOURCE_DIR: ${{ runner.temp }}/qodo-release-source
         run: scripts/publish-release.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,27 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve the immutable release source commit
+        id: release-source
+        run: |
+          set -euo pipefail
+          VERSION="$(node -p "require('./distribution/catalog.json').package.version")"
+          TAG="v${VERSION}"
+          RELEASE_COMMIT="${GITHUB_SHA}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
+            if [[ "$(git cat-file -t "refs/tags/${TAG}")" != 'tag' ]]; then
+              echo "${TAG} is not an annotated tag; refusing recovery." >&2
+              exit 1
+            fi
+            RELEASE_COMMIT="$(git rev-parse "refs/tags/${TAG}^{}")"
+            if ! git merge-base --is-ancestor "${RELEASE_COMMIT}" "${GITHUB_SHA}"; then
+              echo "${TAG} is not an ancestor of current main; refusing recovery." >&2
+              exit 1
+            fi
+          fi
+          echo "commit=${RELEASE_COMMIT}" >> "${GITHUB_OUTPUT}"
+
       - name: Install locked validation dependencies
         run: npm ci
 
@@ -82,10 +103,11 @@ jobs:
         run: >-
           node scripts/build-enterprise-bundle.mjs
           --output "${RUNNER_TEMP}/qodo-enterprise-release"
-          --commit "${GITHUB_SHA}"
+          --commit "${{ steps.release-source.outputs.commit }}"
 
       - name: Publish the immutable tag and GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           QODO_ENTERPRISE_RELEASE_DIR: ${{ runner.temp }}/qodo-enterprise-release
+          QODO_RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
         run: scripts/publish-release.sh

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -76,9 +76,9 @@ a prior run created the protected tag and draft but stopped before publication. 
    protected-tag ruleset before creating any tag or release;
 4. creates annotated tag `v<package-version>`, pushes it without force, and verifies the protected
    remote tag peels to the validated SHA immediately before publication;
-5. builds the deterministic enterprise archive, then creates or resumes a draft release containing
-   the compact index, data-only CLI-managed bundle, enterprise manifest, enterprise archive, and
-   all four SHA-256 files;
+5. materializes the resolved release commit as a clean detached worktree and, before the
+   publication token is exposed, runs that tree's enterprise and release-note builders; publication
+   then uses only those prepared outputs plus that tree's index, CLI-managed bundle, and checksums;
 6. publishes the verified draft, which makes the release immutable;
 7. verifies the published release is immutable, the protected tag is unchanged, and all published
    assets still match the validated checkout byte-for-byte;
@@ -89,10 +89,12 @@ GitHub's release-by-tag REST endpoint does not expose draft releases. The publis
 both drafts and public releases through the paginated release list, rejects duplicate tag claims,
 and addresses the selected release by immutable numeric id. If reviewed release automation advances
 `main` after a draft was created, recovery may use the older tagged commit only when that tag is an
-ancestor of current `main` and an existing draft for the tag is present. The enterprise manifest is
-rebuilt with the tagged source commit, and every downloaded draft asset must match before the draft
-can become public. An older tag without its draft fails closed; tags and assets are never moved,
-deleted, or overwritten.
+ancestor of current `main` and an existing draft for the tag is present. Recovery checks out that
+exact tagged commit into a separate clean worktree; both enterprise packaging and every potentially
+missing release input are read from it, never from current `main`. The publisher revalidates the
+source worktree before mutation, and every downloaded draft asset must match before the draft can
+become public. An older tag without its draft fails closed; tags and assets are never moved, deleted,
+or overwritten.
 
 After that workflow succeeds, dispatch **release: publish skills compatibility channel** in
 `qodo-ai/qodo-in-cli` with the immutable `v<package-version>` tag. The workflow verifies the public

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -12,9 +12,12 @@ npm test
 ```
 
 `release:prepare` increments the affected skill and package versions, regenerates Claude, Codex,
-Kiro, and release-index artifacts, and writes `releases/v<version>.json`. CI rejects a changed
-workflow without a version bump, generated drift, a thin loader, package leakage, or an incomplete
-release record.
+Kiro, and release-index artifacts, and writes `releases/v<version>.json`. CI requires a version bump
+for skill bodies, generated projections, marketplace packaging, and artifact-generating automation;
+it also rejects generated drift, a thin loader, package leakage, or an incomplete release record.
+Operational release publication and validation code can advance independently because it changes no
+installed package bytes—this separation is what permits a reviewed fix to resume an existing tagged
+draft without inventing or moving a package version.
 
 The pull request must state:
 
@@ -63,7 +66,8 @@ token for that pre-publication check. The checked-in audit, runtime preflight, a
 missing credentials, disabled immutability, duplicate/invalid rulesets, forbidden creation rules,
 draft corruption, draft resume, publication, and immutable retry all fail closed.
 After the compatible CLI release is live and the skills PR is merged, a release owner dispatches
-**Release skills** from the current `main` head. Rerunning it is idempotent. The workflow:
+**Release skills** from the current `main` head. Rerunning it is idempotent, including recovery when
+a prior run created the protected tag and draft but stopped before publication. The workflow:
 
 1. requires the dispatched SHA to be the exact `main` head before and after validation; a merge
    after that final check does not change the validated release SHA;
@@ -76,10 +80,19 @@ After the compatible CLI release is live and the skills PR is merged, a release 
    the compact index, data-only CLI-managed bundle, enterprise manifest, enterprise archive, and
    all four SHA-256 files;
 6. publishes the verified draft, which makes the release immutable;
-7. verifies the published release is immutable, the protected tag is unchanged, and both published
+7. verifies the published release is immutable, the protected tag is unchanged, and all published
    assets still match the validated checkout byte-for-byte;
-8. on an idempotent rerun, downloads both existing assets, verifies their checksum, and compares
+8. on an idempotent rerun, downloads all eight existing assets, verifies their checksums, and compares
    them byte-for-byte with the validated checkout before reporting success.
+
+GitHub's release-by-tag REST endpoint does not expose draft releases. The publisher therefore finds
+both drafts and public releases through the paginated release list, rejects duplicate tag claims,
+and addresses the selected release by immutable numeric id. If reviewed release automation advances
+`main` after a draft was created, recovery may use the older tagged commit only when that tag is an
+ancestor of current `main` and an existing draft for the tag is present. The enterprise manifest is
+rebuilt with the tagged source commit, and every downloaded draft asset must match before the draft
+can become public. An older tag without its draft fails closed; tags and assets are never moved,
+deleted, or overwritten.
 
 After that workflow succeeds, dispatch **release: publish skills compatibility channel** in
 `qodo-ai/qodo-in-cli` with the immutable `v<package-version>` tag. The workflow verifies the public

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -78,7 +78,8 @@ a prior run created the protected tag and draft but stopped before publication. 
    remote tag peels to the validated SHA immediately before publication;
 5. materializes the resolved release commit as a clean detached worktree and, before the
    publication token is exposed, runs that tree's enterprise and release-note builders; publication
-   then uses only those prepared outputs plus that tree's index, CLI-managed bundle, and checksums;
+   then uses only those prepared outputs plus that tree's index, CLI-managed bundle, and checksums,
+   and requires the draft title and body to match the tagged-source metadata exactly;
 6. publishes the verified draft, which makes the release immutable;
 7. verifies the published release is immutable, the protected tag is unchanged, and all published
    assets still match the validated checkout byte-for-byte;
@@ -92,9 +93,9 @@ and addresses the selected release by immutable numeric id. If reviewed release 
 ancestor of current `main` and an existing draft for the tag is present. Recovery checks out that
 exact tagged commit into a separate clean worktree; both enterprise packaging and every potentially
 missing release input are read from it, never from current `main`. The publisher revalidates the
-source worktree before mutation, and every downloaded draft asset must match before the draft can
-become public. An older tag without its draft fails closed; tags and assets are never moved, deleted,
-or overwritten.
+source worktree, draft title, and draft body immediately before mutation, and every downloaded draft
+asset must match before the draft can become public. An older tag without its draft fails closed;
+tags and assets are never moved, deleted, or overwritten.
 
 After that workflow succeeds, dispatch **release: publish skills compatibility channel** in
 `qodo-ai/qodo-in-cli` with the immutable `v<package-version>` tag. The workflow verifies the public

--- a/scripts/fixtures/fake-release-gh.mjs
+++ b/scripts/fixtures/fake-release-gh.mjs
@@ -33,7 +33,12 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
     process.stderr.write('release list unavailable\n');
     process.exit(1);
   }
-  if (state.exists) process.stdout.write(`123\t${state.draft}\n`);
+  if (state.exists) {
+    process.stdout.write(`123\t${state.draft}\n`);
+    if (process.env.FAKE_DUPLICATE_RELEASES === 'true') {
+      process.stdout.write(`124\t${state.draft}\n`);
+    }
+  }
 } else if (args[0] === 'api' && /\/releases\/123$/.test(endpoint)) {
   const state = readState();
   if (!state.exists) process.exit(1);

--- a/scripts/fixtures/fake-release-gh.mjs
+++ b/scripts/fixtures/fake-release-gh.mjs
@@ -27,17 +27,27 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
   const valid = process.env.FAKE_RULESET_VALID !== 'false'
     && (process.env.FAKE_RULESET_HAS_CREATION !== 'true' || creationRejected === false);
   process.stdout.write(`${valid}\n`);
-} else if (args[0] === 'api' && endpoint.includes('/releases/tags/')) {
+} else if (args[0] === 'api' && endpoint.endsWith('/releases?per_page=100')) {
   const state = readState();
-  if (args.includes('--include')) {
-    if (process.env.FAKE_RELEASE_LOOKUP_ERROR === 'true') {
-      process.stderr.write('HTTP/2.0 503 Service Unavailable\n');
-      process.exit(1);
-    }
-    process.stdout.write(`HTTP/2.0 ${state.exists ? '200 OK' : '404 Not Found'}\n`);
-    if (!state.exists) process.exit(1);
-  } else if (!state.exists) process.exit(1);
-  else if (query === '.draft') process.stdout.write(`${state.draft}\n`);
+  if (process.env.FAKE_RELEASE_LOOKUP_ERROR === 'true') {
+    process.stderr.write('release list unavailable\n');
+    process.exit(1);
+  }
+  if (state.exists) process.stdout.write(`123\t${state.draft}\n`);
+} else if (args[0] === 'api' && /\/releases\/123$/.test(endpoint)) {
+  const state = readState();
+  if (!state.exists) process.exit(1);
+  if (args[args.indexOf('--method') + 1] === 'PATCH') {
+    const publishing = args.includes('draft=false');
+    const containing = args.includes('draft=true');
+    if (publishing === containing) throw new Error('Release patch must set exactly one draft state');
+    writeState({
+      ...state,
+      draft: containing,
+      immutable: publishing && process.env.FAKE_PUBLISHED_MUTABLE !== 'true',
+      edits: state.edits + 1,
+    });
+  } else if (query === '.draft') process.stdout.write(`${state.draft}\n`);
   else if (query === '.immutable') process.stdout.write(`${state.immutable}\n`);
   else if (query === '.assets[].name') process.stdout.write(`${state.assets.join('\n')}\n`);
   else if (query.includes('.assets[].name')) process.stdout.write(`${[...state.assets].sort().join(' ')}\n`);
@@ -98,19 +108,6 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
     writeFileSync(join(dir, 'qodo-skills-index.json'), 'corrupt\n');
   }
   writeState({ ...state, downloads });
-} else if (args[0] === 'release' && args[1] === 'edit') {
-  const publishing = args.includes('--draft=false');
-  const containing = args.includes('--draft=true');
-  if (!/^v\d+\.\d+\.\d+$/.test(args[2] ?? '') || publishing === containing) {
-    throw new Error('Release edit must specify a valid tag and exactly one draft state');
-  }
-  const state = readState();
-  writeState({
-    ...state,
-    draft: containing,
-    immutable: publishing && process.env.FAKE_PUBLISHED_MUTABLE !== 'true',
-    edits: state.edits + 1,
-  });
 } else {
   throw new Error(`Unsupported fake gh call: ${args.join(' ')}`);
 }

--- a/scripts/fixtures/fake-release-gh.mjs
+++ b/scripts/fixtures/fake-release-gh.mjs
@@ -7,9 +7,19 @@ const args = process.argv.slice(2);
 const statePath = process.env.FAKE_GH_STATE;
 if (!statePath) throw new Error('FAKE_GH_STATE is required');
 
-const readState = () => existsSync(statePath)
-  ? JSON.parse(readFileSync(statePath, 'utf8'))
-  : { exists: false, draft: false, immutable: false, assets: [], downloads: 0, edits: 0 };
+const readState = () => {
+  const state = existsSync(statePath)
+    ? JSON.parse(readFileSync(statePath, 'utf8'))
+    : { exists: false, draft: false, immutable: false, assets: [], downloads: 0, edits: 0 };
+  const tag = process.env.FAKE_RELEASE_TAG
+    ?? args.find((arg) => /^v\d+\.\d+\.\d+$/.test(arg)) ?? 'v0.0.0';
+  return {
+    ...state,
+    name: state.name ?? `Qodo skills ${tag}`,
+    body: state.body ?? (process.env.QODO_RELEASE_NOTES_FILE
+      ? readFileSync(process.env.QODO_RELEASE_NOTES_FILE, 'utf8') : ''),
+  };
+};
 const writeState = (state) => writeFileSync(statePath, `${JSON.stringify(state)}\n`);
 const endpoint = args.find((arg) =>
   arg.startsWith('repos/') || arg.startsWith('installation/')) ?? '';
@@ -54,6 +64,8 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
     });
   } else if (query === '.draft') process.stdout.write(`${state.draft}\n`);
   else if (query === '.immutable') process.stdout.write(`${state.immutable}\n`);
+  else if (query === '.name') process.stdout.write(`${state.name}\n`);
+  else if (query.includes('@base64')) process.stdout.write(`${Buffer.from(state.body).toString('base64')}\n`);
   else if (query === '.assets[].name') process.stdout.write(`${state.assets.join('\n')}\n`);
   else if (query.includes('.assets[].name')) process.stdout.write(`${[...state.assets].sort().join(' ')}\n`);
   else throw new Error(`Unsupported release query: ${query}`);
@@ -96,6 +108,10 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
     draft: true,
     immutable: false,
     assets: [...state.assets, ...assetNames],
+    ...(args[1] === 'create' ? {
+      name: args[args.indexOf('--title') + 1],
+      body: readFileSync(args[args.indexOf('--notes-file') + 1], 'utf8'),
+    } : {}),
   });
 } else if (args[0] === 'release' && args[1] === 'download') {
   if (!/^v\d+\.\d+\.\d+$/.test(args[2] ?? '') || args[args.indexOf('--pattern') + 1] !== 'qodo-*') {

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Create or resume a verified draft, then publish and re-verify immutable bytes.
 # Usage: GH_TOKEN=<contents-write-token> GITHUB_REPOSITORY=owner/repo GITHUB_SHA=<sha> \
-#   RUNNER_TEMP=<dir> QODO_ENTERPRISE_RELEASE_DIR=<prepared-assets-dir> scripts/publish-release.sh
+#   RUNNER_TEMP=<dir> QODO_ENTERPRISE_RELEASE_DIR=<prepared-assets-dir> \
+#   QODO_RELEASE_NOTES_FILE=<prepared-notes> QODO_RELEASE_SOURCE_DIR=<tagged-worktree> \
+#   scripts/publish-release.sh
 set -euo pipefail
 
 for tool in gh git node mktemp cmp rm basename; do
@@ -34,14 +36,36 @@ require_exact_release_checkout() {
 
 require_exact_release_checkout
 
-VERSION="$(node -p "require('./distribution/catalog.json').package.version")"
-TAG="v${VERSION}"
 RELEASE_COMMIT="${QODO_RELEASE_COMMIT:-${GITHUB_SHA}}"
 if [[ ! "${RELEASE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
   echo 'QODO_RELEASE_COMMIT must be a full lowercase commit SHA.' >&2
   exit 1
 fi
-NOTES="${RUNNER_TEMP}/qodo-release-notes.md"
+RELEASE_SOURCE_DIR="${QODO_RELEASE_SOURCE_DIR:-.}"
+if [[ ! -d "${RELEASE_SOURCE_DIR}" ]]; then
+  echo 'QODO_RELEASE_SOURCE_DIR must name the materialized release source tree.' >&2
+  exit 1
+fi
+RELEASE_SOURCE_DIR="$(cd "${RELEASE_SOURCE_DIR}" && pwd -P)"
+require_exact_release_source() {
+  if [[ "$(git -C "${RELEASE_SOURCE_DIR}" rev-parse HEAD)" != "${RELEASE_COMMIT}" ]]; then
+    echo 'Refusing to publish: release source HEAD is not QODO_RELEASE_COMMIT.' >&2
+    exit 1
+  fi
+  if [[ -n "$(git -C "${RELEASE_SOURCE_DIR}" status --porcelain --untracked-files=all)" ]]; then
+    echo 'Refusing to publish: the release source tree is not clean.' >&2
+    exit 1
+  fi
+}
+require_exact_release_source
+CURRENT_VERSION="$(node -p 'require(process.argv[1]).package.version' "$(pwd)/distribution/catalog.json")"
+VERSION="$(node -p 'require(process.argv[1]).package.version' "${RELEASE_SOURCE_DIR}/distribution/catalog.json")"
+if [[ "${VERSION}" != "${CURRENT_VERSION}" ]]; then
+  echo 'Refusing to publish: current automation and immutable release source have different package versions.' >&2
+  exit 1
+fi
+TAG="v${VERSION}"
+NOTES="${QODO_RELEASE_NOTES_FILE:?QODO_RELEASE_NOTES_FILE is required}"
 ENTERPRISE_DIR="${QODO_ENTERPRISE_RELEASE_DIR:?QODO_ENTERPRISE_RELEASE_DIR is required}"
 ARCHIVE_NAME="qodo-enterprise-bundle-v${VERSION}.tar.gz"
 RELEASE_ASSETS=(
@@ -49,19 +73,18 @@ RELEASE_ASSETS=(
   "${ENTERPRISE_DIR}/${ARCHIVE_NAME}.sha256"
   "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json"
   "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json.sha256"
-  distribution/qodo-cli-managed-bundle.json
-  distribution/qodo-cli-managed-bundle.json.sha256
-  distribution/qodo-skills-index.json
-  distribution/qodo-skills-index.json.sha256
+  "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json"
+  "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json.sha256"
+  "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json"
+  "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json.sha256"
 )
 EXPECTED_ASSETS="$(node -e \
   'console.log(process.argv.slice(1).map((asset) => require("node:path").basename(asset)).sort().join(" "))' \
   "${RELEASE_ASSETS[@]}")"
-node scripts/release-notes.mjs "${NOTES}"
-
 for asset in "${RELEASE_ASSETS[@]}"; do
   test -f "${asset}" || { echo "Release asset is missing: ${asset}" >&2; exit 1; }
 done
+test -f "${NOTES}" || { echo "Release notes are missing: ${NOTES}" >&2; exit 1; }
 
 verify_release_assets() {
   local directory="$1"
@@ -72,10 +95,10 @@ verify_release_assets() {
     verify_sha256 "${ARCHIVE_NAME}.sha256"
     verify_sha256 qodo-enterprise-manifest.json.sha256
   )
-  cmp --silent "${directory}/qodo-skills-index.json" distribution/qodo-skills-index.json
-  cmp --silent "${directory}/qodo-skills-index.json.sha256" distribution/qodo-skills-index.json.sha256
-  cmp --silent "${directory}/qodo-cli-managed-bundle.json" distribution/qodo-cli-managed-bundle.json
-  cmp --silent "${directory}/qodo-cli-managed-bundle.json.sha256" distribution/qodo-cli-managed-bundle.json.sha256
+  cmp --silent "${directory}/qodo-skills-index.json" "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json"
+  cmp --silent "${directory}/qodo-skills-index.json.sha256" "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json.sha256"
+  cmp --silent "${directory}/qodo-cli-managed-bundle.json" "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json"
+  cmp --silent "${directory}/qodo-cli-managed-bundle.json.sha256" "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json.sha256"
   cmp --silent "${directory}/${ARCHIVE_NAME}" "${ENTERPRISE_DIR}/${ARCHIVE_NAME}"
   cmp --silent "${directory}/${ARCHIVE_NAME}.sha256" "${ENTERPRISE_DIR}/${ARCHIVE_NAME}.sha256"
   cmp --silent "${directory}/qodo-enterprise-manifest.json" "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json"
@@ -133,6 +156,7 @@ load_release() {
 }
 
 require_current_main
+require_exact_release_source
 
 load_release
 if [[ "${RELEASE_COMMIT}" != "${GITHUB_SHA}" && "${RELEASE_EXISTS}" != 'true' ]]; then
@@ -170,6 +194,7 @@ require_annotated_release_tag
 # not depend on main staying still: the tag and every asset remain bound to the
 # exact commit this job checked out and validated.
 require_current_main
+require_exact_release_source
 git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
 
 if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
@@ -227,6 +252,7 @@ verify_release_assets "${VERIFY_DIR}"
 
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag
+require_exact_release_source
 gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=false >/dev/null
 if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
   echo 'Published release is mutable. Enable repository release immutability before any consumer rollout.' >&2

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -85,6 +85,10 @@ for asset in "${RELEASE_ASSETS[@]}"; do
   test -f "${asset}" || { echo "Release asset is missing: ${asset}" >&2; exit 1; }
 done
 test -f "${NOTES}" || { echo "Release notes are missing: ${NOTES}" >&2; exit 1; }
+EXPECTED_TITLE="Qodo skills ${TAG}"
+EXPECTED_NOTES_BASE64="$(node -e \
+  'process.stdout.write(require("node:fs").readFileSync(process.argv[1]).toString("base64"))' \
+  "${NOTES}")"
 
 verify_release_assets() {
   local directory="$1"
@@ -155,6 +159,20 @@ load_release() {
   fi
 }
 
+require_release_metadata() {
+  local actual_title actual_notes_base64
+  actual_title="$(gh api "${RELEASE_ENDPOINT}" --jq '.name')"
+  if [[ "${actual_title}" != "${EXPECTED_TITLE}" ]]; then
+    echo "Existing release ${TAG} has unexpected title metadata; refusing to publish." >&2
+    exit 1
+  fi
+  actual_notes_base64="$(gh api "${RELEASE_ENDPOINT}" --jq '(.body // "") | @base64')"
+  if [[ "${actual_notes_base64}" != "${EXPECTED_NOTES_BASE64}" ]]; then
+    echo "Existing release ${TAG} has unexpected notes metadata; refusing to publish." >&2
+    exit 1
+  fi
+}
+
 require_current_main
 require_exact_release_source
 
@@ -164,6 +182,7 @@ if [[ "${RELEASE_COMMIT}" != "${GITHUB_SHA}" && "${RELEASE_EXISTS}" != 'true' ]]
   exit 1
 fi
 if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
+  require_release_metadata
   git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
   require_annotated_release_tag
   if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" != 'true' ]]; then
@@ -240,6 +259,7 @@ else
     echo "GitHub did not expose the newly created ${TAG} draft; refusing to continue." >&2
     exit 1
   fi
+  require_release_metadata
 fi
 
 test "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" = 'true'
@@ -253,6 +273,7 @@ verify_release_assets "${VERIFY_DIR}"
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag
 require_exact_release_source
+require_release_metadata
 gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=false >/dev/null
 if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
   echo 'Published release is mutable. Enable repository release immutability before any consumer rollout.' >&2
@@ -263,6 +284,7 @@ if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
 fi
 test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
   "${EXPECTED_ASSETS}"
+require_release_metadata
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag
 PUBLISHED_VERIFY_DIR="$(mktemp -d "${RUNNER_TEMP}/qodo-published-release-verify.XXXXXX")"

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -4,7 +4,7 @@
 #   RUNNER_TEMP=<dir> QODO_ENTERPRISE_RELEASE_DIR=<prepared-assets-dir> scripts/publish-release.sh
 set -euo pipefail
 
-for tool in gh git node mktemp cmp grep cat rm basename; do
+for tool in gh git node mktemp cmp rm basename; do
   command -v "${tool}" >/dev/null 2>&1 || {
     echo "Release publication requires '${tool}', but it is not available." >&2
     exit 1
@@ -36,6 +36,11 @@ require_exact_release_checkout
 
 VERSION="$(node -p "require('./distribution/catalog.json').package.version")"
 TAG="v${VERSION}"
+RELEASE_COMMIT="${QODO_RELEASE_COMMIT:-${GITHUB_SHA}}"
+if [[ ! "${RELEASE_COMMIT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo 'QODO_RELEASE_COMMIT must be a full lowercase commit SHA.' >&2
+  exit 1
+fi
 NOTES="${RUNNER_TEMP}/qodo-release-notes.md"
 ENTERPRISE_DIR="${QODO_ENTERPRISE_RELEASE_DIR:?QODO_ENTERPRISE_RELEASE_DIR is required}"
 ARCHIVE_NAME="qodo-enterprise-bundle-v${VERSION}.tar.gz"
@@ -91,34 +96,58 @@ require_annotated_release_tag() {
     echo "${TAG} is not an annotated tag; refusing to publish." >&2
     exit 1
   fi
-  if [[ "$(git rev-parse "refs/tags/${TAG}^{}")" != "${GITHUB_SHA}" ]]; then
+  if [[ "$(git rev-parse "refs/tags/${TAG}^{}")" != "${RELEASE_COMMIT}" ]]; then
     echo "${TAG} does not resolve to the validated release commit; refusing to publish." >&2
     exit 1
   fi
 }
 
+load_release() {
+  local releases release_count candidate_id candidate_draft
+  if ! releases="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+    --jq ".[] | select(.tag_name == \"${TAG}\") | [.id, .draft] | @tsv")"; then
+    echo "Could not determine whether ${TAG} already exists; refusing to create a release." >&2
+    exit 1
+  fi
+  release_count=0
+  RELEASE_ID=''
+  RELEASE_DRAFT=''
+  while IFS=$'\t' read -r candidate_id candidate_draft; do
+    if [[ -n "${candidate_id:-}" ]]; then
+      release_count=$((release_count + 1))
+      RELEASE_ID="${candidate_id}"
+      RELEASE_DRAFT="${candidate_draft}"
+    fi
+  done <<< "${releases}"
+  if [[ "${release_count}" -gt 1 ]]; then
+    echo "Multiple releases claim ${TAG}; refusing to choose one." >&2
+    exit 1
+  fi
+  if [[ "${release_count}" -eq 1 ]]; then
+    RELEASE_EXISTS=true
+    RELEASE_ENDPOINT="repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"
+  else
+    RELEASE_EXISTS=false
+    RELEASE_ENDPOINT=''
+  fi
+}
+
 require_current_main
 
-RELEASE_EXISTS=false
-RELEASE_LOOKUP="$(mktemp "${RUNNER_TEMP}/qodo-release-lookup.XXXXXX")"
-if gh api --include "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" >"${RELEASE_LOOKUP}" 2>&1; then
-  RELEASE_EXISTS=true
-elif ! grep -Eq '^HTTP/[0-9.]+ 404([[:space:]]|$)' "${RELEASE_LOOKUP}"; then
-  cat "${RELEASE_LOOKUP}" >&2
-  rm -f -- "${RELEASE_LOOKUP}"
-  echo "Could not determine whether ${TAG} already exists; refusing to create a release." >&2
+load_release
+if [[ "${RELEASE_COMMIT}" != "${GITHUB_SHA}" && "${RELEASE_EXISTS}" != 'true' ]]; then
+  echo 'A release commit behind current main may only resume an existing draft.' >&2
   exit 1
 fi
-rm -f -- "${RELEASE_LOOKUP}"
 if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
   git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
   require_annotated_release_tag
-  if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.draft')" != 'true' ]]; then
-    if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.immutable')" != 'true' ]]; then
+  if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" != 'true' ]]; then
+    if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
       echo "Existing public release ${TAG} is mutable; refusing to overwrite its assets." >&2
       exit 1
     fi
-    test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '[.assets[].name] | sort | join(" ")')" = \
+    test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
       "${EXPECTED_ASSETS}"
     VERIFY_DIR="$(mktemp -d "${RUNNER_TEMP}/qodo-release-verify.XXXXXX")"
     trap 'rm -rf -- "${VERIFY_DIR}"' EXIT
@@ -133,7 +162,7 @@ if git rev-parse --verify --quiet "refs/tags/${TAG}" >/dev/null; then
 else
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-  git tag --no-sign -a "${TAG}" "${GITHUB_SHA}" -m "Qodo skills ${TAG}"
+  git tag --no-sign -a "${TAG}" "${RELEASE_COMMIT}" -m "Qodo skills ${TAG}"
 fi
 require_annotated_release_tag
 
@@ -144,14 +173,14 @@ require_current_main
 git push origin "refs/tags/${TAG}:refs/tags/${TAG}"
 
 if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
-  if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.draft')" != 'true' ]]; then
+  if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" != 'true' ]]; then
     echo "Existing release ${TAG} left draft state before asset verification; refusing to mutate it." >&2
     exit 1
   fi
   EXISTING_ASSETS=()
   while IFS= read -r existing_asset; do
     [[ -n "${existing_asset}" ]] && EXISTING_ASSETS+=("${existing_asset}")
-  done < <(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.assets[].name')
+  done < <(gh api "${RELEASE_ENDPOINT}" --jq '.assets[].name')
   for existing_asset in "${EXISTING_ASSETS[@]}"; do
     expected=false
     for release_asset in "${RELEASE_ASSETS[@]}"; do
@@ -181,10 +210,15 @@ if [[ "${RELEASE_EXISTS}" == 'true' ]]; then
 else
   gh release create "${TAG}" --draft --verify-tag --title "Qodo skills ${TAG}" --notes-file "${NOTES}" \
     "${RELEASE_ASSETS[@]}"
+  load_release
+  if [[ "${RELEASE_EXISTS}" != 'true' || "${RELEASE_DRAFT}" != 'true' ]]; then
+    echo "GitHub did not expose the newly created ${TAG} draft; refusing to continue." >&2
+    exit 1
+  fi
 fi
 
-test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.draft')" = 'true'
-test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '[.assets[].name] | sort | join(" ")')" = \
+test "$(gh api "${RELEASE_ENDPOINT}" --jq '.draft')" = 'true'
+test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
   "${EXPECTED_ASSETS}"
 VERIFY_DIR="$(mktemp -d "${RUNNER_TEMP}/qodo-release-verify.XXXXXX")"
 trap 'rm -rf -- "${VERIFY_DIR}"' EXIT
@@ -193,15 +227,15 @@ verify_release_assets "${VERIFY_DIR}"
 
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag
-gh release edit "${TAG}" --draft=false
-if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.immutable')" != 'true' ]]; then
+gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=false >/dev/null
+if [[ "$(gh api "${RELEASE_ENDPOINT}" --jq '.immutable')" != 'true' ]]; then
   echo 'Published release is mutable. Enable repository release immutability before any consumer rollout.' >&2
-  if ! gh release edit "${TAG}" --draft=true; then
+  if ! gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=true >/dev/null; then
     echo 'CRITICAL: could not return the mutable release to draft; stop all consumer rollout.' >&2
   fi
   exit 1
 fi
-test "$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '[.assets[].name] | sort | join(" ")')" = \
+test "$(gh api "${RELEASE_ENDPOINT}" --jq '[.assets[].name] | sort | join(" ")')" = \
   "${EXPECTED_ASSETS}"
 git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
 require_annotated_release_tag

--- a/scripts/test-release-tag-protection.mjs
+++ b/scripts/test-release-tag-protection.mjs
@@ -1,0 +1,78 @@
+/** Verify that the remote repository rejects release-tag movement. */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const fixture = mkdtempSync(join(tmpdir(), 'qodo-release-lease-'));
+const origin = join(fixture, 'origin.git');
+const seed = join(fixture, 'seed');
+const runner = join(fixture, 'runner');
+const git = (cwd, args) => execFileSync('git', [
+  '-c', 'commit.gpgsign=false',
+  '-c', 'tag.gpgSign=false',
+  ...args,
+], { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+
+try {
+  git(fixture, ['init', '--bare', '--initial-branch=main', origin]);
+  const preReceive = join(origin, 'hooks', 'pre-receive');
+  writeFileSync(preReceive, [
+    '#!/usr/bin/env bash',
+    '# Description: reject updates and deletions of release tags in this bare-repository fixture.',
+    '# Usage: Git pre-receive hook; reads "<old-sha> <new-sha> <ref>" records from stdin.',
+    'set -euo pipefail',
+    'while read -r old_sha new_sha ref_name; do',
+    '  case "${ref_name}" in',
+    '    refs/tags/*)',
+    '      if [[ "${old_sha}" == *[!0]* ]]; then',
+    '        echo "immutable release tag update rejected: ${ref_name}" >&2',
+    '        exit 1',
+    '      fi',
+    '      ;;',
+    '  esac',
+    'done',
+    '',
+  ].join('\n'));
+  chmodSync(preReceive, 0o755);
+  git(fixture, ['clone', origin, seed]);
+  git(seed, ['config', 'user.name', 'Release Test']);
+  git(seed, ['config', 'user.email', 'release-test@qodo.invalid']);
+  writeFileSync(join(seed, 'release.txt'), 'v1\n');
+  git(seed, ['add', 'release.txt']);
+  git(seed, ['commit', '-m', 'release v1']);
+  const releaseSha = git(seed, ['rev-parse', 'HEAD']);
+  git(seed, ['push', 'origin', 'main']);
+
+  git(fixture, ['clone', origin, runner]);
+  git(runner, ['config', 'user.name', 'Release Test']);
+  git(runner, ['config', 'user.email', 'release-test@qodo.invalid']);
+  git(runner, ['tag', '-a', 'v1', '-m', 'v1']);
+  git(runner, ['push', 'origin', 'refs/tags/v1:refs/tags/v1']);
+  assert.equal(
+    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
+    releaseSha,
+  );
+
+  writeFileSync(join(seed, 'release.txt'), 'v2\n');
+  git(seed, ['add', 'release.txt']);
+  git(seed, ['commit', '-m', 'advance main']);
+  git(seed, ['push', 'origin', 'main']);
+
+  git(runner, ['fetch', 'origin', 'main']);
+  assert.notEqual(git(runner, ['rev-parse', 'origin/main']), releaseSha,
+    'the final release guard must observe an intervening main advance');
+  git(runner, ['tag', '-f', '-a', 'v1', '-m', 'moved v1', 'origin/main']);
+  assert.throws(() => git(runner, [
+    'push', '--force', 'origin', 'refs/tags/v1:refs/tags/v1',
+  ]), /immutable release tag update rejected/);
+  assert.equal(
+    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
+    releaseSha,
+  );
+} finally {
+  rmSync(fixture, { recursive: true, force: true });
+}
+
+console.log('Release tag protection test passed.');

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -311,6 +311,10 @@ try {
     { draft: published.draft, immutable: published.immutable, edits: published.edits, downloads: published.downloads },
     { draft: false, immutable: true, edits: 1, downloads: 2 },
   );
+  assert.throws(() => runShell(checkout, publishPath, {
+    ...publishEnv,
+    FAKE_DUPLICATE_RELEASES: 'true',
+  }), new RegExp(`Multiple releases claim ${escapedReleaseTag}`));
 
   // A reviewed automation-only main advance can resume an already-tagged
   // draft, but all downloaded assets must still match the tagged release.

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -1,6 +1,7 @@
 /** Verify that release publication fails closed before creating mutable artifacts. */
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import {
   chmodSync,
   copyFileSync,
@@ -14,7 +15,6 @@ import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildEnterpriseBundle } from './build-enterprise-bundle.mjs';
-
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const workflow = readFileSync(join(root, '.github', 'workflows', 'release.yml'), 'utf8');
 const preflight = readFileSync(join(root, 'scripts', 'verify-release-prerequisites.sh'), 'utf8');
@@ -34,7 +34,10 @@ assert.match(workflow, /github\.ref == format\('refs\/heads\/\{0\}', github\.eve
   'the write-scoped release job must run only from the default branch');
 assert.match(workflow, /run: scripts\/verify-release-prerequisites\.sh/);
 assert.match(workflow, /run: scripts\/publish-release\.sh/);
-assert.match(workflow, /node scripts\/build-enterprise-bundle\.mjs/);
+assert.match(workflow, /qodo-release-source\/scripts\/build-enterprise-bundle\.mjs/);
+assert.match(workflow, /git worktree add --detach/);
+assert.match(workflow, /QODO_RELEASE_SOURCE_DIR: \$\{\{ runner\.temp \}\}\/qodo-release-source/);
+assert.match(workflow, /QODO_RELEASE_NOTES_FILE: \$\{\{ runner\.temp \}\}\/qodo-release-notes\.md/);
 assert.match(workflow, /QODO_ENTERPRISE_RELEASE_DIR/);
 assert.match(readFileSync(join(root, 'scripts', 'verify-release-prerequisites.cmd'), 'utf8'),
   /bash "%~dp0verify-release-prerequisites\.sh"/);
@@ -57,7 +60,7 @@ const publisherFinalMainGuard = publisher.lastIndexOf('require_current_main');
 const publisherTagPush = publisher.indexOf('git push origin "refs/tags/${TAG}:refs/tags/${TAG}"');
 const releaseTokenCheck = releaseSource.indexOf('installation-wide, read-only GitHub App token with Administration:read is required');
 const checkoutGuard = publisher.indexOf('\nrequire_exact_release_checkout\n');
-const catalogRead = publisher.indexOf('require(\'./distribution/catalog.json\')');
+const catalogRead = publisher.indexOf('CURRENT_VERSION=');
 const tagRulesetCheck = releaseSource.indexOf('Immutable release tags ruleset is required');
 const releaseVerificationHelper = releaseSource.indexOf('verify_release_assets()');
 const releaseDownload = releaseSource.indexOf('gh release download');
@@ -164,6 +167,8 @@ assert.match(workflow, /id: release-source/);
 assert.match(workflow, /git merge-base --is-ancestor/);
 assert.match(workflow, /QODO_RELEASE_COMMIT: \$\{\{ steps\.release-source\.outputs\.commit \}\}/);
 assert.match(publisher, /A release commit behind current main may only resume an existing draft/);
+assert.match(publisher, /git -C "\$\{RELEASE_SOURCE_DIR\}" rev-parse HEAD/);
+assert.match(publisher, /release source HEAD is not QODO_RELEASE_COMMIT/);
 assert.match(releaseSource, /gh release upload "\$\{TAG\}"/,
   'a partial draft publication must be resumable without abandoning the version');
 assert.doesNotMatch(releaseSource, /gh release upload[^\n]*--clobber/,
@@ -187,7 +192,6 @@ assert.match(
   /^\*\.sh text eol=lf$/m,
   'Git Bash entrypoints must remain LF-only on Windows',
 );
-
 const run = (cwd, command, args = [], env = {}) => execFileSync(command, args, {
   cwd,
   encoding: 'utf8',
@@ -278,8 +282,11 @@ try {
   run(harness, 'git', ['init', '--bare', '--initial-branch=main', behaviorOrigin]);
   run(checkout, 'git', ['remote', 'add', 'origin', behaviorOrigin]);
   run(checkout, 'git', ['push', '-u', 'origin', 'main']);
-  // The publisher owns the tag's format. A runner-level signing preference
-  // must not introduce a pinentry/key dependency into an automated release.
+  const releaseSourceCheckout = join(harness, 'release-source');
+  run(checkout, 'git', ['worktree', 'add', '--detach', releaseSourceCheckout, releaseSha]);
+  const releaseNotes = join(harness, 'release-notes.md');
+  run(releaseSourceCheckout, process.execPath, [join(releaseSourceCheckout, 'scripts', 'release-notes.mjs'), releaseNotes]);
+  // The publisher owns the tag format even when the runner prefers signed tags.
   run(checkout, 'git', ['config', 'tag.gpgSign', 'true']);
 
   const publishEnv = {
@@ -288,6 +295,8 @@ try {
     GITHUB_SHA: releaseSha,
     RUNNER_TEMP: harness,
     QODO_ENTERPRISE_RELEASE_DIR: enterpriseDir,
+    QODO_RELEASE_NOTES_FILE: releaseNotes,
+    QODO_RELEASE_SOURCE_DIR: releaseSourceCheckout,
   };
   const publishPath = join(checkout, 'scripts', 'publish-release.sh');
   assert.throws(() => runShell(checkout, publishPath, {
@@ -325,7 +334,12 @@ try {
     downloads: 0,
     edits: 0,
   })}\n`);
-  run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-m', 'release recovery automation']);
+  const divergentIndex = '{"currentMainOnly":true}\n';
+  writeFileSync(join(checkout, 'distribution', 'qodo-skills-index.json'), divergentIndex);
+  writeFileSync(join(checkout, 'distribution', 'qodo-skills-index.json.sha256'),
+    `${createHash('sha256').update(divergentIndex).digest('hex')}  qodo-skills-index.json\n`);
+  run(checkout, 'git', ['add', 'distribution']);
+  run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '-m', 'release recovery automation']);
   const recoverySha = run(checkout, 'git', ['rev-parse', 'HEAD']).trim();
   run(checkout, 'git', ['push', 'origin', 'main']);
   runShell(checkout, publishPath, {

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -26,7 +26,6 @@ const packageVersion = JSON.parse(
 ).version;
 const releaseTag = `v${packageVersion}`;
 const escapedReleaseTag = releaseTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
 assert.doesNotMatch(releaseSource, /^\s+push:/m,
   'source merge must not bypass the CLI-first release order or an unmet credential gate');
 assert.match(releaseSource, /^\s+workflow_dispatch:/m);
@@ -73,7 +72,6 @@ const draftVerification = releaseSource.indexOf('verify_release_assets "${VERIFY
 const remoteTagCheck = releaseSource.indexOf('require_annotated_release_tag', draftCreation);
 const publishedDownload = releaseSource.indexOf('gh release download', draftPublish);
 const publishedVerification = releaseSource.indexOf('verify_release_assets "${PUBLISHED_VERIFY_DIR}"', publishedDownload);
-
 assert.match(protectionAudit, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/,
   'the administrator audit must check repository immutability');
 assert.match(preflight, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/,
@@ -205,7 +203,6 @@ const runShell = (cwd, script, env = {}) => process.platform === 'win32'
     '/d', '/c', 'call', script.replace(/\.sh$/, '.cmd'),
   ], env)
   : run(cwd, script, [], env);
-
 // Keep a space in the harness path so Windows cmd /c quoting is exercised.
 const harness = mkdtempSync(join(tmpdir(), 'qodo release behavior-'));
 const bin = join(harness, 'bin');
@@ -222,8 +219,8 @@ const fakeGhEnv = {
   GITHUB_REPOSITORY: 'qodo-ai/qodo-skills',
   FAKE_GH_STATE: fakeGhState,
   FAKE_GH_ASSETS: fakeGhAssets,
+  FAKE_RELEASE_TAG: releaseTag,
 };
-
 try {
   const preflightPath = join(root, 'scripts', 'verify-release-prerequisites.sh');
   runShell(root, preflightPath, fakeGhEnv);
@@ -320,13 +317,19 @@ try {
     { draft: published.draft, immutable: published.immutable, edits: published.edits, downloads: published.downloads },
     { draft: false, immutable: true, edits: 1, downloads: 2 },
   );
+  for (const corruption of [{ name: 'wrong title' }, { body: 'wrong notes' }]) {
+    const corrupted = { ...published, ...corruption, draft: true, immutable: false, edits: 0, downloads: 0 };
+    writeFileSync(fakeGhState, `${JSON.stringify(corrupted)}\n`);
+    assert.throws(() => runShell(checkout, publishPath, publishEnv), /unexpected .* metadata/);
+    assert.deepEqual(JSON.parse(readFileSync(fakeGhState, 'utf8')), corrupted);
+  }
+  writeFileSync(fakeGhState, `${JSON.stringify(published)}\n`);
   assert.throws(() => runShell(checkout, publishPath, {
     ...publishEnv,
     FAKE_DUPLICATE_RELEASES: 'true',
   }), new RegExp(`Multiple releases claim ${escapedReleaseTag}`));
 
-  // A reviewed automation-only main advance can resume an already-tagged
-  // draft, but all downloaded assets must still match the tagged release.
+  // Recovery from reviewed automation changes must still use tagged bytes.
   writeFileSync(fakeGhState, `${JSON.stringify({
     ...published,
     draft: true,
@@ -376,8 +379,7 @@ try {
   run(checkout, 'git', ['push', '--force', 'origin', 'main']);
   writeFileSync(fakeGhState, `${JSON.stringify(recovered)}\n`);
 
-  // A lightweight tag at the correct commit is still not the release object
-  // promised by the publication contract.
+  // A lightweight tag is not the promised release object.
   run(checkout, 'git', ['tag', '-d', releaseTag]);
   run(checkout, 'git', ['push', 'origin', `:refs/tags/${releaseTag}`]);
   run(checkout, 'git', ['-c', 'tag.gpgSign=false', 'tag', releaseTag, releaseSha]);
@@ -434,7 +436,6 @@ try {
   assert.equal(rejectedDraft.edits, 0);
   runShell(checkout, publishPath, publishEnv);
   assert.equal(JSON.parse(readFileSync(fakeGhState, 'utf8')).immutable, true);
-
   // A pre-existing public mutable release is never eligible for draft resume.
   const publicMutable = {
     exists: true,
@@ -468,8 +469,7 @@ try {
     { draft: true, immutable: false, edits: 2 },
   );
 
-  // The final public download is independently verified after publication.
-  // A mismatch burns this immutable version and must still fail the workflow.
+  // A final-download mismatch burns the immutable version and fails the workflow.
   writeFileSync(fakeGhState, `${JSON.stringify({
     exists: true,
     draft: true,

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -51,7 +51,7 @@ const validationRun = releaseSource.indexOf('npm test');
 const existingReleaseBranch = releaseSource.indexOf('if [[ "${RELEASE_EXISTS}"');
 const toolChecks = releaseSource.indexOf('for tool in gh git node npm mktemp sha256sum cmp rm; do');
 const firstMainGuard = releaseSource.indexOf('require_current_main');
-const publisherReleaseLookup = publisher.indexOf('RELEASE_LOOKUP=');
+const publisherReleaseLookup = publisher.indexOf('load_release');
 const publisherTagCreation = publisher.indexOf('git tag --no-sign -a');
 const publisherFinalMainGuard = publisher.lastIndexOf('require_current_main');
 const publisherTagPush = publisher.indexOf('git push origin "refs/tags/${TAG}:refs/tags/${TAG}"');
@@ -63,7 +63,7 @@ const releaseVerificationHelper = releaseSource.indexOf('verify_release_assets()
 const releaseDownload = releaseSource.indexOf('gh release download');
 const downloadedVerification = releaseSource.indexOf('verify_release_assets "${VERIFY_DIR}"', releaseDownload);
 const draftCreation = releaseSource.indexOf('gh release create "${TAG}" --draft');
-const draftPublish = releaseSource.indexOf('gh release edit "${TAG}" --draft=false');
+const draftPublish = releaseSource.indexOf('gh api --method PATCH "${RELEASE_ENDPOINT}" -F draft=false');
 const draftAssetCheck = releaseSource.indexOf('.assets[].name', draftCreation);
 const draftDownload = releaseSource.indexOf('gh release download', draftCreation);
 const draftVerification = releaseSource.indexOf('verify_release_assets "${VERIFY_DIR}"', draftDownload);
@@ -106,7 +106,7 @@ assert.match(publisher, /shasum -a 256 --check/);
 assert.match(publisher, /verify_sha256 qodo-skills-index\.json\.sha256/g);
 assert.doesNotMatch(releaseSource, /"\$GITHUB_SHA"/,
   'scalar shell variables must use braced expansion');
-assert.match(publisher, /releases\/tags\/\$\{TAG\}" --jq '\.immutable'/,
+assert.match(publisher, /gh api "\$\{RELEASE_ENDPOINT\}" --jq '\.immutable'/,
   'publication must verify the provider reports an immutable release');
 assert.ok(firstAssetCheck >= 0 && firstAssetCheck < existingReleaseExit,
   'an existing release must be accepted only after its assets are verified');
@@ -156,8 +156,14 @@ assert.ok(publishedDownload > draftPublish,
 assert.ok(publishedVerification > publishedDownload,
   'published immutable assets must still match their checksums and validated bytes');
 assert.match(releaseSource, /RELEASE_EXISTS=false/);
-assert.match(releaseSource, /gh api --include/);
-assert.match(releaseSource, /HTTP\/\[0-9\.\]\+ 404/);
+assert.match(releaseSource, /releases\?per_page=100/,
+  'draft discovery must use the release list because GitHub release-by-tag returns 404 for drafts');
+assert.doesNotMatch(publisher, /releases\/tags\/\$\{TAG\}/,
+  'draft reads must use the release ID returned by the list endpoint');
+assert.match(workflow, /id: release-source/);
+assert.match(workflow, /git merge-base --is-ancestor/);
+assert.match(workflow, /QODO_RELEASE_COMMIT: \$\{\{ steps\.release-source\.outputs\.commit \}\}/);
+assert.match(publisher, /A release commit behind current main may only resume an existing draft/);
 assert.match(releaseSource, /gh release upload "\$\{TAG\}"/,
   'a partial draft publication must be resumable without abandoning the version');
 assert.doesNotMatch(releaseSource, /gh release upload[^\n]*--clobber/,
@@ -306,6 +312,52 @@ try {
     { draft: false, immutable: true, edits: 1, downloads: 2 },
   );
 
+  // A reviewed automation-only main advance can resume an already-tagged
+  // draft, but all downloaded assets must still match the tagged release.
+  writeFileSync(fakeGhState, `${JSON.stringify({
+    ...published,
+    draft: true,
+    immutable: false,
+    downloads: 0,
+    edits: 0,
+  })}\n`);
+  run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-m', 'release recovery automation']);
+  const recoverySha = run(checkout, 'git', ['rev-parse', 'HEAD']).trim();
+  run(checkout, 'git', ['push', 'origin', 'main']);
+  runShell(checkout, publishPath, {
+    ...publishEnv,
+    GITHUB_SHA: recoverySha,
+    QODO_RELEASE_COMMIT: releaseSha,
+  });
+  const recovered = JSON.parse(readFileSync(fakeGhState, 'utf8'));
+  assert.deepEqual(
+    { draft: recovered.draft, immutable: recovered.immutable, edits: recovered.edits, downloads: recovered.downloads },
+    { draft: false, immutable: true, edits: 1, downloads: 2 },
+  );
+  run(checkout, 'git', ['reset', '--hard', releaseSha]);
+  run(checkout, 'git', ['push', '--force', 'origin', 'main']);
+
+  // An older tag without a matching draft can never borrow current-main bytes.
+  writeFileSync(fakeGhState, `${JSON.stringify({
+    exists: false,
+    draft: false,
+    immutable: false,
+    assets: [],
+    downloads: 0,
+    edits: 0,
+  })}\n`);
+  run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '--allow-empty', '-m', 'unsafe untagged recovery']);
+  const unsafeRecoverySha = run(checkout, 'git', ['rev-parse', 'HEAD']).trim();
+  run(checkout, 'git', ['push', 'origin', 'main']);
+  assert.throws(() => runShell(checkout, publishPath, {
+    ...publishEnv,
+    GITHUB_SHA: unsafeRecoverySha,
+    QODO_RELEASE_COMMIT: releaseSha,
+  }), /may only resume an existing draft/);
+  run(checkout, 'git', ['reset', '--hard', releaseSha]);
+  run(checkout, 'git', ['push', '--force', 'origin', 'main']);
+  writeFileSync(fakeGhState, `${JSON.stringify(recovered)}\n`);
+
   // A lightweight tag at the correct commit is still not the release object
   // promised by the publication contract.
   run(checkout, 'git', ['tag', '-d', releaseTag]);
@@ -426,74 +478,5 @@ try {
   rmSync(harness, { recursive: true, force: true });
 }
 
-const fixture = mkdtempSync(join(tmpdir(), 'qodo-release-lease-'));
-const origin = join(fixture, 'origin.git');
-const seed = join(fixture, 'seed');
-const runner = join(fixture, 'runner');
-const git = (cwd, args) => execFileSync('git', [
-  '-c', 'commit.gpgsign=false',
-  '-c', 'tag.gpgSign=false',
-  ...args,
-], { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
-
-try {
-  git(fixture, ['init', '--bare', '--initial-branch=main', origin]);
-  const preReceive = join(origin, 'hooks', 'pre-receive');
-  writeFileSync(preReceive, [
-    '#!/usr/bin/env bash',
-    '# Description: reject updates and deletions of release tags in this bare-repository fixture.',
-    '# Usage: Git pre-receive hook; reads "<old-sha> <new-sha> <ref>" records from stdin.',
-    'set -euo pipefail',
-    'while read -r old_sha new_sha ref_name; do',
-    '  case "${ref_name}" in',
-    '    refs/tags/*)',
-    '      if [[ "${old_sha}" == *[!0]* ]]; then',
-    '        echo "immutable release tag update rejected: ${ref_name}" >&2',
-    '        exit 1',
-    '      fi',
-    '      ;;',
-    '  esac',
-    'done',
-    '',
-  ].join('\n'));
-  chmodSync(preReceive, 0o755);
-  git(fixture, ['clone', origin, seed]);
-  git(seed, ['config', 'user.name', 'Release Test']);
-  git(seed, ['config', 'user.email', 'release-test@qodo.invalid']);
-  writeFileSync(join(seed, 'release.txt'), 'v1\n');
-  git(seed, ['add', 'release.txt']);
-  git(seed, ['commit', '-m', 'release v1']);
-  const releaseSha = git(seed, ['rev-parse', 'HEAD']);
-  git(seed, ['push', 'origin', 'main']);
-
-  git(fixture, ['clone', origin, runner]);
-  git(runner, ['config', 'user.name', 'Release Test']);
-  git(runner, ['config', 'user.email', 'release-test@qodo.invalid']);
-  git(runner, ['tag', '-a', 'v1', '-m', 'v1']);
-  git(runner, ['push', 'origin', 'refs/tags/v1:refs/tags/v1']);
-  assert.equal(
-    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
-    releaseSha,
-  );
-
-  writeFileSync(join(seed, 'release.txt'), 'v2\n');
-  git(seed, ['add', 'release.txt']);
-  git(seed, ['commit', '-m', 'advance main']);
-  git(seed, ['push', 'origin', 'main']);
-
-  git(runner, ['fetch', 'origin', 'main']);
-  assert.notEqual(git(runner, ['rev-parse', 'origin/main']), releaseSha,
-    'the final release guard must observe an intervening main advance');
-  git(runner, ['tag', '-f', '-a', 'v1', '-m', 'moved v1', 'origin/main']);
-  assert.throws(() => git(runner, [
-    'push', '--force', 'origin', 'refs/tags/v1:refs/tags/v1',
-  ]), /immutable release tag update rejected/);
-  assert.equal(
-    git(runner, ['ls-remote', 'origin', 'refs/tags/v1^{}']).split(/\s+/)[0],
-    releaseSha,
-  );
-} finally {
-  rmSync(fixture, { recursive: true, force: true });
-}
-
 console.log('Release workflow safety test passed.');
+await import('./test-release-tag-protection.mjs');

--- a/scripts/test-release.mjs
+++ b/scripts/test-release.mjs
@@ -2,26 +2,14 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import {
-  appendFileSync,
-  cpSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  lstatSync,
-  readlinkSync,
-  readFileSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
+  appendFileSync, cpSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync,
+  readdirSync, readlinkSync, renameSync, rmSync, symlinkSync, writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import assert from 'node:assert/strict';
 import { incrementVersion } from './prepare-release.mjs';
-
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const temporaryRoot = mkdtempSync(join(tmpdir(), 'qodo-skills-release-'));
 const repositoryRoot = join(temporaryRoot, 'repository');
@@ -31,7 +19,6 @@ const sourceReview = sourceCatalog.skills.find((skill) => skill.name === 'qodo-r
 const expectedReviewVersion = incrementVersion(sourceReview.version, 'patch');
 const npmCli = process.env.npm_execpath;
 if (!npmCli) throw new Error('npm_execpath is unavailable; run this release test through npm test');
-
 try {
   mkdirSync(repositoryRoot);
   for (const name of readdirSync(root)) {
@@ -454,6 +441,19 @@ try {
   expectPackageVersionChange('scripts/build-enterprise-bundle.mjs', '\n// enterprise packaging change\n');
   expectPackageVersionChange('scripts/prepare-release.mjs', '\n// release generator change\n');
   expectPackageVersionChange('.github/workflows/ship-marketplaces.yml', '\n# release workflow change\n');
+  const expectOperationalChange = (path, change) => {
+    resetToRelease();
+    appendFileSync(join(repositoryRoot, path), change);
+    commitScenario(`operational ${path} change`);
+    execFileSync(
+      process.execPath,
+      [join(repositoryRoot, 'scripts', 'validate-diff.mjs'), releaseCommit],
+      { cwd: repositoryRoot, stdio: 'pipe' },
+    );
+  };
+  expectOperationalChange('.github/workflows/release.yml', '\n# publication recovery change\n');
+  expectOperationalChange('scripts/publish-release.sh', '\n# publication recovery change\n');
+  expectOperationalChange('scripts/validate-diff.mjs', '\n// validation policy change\n');
   resetToRelease();
   const deletionCatalog = JSON.parse(readFileSync(catalogPath, 'utf8'));
   deletionCatalog.skills = deletionCatalog.skills.filter((skill) => skill.name !== 'qodo-review');

--- a/scripts/validate-diff.mjs
+++ b/scripts/validate-diff.mjs
@@ -136,15 +136,15 @@ const changedReleaseRecords = statuses.flatMap(({ status, path, sourcePath }) =>
   [sourcePath, path].filter((candidate) => candidate?.startsWith('releases/'))
     .map((candidate) => [status, candidate]));
 const versionedPackagePaths = [
-  /^\.github\/workflows\/(?:release|ship-marketplaces)\.yml$/,
+  /^\.github\/workflows\/ship-marketplaces\.yml$/,
   /^\.agents\/plugins\//,
   /^\.claude-plugin\//,
   /^codex-packages\//,
   /^kiro-power(?:-standards)?\//,
   /^packages\//,
   /^distribution\/(?:(?:catalog|codex-submissions|marketplaces)\.schema|codex-submissions|marketplaces)\.json$/,
-  /^scripts\/(?:build-cli-managed-bundle|build-enterprise-bundle|build-release-index|marketplace-release(?:-lock)?|prepare-release|release-notes|skill-provenance|sync-adapters|validate-diff)\.mjs$/,
-  /^scripts\/(?:audit-release-protections|publish-release|verify-kiro-release-source|verify-release-prerequisites)\.(?:cmd|sh)$/,
+  /^scripts\/(?:build-cli-managed-bundle|build-enterprise-bundle|build-release-index|marketplace-release(?:-lock)?|prepare-release|release-notes|skill-provenance|sync-adapters)\.mjs$/,
+  /^scripts\/(?:audit-release-protections|verify-kiro-release-source|verify-release-prerequisites)\.(?:cmd|sh)$/,
 ];
 const packagingChanged = files.some((path) => versionedPackagePaths.some((pattern) => pattern.test(path)));
 if (!changedSkills.size && !catalogChanged && !changedReleaseRecords.length && !packagingChanged) {


### PR DESCRIPTION
## Summary

- resume the existing v1.0.8 draft by numeric release ID
- materialize the protected tagged commit in a separate clean worktree
- build and verify every release input against that immutable source, never current-main bytes
- fail closed on duplicate tag claims, source drift, unexpected assets, or an older tag without its draft

## Validation

- npm test
- node scripts/validate-diff.mjs origin/main
- shellcheck scripts/publish-release.sh
- actionlint .github/workflows/release.yml

Supersedes #75 because GitHub kept its internal pull ref pinned to the pre-fix SHA after a normal fast-forward branch push.