### PR TITLE
docs: define native enterprise bundle importer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,9 +16,16 @@ lifecycle UI—not in workflow content or authority.
 | `qodo-skills` | canonical workflow bodies, package membership, versions, provider projections, marketplace packets, and the data-only CLI-managed compatibility bundle | credentials, API transport, installed host state |
 | Marketplace | install, cache, update, rollback, and removal of its Qodo plugin | Qodo runtime binary or login |
 | skills.sh | install, link/copy, scope, update, and removal for agents without a Qodo listing | Qodo runtime binary or login |
-| Enterprise bundle / QAR | immutable offline skill package, reviewed pin, same-origin download, and customer-controlled plugin rollout | public CLI binary contents or silent agent-root mutation |
+| Enterprise bundle / QAR | immutable offline skill package, reviewed pin, same-origin download, and lifecycle ownership of explicitly selected enterprise roots | public CLI binary contents or silent agent-root mutation |
 | CLI-managed compatibility channel | automatic updates only for byte-exact roots created by a shipped pre-cutover CLI | new installs, missing skills, marketplace/enterprise roots, user-modified copies |
-| Qodo CLI | login, credentials, managed-tool catalog, tool invocation, offline tool help, runtime update, stale-skill notices, and the CLI-managed compatibility updater | new skill installation, task-time playbooks, marketplace caches, enterprise plugin roots |
+| Qodo CLI | login, credentials, managed-tool catalog, tool invocation, offline tool help, runtime update, stale-skill notices, the compatibility updater, and the verified enterprise-bundle importer | authoring or embedding skills, task-time playbooks, marketplace caches, or roots owned by another lifecycle channel |
+
+The enterprise importer is a transport mechanism, not a second source of skill behavior. It is
+available only when the CLI's recorded private origin serves the QAR enterprise pointer, requires
+interactive target selection or explicit non-interactive flags, and copies the exact verified
+portable projection. Its receipt records `enterprise-bundle` ownership; future refreshes use only
+the recorded origin and update only unchanged owned roots. It never invokes skills.sh or a public
+registry, so the same path works in an air-gapped deployment.
 
 After an explicit migration command, the CLI may retire only byte-identical copies produced by a
 shipped CLI release. It atomically moves them out of the host skill name into a recoverable hidden
@@ -78,7 +85,9 @@ the finite CLI-managed cohort. The updater enrolls a root only when every byte m
 from an actually shipped CLI, records the installed digest, and refuses to overwrite subsequent
 drift. It never adds a missing skill, so optional Standards remains optional. Replacement is staged,
 verified, atomically renamed, and leaves the prior copy recoverable. Public users read the immutable
-qodo-skills release; on-prem users read the QAR-pinned copy from their recorded runtime origin.
+qodo-skills release through their marketplace or skills.sh owner; on-prem users read the QAR-pinned
+copy from their recorded runtime origin. The on-prem importer installs core only by default and
+preserves Standards as a separately selected package per root.
 
 ## Why workflows are embedded
 
@@ -114,4 +123,6 @@ Production-usage data prioritizes smoke testing but does not define an allowlist
   is necessary but not proof of marketplace acceptance.
 - Enterprise archives are deterministic, checksum-published, contain no CLI binary or credential,
   keep Standards opt-in, declare `DO_NOT_TRACK=1` for any skills-CLI-based enterprise import, and
-  are independently pinned by QAR.
+  are independently pinned by QAR. The native CLI importer does not use the skills CLI or public
+  network; it verifies pointer, manifest, archive, embedded identity, tar members, and complete
+  staged file digests before an atomic rename.

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -50,8 +50,9 @@ skills/<name>/ (authored once)
           └── CLI-managed bundle    current bytes for proven earlier CLI-managed roots
 
 qodo CLI ── login + runtime + tool help + version notice
-        ├── never creates a new skill installation after cutover
-        └── updates only roots carrying CLI-managed ownership proof
+        ├── public: never creates marketplace/skills.sh installations after cutover
+        ├── compatibility: updates only roots carrying CLI-managed ownership proof
+        └── enterprise: imports only an authenticated, same-origin QAR bundle after explicit consent
 
 QAR /toolbox ── independently pinned CLI + enterprise skills assets
              └── same-origin checksummed metadata; no public-network dependency at runtime

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -12,13 +12,15 @@ Qodo moves skill ownership out of the CLI without creating a second architecture
 - Claude Code, Codex, and Kiro receive complete generated skills through their official listings.
 - Compatible agents without a Qodo listing use skills.sh.
 - On-prem QAR deployments pin and serve one immutable enterprise archive beside the independently
-  pinned CLI; customer deployment tooling owns plugin rollout.
+  pinned CLI. The CLI natively imports its verified portable projection after explicit agent
+  selection; the enterprise bundle remains the lifecycle owner.
 - `qodo-standards` remains a separate optional package everywhere.
 - Existing users who keep the copies originally installed by the CLI continue receiving current
   skills automatically; marketplace migration is optional, not a support deadline.
 - The CLI authenticates and runs tools, updates itself, prints lifecycle guidance, emits stale-skill
   notices, and maintains only hash-exact CLI-managed copies through a separate compatibility channel.
