### PR TITLE
feat(enterprise): publish Agent Skills discovery feeds

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "plugins": [
     {

--- a/codex-packages/qodo-standards/.codex-plugin/plugin.json
+++ b/codex-packages/qodo-standards/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo-standards/plugin.json
+++ b/codex-packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/.codex-plugin/plugin.json
+++ b/codex-packages/qodo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/plugin.json
+++ b/codex-packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/distribution/catalog.json
+++ b/distribution/catalog.json
@@ -5,7 +5,7 @@
   "package": {
     "name": "qodo",
     "displayName": "Qodo for coding agents",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
     "repository": "https://github.com/qodo-ai/qodo-skills",
     "homepage": "https://www.qodo.ai",

--- a/distribution/qodo-cli-managed-bundle.json
+++ b/distribution/qodo-cli-managed-bundle.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "distribution": "qodo-cli-managed",
   "instructionMode": "embedded",
-  "packageVersion": "1.0.8",
+  "packageVersion": "1.0.9",
   "minimumCliVersion": "0.1.0-next.37",
   "source": {
     "repository": "https://github.com/qodo-ai/qodo-skills",
-    "tag": "v1.0.8"
+    "tag": "v1.0.9"
   },
   "aliases": {
     "codebase-wisdom": "qodo-codebase-wisdom",

--- a/distribution/qodo-cli-managed-bundle.json.sha256
+++ b/distribution/qodo-cli-managed-bundle.json.sha256
@@ -1,1 +1,1 @@
-b54f97b417219ce8c87c6edc030c45690354af7e9e831807ae9d277b9bdb682d  qodo-cli-managed-bundle.json
+990101a27371270b6ca0abab86e37288138639c85c50839ca5bb123c1ad6493e  qodo-cli-managed-bundle.json

--- a/distribution/qodo-skills-index.json
+++ b/distribution/qodo-skills-index.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "instructionMode": "embedded",
-  "packageVersion": "1.0.8",
+  "packageVersion": "1.0.9",
   "minimumCliVersion": "0.1.0-next.37",
   "repository": "https://github.com/qodo-ai/qodo-skills",
   "skills": {

--- a/distribution/qodo-skills-index.json.sha256
+++ b/distribution/qodo-skills-index.json.sha256
@@ -1,1 +1,1 @@
-7775b96dd9803f7c33caff0bbd7d63ad8fdfbb9653e022ad8e2a1533e71e87e6  qodo-skills-index.json
+8bc87c85d9f9f7d8b8e9baf91f70d0575e31aed1a67053ae89c708ced2805c78  qodo-skills-index.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,8 +2,8 @@
 
 ## Invariant
 
-> Qodo authors skills once; every installed root has one lifecycle owner. Marketplaces and the
-> enterprise bundle update plugin roots; the CLI-managed channel updates only roots created by
+> Qodo authors skills once; every installed root has one lifecycle owner. Marketplaces, skills.sh,
+> and the enterprise bundle update skills; the CLI-managed channel updates only roots created by
 > earlier Qodo CLI releases; the CLI updates the runtime.
 
 This is one architecture across every local coding agent. Providers differ only in packaging and
@@ -18,14 +18,17 @@ lifecycle UI—not in workflow content or authority.
 | skills.sh | install, link/copy, scope, update, and removal for agents without a Qodo listing | Qodo runtime binary or login |
 | Enterprise bundle / QAR | immutable offline skill package, reviewed pin, same-origin download, and lifecycle ownership of explicitly selected enterprise roots | public CLI binary contents or silent agent-root mutation |
 | CLI-managed compatibility channel | automatic updates only for byte-exact roots created by a shipped pre-cutover CLI | new installs, missing skills, marketplace/enterprise roots, user-modified copies |
-| Qodo CLI | login, credentials, managed-tool catalog, tool invocation, offline tool help, runtime update, stale-skill notices, the compatibility updater, and the verified enterprise-bundle importer | authoring or embedding skills, task-time playbooks, marketplace caches, or roots owned by another lifecycle channel |
+| Qodo CLI | login, credentials, managed-tool catalog, tool invocation, offline tool help, runtime update, stale-skill notices, the compatibility updater, and an authenticated launcher for the pinned enterprise skills engine | authoring or embedding skill bodies, maintaining agent mappings, parsing skill archives, task-time playbooks, marketplace caches, or roots owned by another lifecycle channel |
 
-The enterprise importer is a transport mechanism, not a second source of skill behavior. It is
-available only when the CLI's recorded private origin serves the QAR enterprise pointer, requires
-interactive target selection or explicit non-interactive flags, and copies the exact verified
-portable projection. Its receipt records `enterprise-bundle` ownership; future refreshes use only
-the recorded origin and update only unchanged owned roots. It never invokes skills.sh or a public
-registry, so the same path works in an air-gapped deployment.
+The enterprise command is a transport launcher, not a second installer implementation. It is
+available only when the CLI's recorded private origin serves QAR's path-scoped discovery feeds and
+requires authentication plus interactive target selection or explicit non-interactive consent.
+The CLI materializes a digest-verified packaging build of exact-pinned `skills@1.5.15` and forces
+`DO_NOT_TRACK=1`; that engine performs current agent discovery and installation. The client never
+contacts npm, skills.sh, GitHub, or a marketplace, so the same path works in an air-gapped deployment.
+The discovery manifest requires Qodo CLI `0.1.0-next.39` or newer, independently from the older
+package-wide compatibility floor. Updates remain prompted until that engine can prove modified-root
+preservation.
 
 After an explicit migration command, the CLI may retire only byte-identical copies produced by a
 shipped CLI release. It atomically moves them out of the host skill name into a recoverable hidden
@@ -121,8 +124,7 @@ Production-usage data prioritizes smoke testing but does not define an allowlist
   modified copies and marketplace/enterprise roots are preserved.
 - Provider-visible publication, fresh install, and upgrade tests are release gates; green source CI
   is necessary but not proof of marketplace acceptance.
-- Enterprise archives are deterministic, checksum-published, contain no CLI binary or credential,
-  keep Standards opt-in, declare `DO_NOT_TRACK=1` for any skills-CLI-based enterprise import, and
-  are independently pinned by QAR. The native CLI importer does not use the skills CLI or public
-  network; it verifies pointer, manifest, archive, embedded identity, tar members, and complete
-  staged file digests before an atomic rename.
+- Enterprise archives and discovery feeds are deterministic, digest-published, contain no CLI
+  binary or credential, keep Standards opt-in, declare `DO_NOT_TRACK=1`, and are independently
+  pinned by QAR. QAR verifies every feed/archive byte during its image build; the CLI verifies its
+  embedded helper by digest and delegates installation only after login and same-origin discovery.

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -4,23 +4,24 @@
 
 Qodo moves skill ownership out of the CLI without creating a second architecture:
 
-> Qodo authors skills once; every installed root has one lifecycle owner. Marketplaces and the
-> enterprise bundle update plugin roots; the CLI-managed channel updates only roots created by
-> earlier Qodo CLI releases;
-> the CLI updates the runtime.
+> Qodo authors skills once; every installed root has one lifecycle owner. Marketplaces, skills.sh,
+> or the enterprise bundle update skills; the CLI-managed channel updates only roots created by
+> earlier Qodo CLI releases; the CLI updates the runtime.
 
 - Claude Code, Codex, and Kiro receive complete generated skills through their official listings.
 - Compatible agents without a Qodo listing use skills.sh.
-- On-prem QAR deployments pin and serve one immutable enterprise archive beside the independently
-  pinned CLI. The CLI natively imports its verified portable projection after explicit agent
-  selection; the enterprise bundle remains the lifecycle owner.
+- On-prem QAR deployments pin the independently released CLI and skills assets. QAR exposes
+  path-scoped Agent Skills Discovery v0.2 feeds for core and Standards. After login, the CLI invokes
+  a build-pinned, telemetry-disabled skills lifecycle engine; that engine owns agent discovery and
+  installation while the enterprise bundle remains the content lifecycle owner.
 - `qodo-standards` remains a separate optional package everywhere.
 - Existing users who keep the copies originally installed by the CLI continue receiving current
   skills automatically; marketplace migration is optional, not a support deadline.
 - The CLI authenticates and runs tools, updates itself, prints lifecycle guidance, emits stale-skill
   notices, and maintains only hash-exact CLI-managed copies through a separate compatibility channel.
 - No task-time playbook loader or general-purpose public CLI skill installer ships in the cutover.
-  The enterprise importer is enabled only by a same-origin QAR bundle and needs no public registry.
+  The enterprise command is only an authenticated launcher for the same-origin QAR feeds; it does
+  not carry agent mappings, parse skill archives, or copy skill trees itself.
 
 ## Why this design
 
@@ -46,16 +47,17 @@ skills/<name>/ (authored once)
           ├── codex-packages/       Codex complete skills
           ├── kiro-power*/          Kiro Agent Plugins power packages
           ├── skills/               skills.sh source
-          ├── enterprise archive    Claude/Codex/Kiro/portable offline projections
+          ├── enterprise archive    offline projections and compatibility artifact
+          ├── discovery feeds       core + optional Standards, one digest-pinned archive per skill
           └── CLI-managed bundle    current bytes for proven earlier CLI-managed roots
 
-qodo CLI ── login + runtime + tool help + version notice
+qodo CLI ── login + runtime + tool help + version notice + pinned skills launcher
         ├── public: never creates marketplace/skills.sh installations after cutover
         ├── compatibility: updates only roots carrying CLI-managed ownership proof
-        └── enterprise: imports only an authenticated, same-origin QAR bundle after explicit consent
+        └── enterprise: delegates same-origin feed installation after authentication and consent
 
 QAR /toolbox ── independently pinned CLI + enterprise skills assets
-             └── same-origin checksummed metadata; no public-network dependency at runtime
+             └── path-scoped v0.2 feeds and digest-pinned archives; no runtime public egress
 ```
 
 ## Cutover sequence
@@ -169,26 +171,39 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 
 ### 2a. Prepare the on-prem enterprise lane
 
-- The immutable skills release includes a deterministic enterprise manifest, archive, and
-  checksums. The archive stamps `enterprise-bundle` provenance into complete Claude, Codex, Kiro,
-  and portable projections while preserving core/Standards package isolation.
+- The immutable skills release includes the deterministic enterprise compatibility archive plus
+  path-scoped Agent Skills Discovery v0.2 indexes for `qodo` and `qodo-standards`. Every feed entry
+  points to a deterministic, SHA-256-pinned single-skill archive with `enterprise-bundle`
+  provenance. Core and Standards never share an index.
 - QAR pins the skills version and hashes in a lock separate from its CLI lock, verifies and bakes
-  both during the backend image build, and serves the skills index, CLI-managed bundle, and archive
-  under `/toolbox`.
+  both during the backend image build, and serves the compatibility assets, discovery indexes, and
+  per-skill archives under `/toolbox/skills`.
 - The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
   public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
   lifecycle owners.
-- After login, interactive setup offers a multi-select of supported local agents. The explicit
-  automation form is `qodo agents install --enterprise --agent <ids> --yes`. Both install core only
-  unless Standards is selected separately.
-- The native importer verifies and atomically applies the portable projection without `npx` or
-  skills.sh. A customer may instead use an approved host importer; when that path invokes the
-  skills CLI it runs with `DO_NOT_TRACK=1`, as declared by the manifest.
+- After login, `qodo agents install --enterprise` opens the lifecycle engine's current detected-agent
+  multi-select and installs core globally. Qodo Standards remains absent unless explicitly selected.
+  Automation may pass current agent IDs with `--agent ... --yes`; the lifecycle engine, not Qodo's
+  CLI source, validates those IDs. A newly supported agent therefore needs only a reviewed helper
+  pin/release, never a new Qodo-owned mapping or copier.
+- The launcher suppresses only the parent process's build-derived agent-detection markers so running
+  setup from Codex or Claude cannot bypass multi-select and consent; it does not maintain target
+  paths or agent IDs.
+- The Qodo CLI release embeds a reproducible packaging build of exact-pinned `skills@1.5.15`, the
+  newest tested release that both supports discovery v0.2 and executes at Qodo's Node 20.6 floor.
+  It materializes that helper by SHA-256 under Qodo's private runtime directory and forces
+  `DO_NOT_TRACK=1`. No npm, npx, skills.sh, GitHub, or marketplace access occurs on the client.
+- Background maintenance checks only the QAR version pointer. When newer content exists it emits
+  the exact `qodo agents update --enterprise` action. Updates are never unattended: the user sees
+  the lifecycle engine's overwrite summary and confirms it. This remains the policy until the
+  upstream engine can prove modified-root preservation; local edits are not silently discarded.
+- The discovery manifest declares `minimumCliVersion: 0.1.0-next.39` independently from the
+  package-wide `.37` minimum. QAR rejects the feed until its CLI lock reaches that version.
 
-Gate: deterministic archive rebuild; exact manifest/archive/index checksums; QAR offline image
-build and route tests; private-origin no-egress; telemetry-disabled skills-CLI import when used;
-fresh clean-machine core import; Standards absent; enterprise bundle upgrade; modified-copy
-preservation; retry no-op; new-session activation. The QAR PR cannot become merge-ready until the pinned
+Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
+offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
+import at Node 20.6; fresh clean-machine core import into Codex and Claude; Standards absent;
+prompted upgrade; retry; new-session activation. The QAR PR cannot become merge-ready until the pinned
 immutable qodo-skills release exists at the exact bytes in its lock.
 
 Rollback: publish a new immutable skills patch and advance only the QAR skills pin. The CLI pin is
@@ -270,7 +285,8 @@ deleted.
 ## Update experience after cutover
 
 1. The marketplace or skills.sh publishes/observes the new complete skill.
-2. The CLI’s daily bounded metadata refresh may notice that the loaded skill version is stale.
+2. The CLI’s daily bounded metadata refresh may notice that the loaded skill version is stale. For
+   enterprise installs this is a detached QAR pointer check, never an unattended root mutation.
 3. The current Qodo command succeeds and emits `QODO_NOTICE` on stderr.
 4. The skill finishes the current task, inventories its lifecycle owner read-only, shows the fully
    resolved scope-preserving action, and asks once.

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -176,8 +176,10 @@ Rollback: publish a new immutable patch. Never replace the release asset.
   points to a deterministic, SHA-256-pinned single-skill archive with `enterprise-bundle`
   provenance. Core and Standards never share an index.
 - QAR pins the skills version and hashes in a lock separate from its CLI lock, verifies and bakes
-  both during the backend image build, and serves the compatibility assets, discovery indexes, and
-  per-skill archives under `/toolbox/skills`.
+  both during the backend image build, and serves each discovery index at
+  `/toolbox/skills/<package>/.well-known/agent-skills/index.json` and its digest-pinned archives at
+  `/toolbox/skills/<package>/artifacts/<asset>`. The index-relative `../../artifacts/<asset>` URL
+  resolves to that same package-scoped route; it does not escape `/toolbox/skills/<package>`.
 - The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
   public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
   lifecycle owners.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -193,28 +193,33 @@ representative non-marketplace agents, including multi-agent and project/global 
 
 ## 6. QAR enterprise channel
 
-Every immutable skills release carries `qodo-enterprise-manifest.json` plus the deterministic
-`qodo-enterprise-bundle-v<version>.tar.gz` and checksums. The manifest carries the package's
+Every immutable skills release carries `qodo-enterprise-manifest.json`, the deterministic
+`qodo-enterprise-bundle-v<version>.tar.gz`, separate core/Standards Agent Skills Discovery v0.2
+indexes, and one digest-pinned archive per skill. The manifest carries the package's
 `minimumCliVersion`; QAR must reject the bundle when its independent CLI lock is older. QAR pins that release independently from
 its CLI pin, verifies every byte while building the backend image, and serves it from the existing
 `/toolbox` origin. Its separate dependency workflow opens the reviewed skills-pin PR.
 
-The archive is an enterprise distribution input, not a hidden CLI payload. After authentication,
-the QAR-supplied CLI may import its exact portable projection only after interactive agent
-selection or explicit non-interactive flags. The receipt names `enterprise-bundle` as lifecycle
-owner; the CLI is only the verifier/copier and never embeds or authors those bytes. This native
-path uses no public registry. A customer may instead use an approved host-specific importer; the
-manifest requires `DO_NOT_TRACK=1` whenever that rollout invokes the skills CLI.
+The discovery section has its own runtime minimum. QAR enforces the greater of the package-wide
+minimum and the discovery minimum, so compatibility assets can retain their older floor without
+allowing a discovery-capable bundle to pair with an incapable CLI.
+
+The archive and discovery feeds are enterprise distribution inputs, not hidden CLI payloads. After
+authentication, the QAR-supplied CLI launches its build-pinned skills engine against the same-origin
+core feed; Standards uses a separate feed and remains explicit. The CLI embeds no skill body,
+agent registry, or archive installer. It forces `DO_NOT_TRACK=1`, and client runtime needs no public
+registry or package-manager access.
 
 The CLI reads QAR's same-origin compact index, CLI-managed bundle, and enterprise pointer. The
 compatibility updater still touches only proven historical CLI-managed roots. The enterprise
-updater separately touches only unchanged roots in its enterprise receipt, preserves foreign or
-modified roots, and never falls back to a public origin.
+checker never mutates roots in the background or falls back to a public origin. It emits
+`qodo agents update --enterprise`; the user then reviews the lifecycle engine's overwrite summary
+and confirms the update.
 
-Gate: deterministic rebuild, manifest/archive/index checksums, no credential or CLI bytes, core and
-Standards isolation, QAR same-origin download, private-origin no-egress behavior, telemetry-disabled
-skills-CLI use when applicable, clean-machine native import, unchanged-copy update, modified-copy
-preservation, retry no-op, and a new agent session.
+Gate: deterministic rebuild, manifest/archive/discovery digests, no credential or CLI bytes, core
+and Standards isolation, QAR same-origin download, private-origin no-egress behavior,
+telemetry-disabled pinned-helper use at Node 20.6, clean-machine delegated import, prompted update,
+retry, and a new agent session.
 
 ## Rollback
 

--- a/kiro-power-standards/plugin.json
+++ b/kiro-power-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qodo/agent-skills",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "MIT",
       "devDependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "description": "Canonical Qodo skills and local coding-agent marketplace adapters.",
   "type": "module",

--- a/packages/qodo-standards/.claude-plugin/plugin.json
+++ b/packages/qodo-standards/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo-standards/plugin.json
+++ b/packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/.claude-plugin/plugin.json
+++ b/packages/qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/plugin.json
+++ b/packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/releases/v1.0.9.json
+++ b/releases/v1.0.9.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.9",
+  "summary": "Add Agent Skills Discovery feeds for thin enterprise installation",
+  "package": {
+    "change": "patch"
+  },
+  "runtimeProtocolVersion": 2,
+  "minimumCliVersion": "0.1.0-next.37",
+  "skills": []
+}

--- a/scripts/build-enterprise-bundle.mjs
+++ b/scripts/build-enterprise-bundle.mjs
@@ -14,6 +14,8 @@ import { fileURLToPath } from 'node:url';
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const DISTRIBUTION = 'enterprise-bundle';
 const PREFIX = 'qodo-enterprise';
+const DISCOVERY_SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
+const DISCOVERY_MINIMUM_CLI_VERSION = '0.1.0-next.39';
 const PRIVATE_KEY_PEM = /-----BEGIN (?:[A-Z0-9][A-Z0-9 -]* )?PRIVATE KEY(?: BLOCK)?-----/;
 
 function sha256(payload) {
@@ -134,6 +136,48 @@ function tar(files) {
   return Buffer.concat(parts);
 }
 
+function buildDiscoveryFeeds({ catalog, outputDir, repositoryRoot }) {
+  const skillMetadata = new Map(catalog.skills.map((skill) => [skill.name, skill]));
+  const packages = [];
+  const assets = [];
+  for (const installPackage of catalog.installPackages) {
+    const entries = [];
+    for (const skillName of installPackage.skills) {
+      const files = [];
+      collectTree(join(repositoryRoot, 'skills', skillName), '', files);
+      const archiveName = `qodo-agent-skill-${skillName}.tar.gz`;
+      const archive = gzipSync(tar(files), { level: 9, mtime: 0 });
+      const digest = sha256(archive);
+      writeFileSync(join(outputDir, archiveName), archive);
+      entries.push({
+        name: skillName,
+        description: skillMetadata.get(skillName)?.shortDescription
+          ?? `Qodo workflow ${skillName}.`,
+        type: 'archive',
+        url: `../../artifacts/${archiveName}`,
+        digest: `sha256:${digest}`,
+      });
+      assets.push({ name: archiveName, sha256: digest });
+    }
+    const indexName = `qodo-agent-skills-${installPackage.name === 'qodo' ? 'core' : 'standards'}-index.json`;
+    const indexPayload = Buffer.from(`${JSON.stringify({ $schema: DISCOVERY_SCHEMA, skills: entries }, null, 2)}\n`);
+    writeFileSync(join(outputDir, indexName), indexPayload);
+    const indexDigest = sha256(indexPayload);
+    assets.push({ name: indexName, sha256: indexDigest });
+    packages.push({
+      name: installPackage.name,
+      sourcePath: installPackage.name,
+      index: { name: indexName, sha256: indexDigest },
+      skills: entries.map((entry) => ({
+        name: entry.name,
+        archive: entry.url.split('/').at(-1),
+        sha256: entry.digest.slice('sha256:'.length),
+      })),
+    });
+  }
+  return { schema: DISCOVERY_SCHEMA, packages, assets };
+}
+
 function packageRoots(name) {
   return {
     claude: `${PREFIX}/claude/${name}`,
@@ -244,6 +288,7 @@ export function buildEnterpriseBundle({ output, commit }, repositoryRoot = root)
 
   const outputDir = resolve(repositoryRoot, output);
   mkdirSync(outputDir, { recursive: true });
+  const discovery = buildDiscoveryFeeds({ catalog, outputDir, repositoryRoot });
   const archiveName = `qodo-enterprise-bundle-v${version}.tar.gz`;
   const archive = gzipSync(tar(files), { level: 9, mtime: 0 });
   const archiveDigest = sha256(archive);
@@ -259,6 +304,11 @@ export function buildEnterpriseBundle({ output, commit }, repositoryRoot = root)
     ...bundle,
     archive: { name: archiveName, sha256: archiveDigest },
     index: { name: indexName, sha256: indexDigest, checksumName: `${indexName}.sha256` },
+    discovery: {
+      schema: discovery.schema,
+      minimumCliVersion: DISCOVERY_MINIMUM_CLI_VERSION,
+      packages: discovery.packages,
+    },
   };
   const manifestName = 'qodo-enterprise-manifest.json';
   const manifestPath = join(outputDir, manifestName);
@@ -273,6 +323,7 @@ export function buildEnterpriseBundle({ output, commit }, repositoryRoot = root)
     archiveName,
     archiveSha256: archiveDigest,
     manifestName,
+    discoveryAssets: discovery.assets.map((asset) => asset.name),
     outputDir,
   };
 }

--- a/scripts/fixtures/fake-release-gh.mjs
+++ b/scripts/fixtures/fake-release-gh.mjs
@@ -116,7 +116,7 @@ if (args[0] === 'api' && endpoint.startsWith('installation/repositories')) {
     throw new Error('Release upload must never overwrite an existing asset');
   }
   const state = readState();
-  const assetPattern = /(?:qodo-(?:skills-index|cli-managed-bundle)\.json(?:\.sha256)?|qodo-enterprise-manifest\.json(?:\.sha256)?|qodo-enterprise-bundle-v\d+\.\d+\.\d+\.tar\.gz(?:\.sha256)?)$/;
+  const assetPattern = /(?:qodo-(?:skills-index|cli-managed-bundle)\.json(?:\.sha256)?|qodo-enterprise-manifest\.json(?:\.sha256)?|qodo-enterprise-bundle-v\d+\.\d+\.\d+\.tar\.gz(?:\.sha256)?|qodo-agent-skills-(?:core|standards)-index\.json|qodo-agent-skill-qodo-[a-z0-9-]+\.tar\.gz)$/;
   if (args[1] === 'upload' && (!state.exists || !state.draft)) {
     throw new Error('Release upload requires an existing draft');
   }

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -78,6 +78,22 @@ RELEASE_ASSETS=(
   "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json"
   "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json.sha256"
 )
+while IFS= read -r discovery_asset; do
+  [[ -n "${discovery_asset}" ]] && RELEASE_ASSETS+=("${ENTERPRISE_DIR}/${discovery_asset}")
+done < <(node -e '
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const manifest = JSON.parse(fs.readFileSync(path.join(process.argv[1], "qodo-enterprise-manifest.json"), "utf8"));
+  const names = [];
+  for (const pkg of manifest.discovery?.packages ?? []) {
+    names.push(pkg.index?.name);
+    for (const skill of pkg.skills ?? []) names.push(skill.archive);
+  }
+  for (const name of [...new Set(names)].sort()) {
+    if (typeof name !== "string" || !/^qodo-agent-(?:skill|skills)-[a-z0-9-]+(?:-index)?\.json$/.test(name) && !/^qodo-agent-skill-[a-z0-9-]+\.tar\.gz$/.test(name)) process.exit(2);
+    console.log(name);
+  }
+' "${ENTERPRISE_DIR}")
 EXPECTED_ASSETS="$(node -e \
   'console.log(process.argv.slice(1).map((asset) => require("node:path").basename(asset)).sort().join(" "))' \
   "${RELEASE_ASSETS[@]}")"
@@ -107,6 +123,19 @@ verify_release_assets() {
   cmp --silent "${directory}/${ARCHIVE_NAME}.sha256" "${ENTERPRISE_DIR}/${ARCHIVE_NAME}.sha256"
   cmp --silent "${directory}/qodo-enterprise-manifest.json" "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json"
   cmp --silent "${directory}/qodo-enterprise-manifest.json.sha256" "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json.sha256"
+  while IFS= read -r discovery_asset; do
+    [[ -n "${discovery_asset}" ]] || continue
+    cmp --silent "${directory}/${discovery_asset}" "${ENTERPRISE_DIR}/${discovery_asset}"
+  done < <(node -e '
+    const fs = require("node:fs");
+    const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    const names = [];
+    for (const pkg of manifest.discovery.packages) {
+      names.push(pkg.index.name);
+      for (const skill of pkg.skills) names.push(skill.archive);
+    }
+    console.log([...new Set(names)].sort().join("\n"));
+  ' "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json")
 }
 
 require_current_main() {

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -78,28 +78,59 @@ RELEASE_ASSETS=(
   "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json"
   "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json.sha256"
 )
-while IFS= read -r discovery_asset; do
-  [[ -n "${discovery_asset}" ]] && RELEASE_ASSETS+=("${ENTERPRISE_DIR}/${discovery_asset}")
-done < <(node -e '
+if ! DISCOVERY_ASSET_ROWS="$(node -e '
   const fs = require("node:fs");
   const path = require("node:path");
   const manifest = JSON.parse(fs.readFileSync(path.join(process.argv[1], "qodo-enterprise-manifest.json"), "utf8"));
-  const names = [];
-  for (const pkg of manifest.discovery?.packages ?? []) {
-    names.push(pkg.index?.name);
-    for (const skill of pkg.skills ?? []) names.push(skill.archive);
+  if (!Array.isArray(manifest.discovery?.packages) || manifest.discovery.packages.length === 0) {
+    throw new Error("manifest has no discovery packages");
   }
-  for (const name of [...new Set(names)].sort()) {
-    if (typeof name !== "string" || !/^qodo-agent-(?:skill|skills)-[a-z0-9-]+(?:-index)?\.json$/.test(name) && !/^qodo-agent-skill-[a-z0-9-]+\.tar\.gz$/.test(name)) process.exit(2);
-    console.log(name);
+  const assets = new Map();
+  const add = (name, digest, pattern) => {
+    if (typeof name !== "string" || !pattern.test(name)) throw new Error(`invalid discovery asset name: ${name}`);
+    if (typeof digest !== "string" || !/^[a-f0-9]{64}$/.test(digest)) throw new Error(`invalid discovery digest: ${name}`);
+    if (assets.has(name) && assets.get(name) !== digest) throw new Error(`conflicting discovery asset: ${name}`);
+    assets.set(name, digest);
+  };
+  for (const pkg of manifest.discovery.packages) {
+    add(pkg.index?.name, pkg.index?.sha256, /^qodo-agent-skills-(?:core|standards)-index\.json$/);
+    if (!Array.isArray(pkg.skills) || pkg.skills.length === 0) throw new Error(`discovery package has no skills: ${pkg.name}`);
+    for (const skill of pkg.skills) {
+      add(skill.archive, skill.sha256, /^qodo-agent-skill-qodo-[a-z0-9-]+\.tar\.gz$/);
+    }
   }
-' "${ENTERPRISE_DIR}")
+  for (const [name, digest] of [...assets].sort(([left], [right]) => Buffer.compare(Buffer.from(left), Buffer.from(right)))) {
+    console.log(`${name}\t${digest}`);
+  }
+' "${ENTERPRISE_DIR}")"; then
+  echo 'Could not enumerate and validate the discovery asset inventory.' >&2
+  exit 1
+fi
+while IFS=$'\t' read -r discovery_asset discovery_digest; do
+  [[ -n "${discovery_asset}" ]] && RELEASE_ASSETS+=("${ENTERPRISE_DIR}/${discovery_asset}")
+done <<< "${DISCOVERY_ASSET_ROWS}"
 EXPECTED_ASSETS="$(node -e \
   'console.log(process.argv.slice(1).map((asset) => require("node:path").basename(asset)).sort().join(" "))' \
   "${RELEASE_ASSETS[@]}")"
 for asset in "${RELEASE_ASSETS[@]}"; do
   test -f "${asset}" || { echo "Release asset is missing: ${asset}" >&2; exit 1; }
 done
+verify_discovery_digest() {
+  local asset="$1" expected="$2" actual
+  actual="$(node -e '
+    const fs = require("node:fs");
+    const crypto = require("node:crypto");
+    process.stdout.write(crypto.createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex"));
+  ' "${asset}")"
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "Discovery asset digest mismatch: $(basename "${asset}")" >&2
+    return 1
+  fi
+}
+while IFS=$'\t' read -r discovery_asset discovery_digest; do
+  [[ -n "${discovery_asset}" ]] || continue
+  verify_discovery_digest "${ENTERPRISE_DIR}/${discovery_asset}" "${discovery_digest}"
+done <<< "${DISCOVERY_ASSET_ROWS}"
 test -f "${NOTES}" || { echo "Release notes are missing: ${NOTES}" >&2; exit 1; }
 EXPECTED_TITLE="Qodo skills ${TAG}"
 EXPECTED_NOTES_BASE64="$(node -e \
@@ -123,19 +154,12 @@ verify_release_assets() {
   cmp --silent "${directory}/${ARCHIVE_NAME}.sha256" "${ENTERPRISE_DIR}/${ARCHIVE_NAME}.sha256"
   cmp --silent "${directory}/qodo-enterprise-manifest.json" "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json"
   cmp --silent "${directory}/qodo-enterprise-manifest.json.sha256" "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json.sha256"
-  while IFS= read -r discovery_asset; do
+  while IFS=$'\t' read -r discovery_asset discovery_digest; do
     [[ -n "${discovery_asset}" ]] || continue
     cmp --silent "${directory}/${discovery_asset}" "${ENTERPRISE_DIR}/${discovery_asset}"
-  done < <(node -e '
-    const fs = require("node:fs");
-    const manifest = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-    const names = [];
-    for (const pkg of manifest.discovery.packages) {
-      names.push(pkg.index.name);
-      for (const skill of pkg.skills) names.push(skill.archive);
-    }
-    console.log([...new Set(names)].sort().join("\n"));
-  ' "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json")
+    verify_discovery_digest "${directory}/${discovery_asset}" "${discovery_digest}"
+    verify_discovery_digest "${ENTERPRISE_DIR}/${discovery_asset}" "${discovery_digest}"
+  done <<< "${DISCOVERY_ASSET_ROWS}"
 }
 
 require_current_main() {

--- a/scripts/test-enterprise-bundle.mjs
+++ b/scripts/test-enterprise-bundle.mjs
@@ -97,6 +97,12 @@ try {
       assert.equal(entry.type, 'archive');
       assert.match(entry.url, /^\.\.\/\.\.\/artifacts\/qodo-agent-skill-qodo-[a-z0-9-]+\.tar\.gz$/);
       const archiveName = entry.url.split('/').at(-1);
+      const indexUrl = `https://qar.example/toolbox/skills/${packageName}/.well-known/agent-skills/index.json`;
+      assert.equal(
+        new URL(entry.url, indexUrl).pathname,
+        `/toolbox/skills/${packageName}/artifacts/${archiveName}`,
+        `${packageName} archive URL must resolve inside its package-scoped QAR route`,
+      );
       const firstSkillArchive = readFileSync(join(firstRoot, archiveName));
       const secondSkillArchive = readFileSync(join(secondRoot, archiveName));
       assert.deepEqual(firstSkillArchive, secondSkillArchive, `${entry.name} archive must be deterministic`);

--- a/scripts/test-enterprise-bundle.mjs
+++ b/scripts/test-enterprise-bundle.mjs
@@ -68,6 +68,8 @@ try {
     tag: `v${packageVersion}`,
   });
   assert.deepEqual(manifest.archive, { name: first.archiveName, sha256: first.archiveSha256 });
+  assert.equal(manifest.discovery.schema, 'https://schemas.agentskills.io/discovery/0.2.0/schema.json');
+  assert.equal(manifest.discovery.minimumCliVersion, '0.1.0-next.39');
   assert.deepEqual(manifest.installation, {
     skillsCli: { environment: { DO_NOT_TRACK: '1' } },
   });
@@ -76,6 +78,35 @@ try {
     readFileSync(join(firstRoot, `${first.manifestName}.sha256`), 'utf8'),
     `${sha256(manifestPayload)}  ${first.manifestName}\n`,
   );
+
+  const discoveryPackages = new Map(manifest.discovery.packages.map((entry) => [entry.name, entry]));
+  assert.deepEqual([...discoveryPackages.keys()].sort(), ['qodo', 'qodo-standards']);
+  for (const [packageName, discoveryPackage] of discoveryPackages) {
+    const expectedIndex = packageName === 'qodo'
+      ? 'qodo-agent-skills-core-index.json'
+      : 'qodo-agent-skills-standards-index.json';
+    assert.equal(discoveryPackage.index.name, expectedIndex);
+    const firstIndex = readFileSync(join(firstRoot, expectedIndex));
+    const secondIndex = readFileSync(join(secondRoot, expectedIndex));
+    assert.deepEqual(firstIndex, secondIndex, `${packageName} discovery index must be deterministic`);
+    assert.equal(sha256(firstIndex), discoveryPackage.index.sha256);
+    const index = JSON.parse(firstIndex);
+    assert.equal(index.$schema, manifest.discovery.schema);
+    assert.deepEqual(index.skills.map((entry) => entry.name), discoveryPackage.skills.map((entry) => entry.name));
+    for (const entry of index.skills) {
+      assert.equal(entry.type, 'archive');
+      assert.match(entry.url, /^\.\.\/\.\.\/artifacts\/qodo-agent-skill-qodo-[a-z0-9-]+\.tar\.gz$/);
+      const archiveName = entry.url.split('/').at(-1);
+      const firstSkillArchive = readFileSync(join(firstRoot, archiveName));
+      const secondSkillArchive = readFileSync(join(secondRoot, archiveName));
+      assert.deepEqual(firstSkillArchive, secondSkillArchive, `${entry.name} archive must be deterministic`);
+      assert.equal(entry.digest, `sha256:${sha256(firstSkillArchive)}`);
+      const skillArchiveFiles = tarFiles(firstSkillArchive);
+      assert.ok(skillArchiveFiles.has('SKILL.md'));
+      assert.match(skillArchiveFiles.get('SKILL.md').toString(), /  distribution: "enterprise-bundle"/);
+      assert.ok([...skillArchiveFiles.keys()].every((path) => !path.startsWith('qodo-enterprise/')));
+    }
+  }
 
   const files = tarFiles(firstArchive);
   assert.ok(files.has('qodo-enterprise/README.md'));

--- a/scripts/test-release-discovery-assets.mjs
+++ b/scripts/test-release-discovery-assets.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function assertDiscoveryPublisherSource(publisher) {
+  assert.match(publisher, /if ! DISCOVERY_ASSET_ROWS="\$\(node -e/,
+    'discovery inventory parsing must propagate producer failures');
+  assert.match(publisher, /verify_discovery_digest "\$\{ENTERPRISE_DIR\}\/\$\{discovery_asset\}"/,
+    'local discovery assets must match manifest digests before publication');
+  assert.match(publisher, /verify_discovery_digest "\$\{directory\}\/\$\{discovery_asset\}"/,
+    'downloaded discovery assets must match manifest digests');
+}
+
+export function assertDiscoveryManifestFailures({
+  publisher,
+  enterpriseDir,
+  checkout,
+  publishPath,
+  publishEnv,
+  releaseTag,
+  run,
+  runShell,
+}) {
+  assertDiscoveryPublisherSource(publisher);
+  const manifestPath = join(enterpriseDir, 'qodo-enterprise-manifest.json');
+  const checksumPath = `${manifestPath}.sha256`;
+  const originalManifest = readFileSync(manifestPath);
+  const originalChecksum = readFileSync(checksumPath);
+  const writeManifest = (manifest) => {
+    const payload = Buffer.from(`${JSON.stringify(manifest, null, 2)}\n`);
+    writeFileSync(manifestPath, payload);
+    writeFileSync(checksumPath,
+      `${createHash('sha256').update(payload).digest('hex')}  qodo-enterprise-manifest.json\n`);
+  };
+
+  const invalidInventory = JSON.parse(originalManifest);
+  invalidInventory.discovery.packages[0].index.name = '../escaped-index.json';
+  writeManifest(invalidInventory);
+  assert.throws(() => runShell(checkout, publishPath, publishEnv),
+    /Could not enumerate and validate the discovery asset inventory/);
+  assert.equal(run(checkout, 'git', ['ls-remote', '--tags', 'origin', releaseTag]).trim(), '');
+
+  const invalidDigest = JSON.parse(originalManifest);
+  invalidDigest.discovery.packages[0].index.sha256 = '0'.repeat(64);
+  writeManifest(invalidDigest);
+  assert.throws(() => runShell(checkout, publishPath, publishEnv),
+    /Discovery asset digest mismatch: qodo-agent-skills-core-index\.json/);
+  assert.equal(run(checkout, 'git', ['ls-remote', '--tags', 'origin', releaseTag]).trim(), '');
+
+  writeFileSync(manifestPath, originalManifest);
+  writeFileSync(checksumPath, originalChecksum);
+}

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -315,7 +315,7 @@ try {
   const published = JSON.parse(readFileSync(fakeGhState, 'utf8'));
   assert.deepEqual(
     { draft: published.draft, immutable: published.immutable, edits: published.edits, downloads: published.downloads },
-    { draft: false, immutable: true, edits: 1, downloads: 9 },
+    { draft: false, immutable: true, edits: 1, downloads: published.assets.length + 1 },
   );
   for (const corruption of [{ name: 'wrong title' }, { body: 'wrong notes' }]) {
     const corrupted = { ...published, ...corruption, draft: true, immutable: false, edits: 0, downloads: 0 };
@@ -353,7 +353,7 @@ try {
   const recovered = JSON.parse(readFileSync(fakeGhState, 'utf8'));
   assert.deepEqual(
     { draft: recovered.draft, immutable: recovered.immutable, edits: recovered.edits, downloads: recovered.downloads },
-    { draft: false, immutable: true, edits: 1, downloads: 9 },
+    { draft: false, immutable: true, edits: 1, downloads: recovered.assets.length + 1 },
   );
   run(checkout, 'git', ['reset', '--hard', releaseSha]);
   run(checkout, 'git', ['push', '--force', 'origin', 'main']);
@@ -402,7 +402,7 @@ try {
   runShell(checkout, publishPath, publishEnv);
   const verifiedRetry = JSON.parse(readFileSync(fakeGhState, 'utf8'));
   assert.equal(verifiedRetry.edits, 1);
-  assert.equal(verifiedRetry.downloads, 10);
+  assert.equal(verifiedRetry.downloads, verifiedRetry.assets.length + 2);
 
   // A resumed draft with an unexpected asset is rejected without mutation.
   const unexpectedDraft = {
@@ -490,7 +490,7 @@ try {
       edits: rejectedPublicBytes.edits,
       downloads: rejectedPublicBytes.downloads,
     },
-    { draft: false, immutable: true, edits: 1, downloads: 9 },
+    { draft: false, immutable: true, edits: 1, downloads: rejectedPublicBytes.assets.length + 1 },
   );
 } finally {
   rmSync(harness, { recursive: true, force: true });

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildEnterpriseBundle } from './build-enterprise-bundle.mjs';
+import { assertDiscoveryManifestFailures } from './test-release-discovery-assets.mjs';
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const workflow = readFileSync(join(root, '.github', 'workflows', 'release.yml'), 'utf8');
 const preflight = readFileSync(join(root, 'scripts', 'verify-release-prerequisites.sh'), 'utf8');
@@ -310,6 +311,7 @@ try {
   assert.throws(() => runShell(checkout, publishPath, publishEnv),
     /release checkout has tracked worktree changes/);
   run(checkout, 'git', ['reset', '--hard', releaseSha]);
+  assertDiscoveryManifestFailures({ publisher, enterpriseDir, checkout, publishPath, publishEnv, releaseTag, run, runShell });
   runShell(checkout, publishPath, publishEnv);
   assert.equal(run(checkout, 'git', ['rev-list', '-n', '1', releaseTag]).trim(), releaseSha);
   const published = JSON.parse(readFileSync(fakeGhState, 'utf8'));
@@ -328,7 +330,6 @@ try {
     ...publishEnv,
     FAKE_DUPLICATE_RELEASES: 'true',
   }), new RegExp(`Multiple releases claim ${escapedReleaseTag}`));
-
   // Recovery from reviewed automation changes must still use tagged bytes.
   writeFileSync(fakeGhState, `${JSON.stringify({
     ...published,


### PR DESCRIPTION
## Summary

- publish deterministic Agent Skills Discovery v0.2 indexes for core and optional Standards
- publish one digest-pinned archive per skill and include them in immutable release verification
- declare CLI `0.1.0-next.39` as the discovery-specific minimum while preserving the `.37` compatibility floor
- update the cutover, architecture, and release strategy for the pinned-helper enterprise lane

## Validation

- `npm test`
- `git diff --check`

## Dependency order

Merge may precede the CLI release, but do not publish or QAR-pin v1.0.9 until qodo-in-cli#227 releases `0.1.0-next.39`. QAR #585 enforces this minimum.

Tracks CLI-322. Implements KB-366.