-- No task-time playbook loader or general-purpose CLI skill installer ships in the cutover.
+- No task-time playbook loader or general-purpose public CLI skill installer ships in the cutover.
+  The enterprise importer is enabled only by a same-origin QAR bundle and needs no public registry.
 
 ## Why this design
 
@@ -172,17 +174,20 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 - QAR pins the skills version and hashes in a lock separate from its CLI lock, verifies and bakes
   both during the backend image build, and serves the skills index, CLI-managed bundle, and archive
   under `/toolbox`.
-- The compatible CLI fetches the CLI-managed bundle from the recorded QAR origin, so an on-prem
-  client never falls back to public GitHub. Only previously enrolled CLI-managed roots are updated;
-  enterprise plugin imports remain customer-controlled.
-- A customer deployment imports the matching host package through its approved local plugin
-  lifecycle. If that importer uses the skills CLI, every command runs with `DO_NOT_TRACK=1`, as
-  declared by the bundle manifest. Qodo Standards remains a separate explicit choice.
+- The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
+  public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
+  lifecycle owners.
+- After login, interactive setup offers a multi-select of supported local agents. The explicit
+  automation form is `qodo agents install --enterprise --agent <ids> --yes`. Both install core only
+  unless Standards is selected separately.
+- The native importer verifies and atomically applies the portable projection without `npx` or
+  skills.sh. A customer may instead use an approved host importer; when that path invokes the
+  skills CLI it runs with `DO_NOT_TRACK=1`, as declared by the manifest.
 
 Gate: deterministic archive rebuild; exact manifest/archive/index checksums; QAR offline image
 build and route tests; private-origin no-egress; telemetry-disabled skills-CLI import when used;
-fresh core import; Standards absent; enterprise
-bundle upgrade; new-session activation. The QAR PR cannot become merge-ready until the pinned
+fresh clean-machine core import; Standards absent; enterprise bundle upgrade; modified-copy
+preservation; retry no-op; new-session activation. The QAR PR cannot become merge-ready until the pinned
 immutable qodo-skills release exists at the exact bytes in its lock.
 
 Rollback: publish a new immutable skills patch and advance only the QAR skills pin. The CLI pin is

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -199,17 +199,22 @@ Every immutable skills release carries `qodo-enterprise-manifest.json` plus the 
 its CLI pin, verifies every byte while building the backend image, and serves it from the existing
 `/toolbox` origin. Its separate dependency workflow opens the reviewed skills-pin PR.
 
-The archive is an enterprise distribution input, not a hidden CLI payload. A customer deployment
-imports the host-specific package or portable local source through its approved plugin rollout.
-The manifest requires `DO_NOT_TRACK=1` whenever that rollout invokes the skills CLI; direct host
-imports need no skills CLI at all.
-The CLI reads QAR's same-origin compact index and CLI-managed bundle. It never copies enterprise
-archive contents into an agent root; only roots already proven to be CLI-managed are refreshed.
+The archive is an enterprise distribution input, not a hidden CLI payload. After authentication,
+the QAR-supplied CLI may import its exact portable projection only after interactive agent
+selection or explicit non-interactive flags. The receipt names `enterprise-bundle` as lifecycle
+owner; the CLI is only the verifier/copier and never embeds or authors those bytes. This native
+path uses no public registry. A customer may instead use an approved host-specific importer; the
+manifest requires `DO_NOT_TRACK=1` whenever that rollout invokes the skills CLI.
+
+The CLI reads QAR's same-origin compact index, CLI-managed bundle, and enterprise pointer. The
+compatibility updater still touches only proven historical CLI-managed roots. The enterprise
+updater separately touches only unchanged roots in its enterprise receipt, preserves foreign or
+modified roots, and never falls back to a public origin.
 
 Gate: deterministic rebuild, manifest/archive/index checksums, no credential or CLI bytes, core and
 Standards isolation, QAR same-origin download, private-origin no-egress behavior, telemetry-disabled
-skills-CLI use when applicable, and a customer
-plugin update followed by a new agent session.
+skills-CLI use when applicable, clean-machine native import, unchanged-copy update, modified-copy
+preservation, retry no-op, and a new agent session.
 
 ## Rollback
 


### PR DESCRIPTION
## Summary
- document the QAR-only native enterprise bundle applicator
- preserve marketplace and skills.sh ownership for public installs
- make clean-machine install, package isolation, safe update, and new-session activation explicit release gates

## Architecture
The CLI does not embed or author skills. After authenticated consent, it verifies and applies exact bytes from the same-origin QAR enterprise bundle; the receipt keeps `enterprise-bundle` as lifecycle owner. The historical CLI-managed compatibility channel remains separate.

## Validation
- `npm test`

Tracks [CLI-322](https://linear.app/qodo/issue/CLI-322/complete-marketplace-owned-skills-migration-and-gated-release). Strategy: [KB-366](https://app.notion.com/p/Qodo-marketplace-cutover-and-release-strategy-3c51a4c172d681eeb580d6a2b39650cf).