### PR TITLE
release: bind skill installs to immutable source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
-    "version": "1.0.9"
+    "version": "1.0.10"
   },
   "plugins": [
     {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,14 +109,18 @@ jobs:
           test "$(git -C "${RELEASE_SOURCE_DIR}" rev-parse HEAD)" = "${RELEASE_COMMIT}"
           test -z "$(git -C "${RELEASE_SOURCE_DIR}" status --porcelain --untracked-files=all)"
 
-      - name: Build the deterministic enterprise bundle from the immutable source
+      - name: Build deterministic release assets from the immutable source
         env:
           RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
         run: |
           set -euo pipefail
+          node "${RUNNER_TEMP}/qodo-release-source/scripts/build-release-index.mjs" \
+            --output-dir "${RUNNER_TEMP}/qodo-release-index" \
+            --source-commit "${RELEASE_COMMIT}"
           node "${RUNNER_TEMP}/qodo-release-source/scripts/build-enterprise-bundle.mjs" \
             --output "${RUNNER_TEMP}/qodo-enterprise-release" \
-            --commit "${RELEASE_COMMIT}"
+            --commit "${RELEASE_COMMIT}" \
+            --release-index "${RUNNER_TEMP}/qodo-release-index/qodo-skills-index.json"
           node "${RUNNER_TEMP}/qodo-release-source/scripts/release-notes.mjs" \
             "${RUNNER_TEMP}/qodo-release-notes.md"
 
@@ -127,4 +131,5 @@ jobs:
           QODO_RELEASE_COMMIT: ${{ steps.release-source.outputs.commit }}
           QODO_RELEASE_NOTES_FILE: ${{ runner.temp }}/qodo-release-notes.md
           QODO_RELEASE_SOURCE_DIR: ${{ runner.temp }}/qodo-release-source
+          QODO_RELEASE_INDEX_DIR: ${{ runner.temp }}/qodo-release-index
         run: scripts/publish-release.sh

--- a/codex-packages/qodo-standards/.codex-plugin/plugin.json
+++ b/codex-packages/qodo-standards/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo-standards/plugin.json
+++ b/codex-packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/.codex-plugin/plugin.json
+++ b/codex-packages/qodo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/plugin.json
+++ b/codex-packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/distribution/catalog.json
+++ b/distribution/catalog.json
@@ -5,7 +5,7 @@
   "package": {
     "name": "qodo",
     "displayName": "Qodo for coding agents",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
     "repository": "https://github.com/qodo-ai/qodo-skills",
     "homepage": "https://www.qodo.ai",

--- a/distribution/qodo-cli-managed-bundle.json
+++ b/distribution/qodo-cli-managed-bundle.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "distribution": "qodo-cli-managed",
   "instructionMode": "embedded",
-  "packageVersion": "1.0.9",
+  "packageVersion": "1.0.10",
   "minimumCliVersion": "0.1.0-next.37",
   "source": {
     "repository": "https://github.com/qodo-ai/qodo-skills",
-    "tag": "v1.0.9"
+    "tag": "v1.0.10"
   },
   "aliases": {
     "codebase-wisdom": "qodo-codebase-wisdom",

--- a/distribution/qodo-cli-managed-bundle.json.sha256
+++ b/distribution/qodo-cli-managed-bundle.json.sha256
@@ -1,1 +1,1 @@
-990101a27371270b6ca0abab86e37288138639c85c50839ca5bb123c1ad6493e  qodo-cli-managed-bundle.json
+a7b7a4fc3ce335c3af2ee73daeffcc7bfdd7a74869dfe1da8ec2f03a7ce4be32  qodo-cli-managed-bundle.json

--- a/distribution/qodo-skills-index.json
+++ b/distribution/qodo-skills-index.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "instructionMode": "embedded",
-  "packageVersion": "1.0.9",
+  "packageVersion": "1.0.10",
   "minimumCliVersion": "0.1.0-next.37",
   "repository": "https://github.com/qodo-ai/qodo-skills",
   "skills": {

--- a/distribution/qodo-skills-index.json.sha256
+++ b/distribution/qodo-skills-index.json.sha256
@@ -1,1 +1,1 @@
-8bc87c85d9f9f7d8b8e9baf91f70d0575e31aed1a67053ae89c708ced2805c78  qodo-skills-index.json
+999e02776b6fe9686afe168969e60a0646f79601ccb971861c2456bf14444f3c  qodo-skills-index.json

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,8 +82,11 @@ Every skill:
 6. invokes the authenticated runtime;
 7. treats a `QODO_NOTICE` as non-fatal metadata after preserving the command result.
 
-The CLI’s compact release index contains only package, skill, and minimum-runtime versions for
-marketplace/skills.sh notices. Separately, the CLI-managed bundle carries current canonical bytes for
+The checked-in schema-v1 compatibility index contains package, skill, and minimum-runtime versions
+for marketplace/skills.sh notices. A published immutable release index uses schema v2 and adds the
+exact 40-character `sourceCommit` from which its assets were built; QAR byte-verifies and preserves
+that index under the versioned release route while projecting schema v1 at the stable endpoint for
+pre-v2 CLIs. Separately, the CLI-managed bundle carries current canonical bytes for
 the finite CLI-managed cohort. The updater enrolls a root only when every byte matches a fingerprint
 from an actually shipped CLI, records the installed digest, and refuses to overwrite subsequent
 drift. It never adds a missing skill, so optional Standards remains optional. Replacement is staged,

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -9,7 +9,9 @@ Qodo moves skill ownership out of the CLI without creating a second architecture
 > earlier Qodo CLI releases; the CLI updates the runtime.
 
 - Claude Code, Codex, and Kiro receive complete generated skills through their official listings.
-- Compatible agents without a Qodo listing use skills.sh.
+- Compatible agents without a Qodo listing use the skills.sh lifecycle through Qodo's pinned,
+  embedded upstream engine: the CLI performs the selected, consented install and verifies the
+  resulting receipt and bytes. No separate npm or `npx` step is left to the user.
 - On-prem QAR deployments pin the independently released CLI and skills assets. QAR exposes
   path-scoped Agent Skills Discovery v0.2 feeds for core and Standards. After login, the CLI invokes
   a build-pinned, telemetry-disabled skills lifecycle engine; that engine owns agent discovery and
@@ -19,9 +21,10 @@ Qodo moves skill ownership out of the CLI without creating a second architecture
   skills automatically; marketplace migration is optional, not a support deadline.
 - The CLI authenticates and runs tools, updates itself, prints lifecycle guidance, emits stale-skill
   notices, and maintains only hash-exact CLI-managed copies through a separate compatibility channel.
-- No task-time playbook loader or general-purpose public CLI skill installer ships in the cutover.
-  The enterprise command is only an authenticated launcher for the same-origin QAR feeds; it does
-  not carry agent mappings, parse skill archives, or copy skill trees itself.
+- No task-time playbook loader or Qodo-authored agent-path copier ships in the cutover. Public and
+  enterprise commands are authenticated launchers for a build-pinned skills lifecycle engine; the
+  CLI owns orchestration, consent, immutable-source verification, and rollback, while the upstream
+  engine owns agent mappings and target materialization.
 
 ## Why this design
 
@@ -52,7 +55,7 @@ skills/<name>/ (authored once)
           └── CLI-managed bundle    current bytes for proven earlier CLI-managed roots
 
 qodo CLI ── login + runtime + tool help + version notice + pinned skills launcher
-        ├── public: never creates marketplace/skills.sh installations after cutover
+        ├── public: selected install/update through the pinned engine; never mutates unattended
         ├── compatibility: updates only roots carrying CLI-managed ownership proof
         └── enterprise: delegates same-origin feed installation after authentication and consent
 
@@ -109,7 +112,9 @@ Ship the CLI that:
 - detects known skills.sh-compatible local agents and supports multiple selection;
 - when none is detected, reads the current skills.sh agent catalog, excludes marketplace-owned
   IDs, and preserves each selected agent's supported project/global scope;
-- prints exact core and optional-package commands without executing them;
+- explains which detected agents are marketplace-owned and which can be completed immediately;
+- after one explicit confirmation, installs and byte-verifies core for selected non-marketplace
+  agents; Qodo Standards remains a separate opt-in;
 - has no `qodo skills install` and no task-time workflow endpoint;
 - enrolls only byte-exact copies from shipped CLI releases, including the live `next.36` bytes;
 - immediately refreshes enrolled copies from its embedded cutover snapshot, then follows the
@@ -135,11 +140,12 @@ copy and recoverable predecessor; marketplace skills remain owned by their host.
 
 ### 2. Publish one complete canonical skills release
 
+- Before publishing `v1.0.10`, merge and deploy qodo-agent-runtime#587. It adds backward-compatible
+  schema-v2 parsing and requires the index `sourceCommit` to equal the enterprise manifest commit;
+  it does not advance the QAR skills pin.
 - Merge the canonical/provider PR, then rebase and merge its stacked distribution PR containing
-  both the CLI-managed and enterprise release assets. Do not publish the intermediate package
-  versions: the first cutover release is the complete `v1.0.8` tag. Candidate `v1.0.7` was not
-  published because its administrator audit used an endpoint unavailable to normal admin tokens;
-  `v1.0.8` splits hidden-setting checks from exact App-token repository-scope verification.
+  both the CLI-managed and enterprise release assets. The next release is `v1.0.10`; it adds the
+  immutable source identity required by the public installer without changing skill bodies.
 - Release validation derives changes from both canonical files and the catalog: packaging-only
   changes require a package release, every semantic-version delta must match its release record,
   catalog-only bumps cannot disappear from release notes, `initial` cannot target an existing
@@ -150,8 +156,10 @@ copy and recoverable predecessor; marketplace skills remain owned by their host.
   before publication, and then re-verifies the immutable tag and assets after publication.
 - CI executes those checked-in preflight and publication programs with a stateful fake GitHub CLI,
   including credential/ruleset failures, corrupted draft rejection and resume, successful
-  publication, and idempotent immutable verification. The release asset inventory includes the
-  compact index, the data-only CLI-managed bundle, the enterprise bundle, and their checksums.
+  publication, and idempotent immutable verification. The release asset inventory includes a
+  schema-v2 compact index generated from the detached release worktree with its exact source commit,
+  the data-only CLI-managed bundle, the enterprise bundle, and their checksums. Publication rejects
+  an index whose commit or package version differs from the resolved release.
 - After the immutable GitHub release is verified, dispatch **release: publish skills compatibility
   channel** in `qodo-ai/qodo-in-cli` with that exact tag. Its canary job verifies the immutable
   release and checksums, copies the compact index and CLI-managed bundle to tag-scoped
@@ -205,8 +213,9 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
 import at Node 20.6; fresh clean-machine core import into Codex and Claude; Standards absent;
-prompted upgrade; retry; new-session activation. The QAR PR cannot become merge-ready until the pinned
-immutable qodo-skills release exists at the exact bytes in its lock.
+prompted upgrade; retry; new-session activation. A later QAR **repin** PR cannot become merge-ready
+until the immutable qodo-skills release exists at the exact bytes in its lock; the backward-compatible
+schema parser must land before that release is published.
 
 Rollback: publish a new immutable skills patch and advance only the QAR skills pin. The CLI pin is
 unchanged unless runtime compatibility independently requires it.
@@ -274,7 +283,8 @@ verified copy and receives no false claim of freshness.
 - If the official plugin is installed, ask for a new session and verify Qodo.
 - If a listing is visible, direct the user to the host’s install action.
 - If no listing exists, use detected agents or the current read-only skills.sh catalog to select
-  one or more non-marketplace agents, then print exact scope-preserving commands.
+  one or more non-marketplace agents, confirm once, then install and verify them in the requested
+  scope through the pinned engine.
 - Install Qodo Standards only after an explicit selection.
 - Retire exact CLI copies only after the new owner works in a fresh session.
 
@@ -292,7 +302,8 @@ deleted.
 3. The current Qodo command succeeds and emits `QODO_NOTICE` on stderr.
 4. The skill finishes the current task, inventories its lifecycle owner read-only, shows the fully
    resolved scope-preserving action, and asks once.
-5. The lifecycle owner updates the skill; the user starts a new agent session.
+5. The lifecycle owner updates the skill. For skills.sh-owned roots, the shown action is the exact
+   `qodo agents update --agent <ids> --yes` command; the user then starts a new agent session.
 
 The CLI never runs `npx skills` in the background and never rewrites marketplace files. New
 optional skills are discoverable but never auto-installed.

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -141,8 +141,10 @@ copy and recoverable predecessor; marketplace skills remain owned by their host.
 ### 2. Publish one complete canonical skills release
 
 - Before publishing `v1.0.10`, merge and deploy qodo-agent-runtime#587. It adds backward-compatible
-  schema-v2 parsing and requires the index `sourceCommit` to equal the enterprise manifest commit;
-  it does not advance the QAR skills pin.
+  schema-v2 parsing, requires the index `sourceCommit` to equal the enterprise manifest commit,
+  preserves the exact v2 bytes under the immutable release path, and serves a checksum-matched
+  schema-v1 projection from the existing stale-notice endpoint for pre-`.40` CLIs. It does not
+  advance the QAR skills pin.
 - Merge the canonical/provider PR, then rebase and merge its stacked distribution PR containing
   both the CLI-managed and enterprise release assets. The next release is `v1.0.10`; it adds the
   immutable source identity required by the public installer without changing skill bodies.
@@ -213,7 +215,8 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
 import at Node 20.6; fresh clean-machine core import into Codex and Claude; Standards absent;
-prompted upgrade; retry; new-session activation. A later QAR **repin** PR cannot become merge-ready
+prompted upgrade; retry; new-session activation; and a pre-`.40` CLI accepting the generated
+schema-v1 pointer and checksum. A later QAR **repin** PR cannot become merge-ready
 until the immutable qodo-skills release exists at the exact bytes in its lock; the backward-compatible
 schema parser must land before that release is published.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -77,9 +77,10 @@ a prior run created the protected tag and draft but stopped before publication. 
 4. creates annotated tag `v<package-version>`, pushes it without force, and verifies the protected
    remote tag peels to the validated SHA immediately before publication;
 5. materializes the resolved release commit as a clean detached worktree and, before the
-   publication token is exposed, runs that tree's enterprise and release-note builders; publication
-   then uses only those prepared outputs plus that tree's index, CLI-managed bundle, and checksums,
-   and requires the draft title and body to match the tagged-source metadata exactly;
+   publication token is exposed, runs that tree's enterprise, release-index, and release-note
+   builders; the generated schema-v2 index records the exact resolved commit. Publication uses only
+   those prepared outputs plus that tree's CLI-managed bundle, requires the index commit and package
+   version to match the release, and requires the draft title and body to match exactly;
 6. publishes the verified draft, which makes the release immutable;
 7. verifies the published release is immutable, the protected tag is unchanged, and all published
    assets still match the validated checkout byte-for-byte;

--- a/kiro-power-standards/plugin.json
+++ b/kiro-power-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qodo/agent-skills",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "devDependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "Canonical Qodo skills and local coding-agent marketplace adapters.",
   "type": "module",

--- a/packages/qodo-standards/.claude-plugin/plugin.json
+++ b/packages/qodo-standards/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo-standards/plugin.json
+++ b/packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/.claude-plugin/plugin.json
+++ b/packages/qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/plugin.json
+++ b/packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/releases/v1.0.10.json
+++ b/releases/v1.0.10.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.10",
+  "summary": "Bind portable installs to the immutable release commit.",
+  "package": {
+    "change": "patch"
+  },
+  "runtimeProtocolVersion": 2,
+  "minimumCliVersion": "0.1.0-next.37",
+  "skills": []
+}

--- a/scripts/build-enterprise-bundle.mjs
+++ b/scripts/build-enterprise-bundle.mjs
@@ -220,15 +220,15 @@ function argumentsFrom(argv) {
   for (let index = 0; index < argv.length; index += 2) {
     const flag = argv[index];
     const value = argv[index + 1];
-    if (!value || !['--output', '--commit'].includes(flag)) throw new Error(`Unknown or incomplete argument: ${flag}`);
-    options[flag.slice(2)] = value;
+    if (!value || !['--output', '--commit', '--release-index'].includes(flag)) throw new Error(`Unknown or incomplete argument: ${flag}`);
+    options[flag === '--release-index' ? 'releaseIndex' : flag.slice(2)] = value;
   }
   if (!options.output) throw new Error('--output is required');
   if (!/^[a-f0-9]{40}$/i.test(options.commit ?? '')) throw new Error('--commit must be a 40-character Git SHA');
   return options;
 }
 
-export function buildEnterpriseBundle({ output, commit }, repositoryRoot = root) {
+export function buildEnterpriseBundle({ output, commit, releaseIndex }, repositoryRoot = root) {
   const catalog = JSON.parse(readFileSync(join(repositoryRoot, 'distribution', 'catalog.json'), 'utf8'));
   const version = catalog.package.version;
   const files = [];
@@ -296,8 +296,9 @@ export function buildEnterpriseBundle({ output, commit }, repositoryRoot = root)
   writeFileSync(join(outputDir, `${archiveName}.sha256`), `${archiveDigest}  ${archiveName}\n`);
 
   const indexName = 'qodo-skills-index.json';
-  const index = readFileSync(join(repositoryRoot, 'distribution', indexName));
-  const indexChecksum = readFileSync(join(repositoryRoot, 'distribution', `${indexName}.sha256`), 'utf8');
+  const indexPath = resolve(repositoryRoot, releaseIndex ?? join('distribution', indexName));
+  const index = readFileSync(indexPath);
+  const indexChecksum = readFileSync(`${indexPath}.sha256`, 'utf8');
   const indexDigest = sha256(index);
   if (!indexChecksum.startsWith(`${indexDigest}  ${indexName}`)) throw new Error('Qodo skills index checksum is stale');
   const manifest = {

--- a/scripts/build-release-index.mjs
+++ b/scripts/build-release-index.mjs
@@ -1,13 +1,28 @@
 /** Build the compact, checksummed skill-version index consumed by the Qodo CLI. */
 import { createHash } from 'node:crypto';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const check = process.argv.includes('--check');
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  if (index < 0) return undefined;
+  const value = process.argv[index + 1];
+  if (!value || value.startsWith('--')) throw new Error(`${name} requires a value`);
+  return value;
+}
+const sourceCommit = argument('--source-commit');
+if (sourceCommit && !/^[a-f0-9]{40}$/.test(sourceCommit)) {
+  throw new Error('--source-commit must be a full lowercase commit SHA');
+}
+const outputDirectory = resolve(argument('--output-dir') ?? join(root, 'distribution'));
+if (check && (sourceCommit || argument('--output-dir'))) {
+  throw new Error('--check cannot be combined with release output options');
+}
 const catalog = JSON.parse(readFileSync(join(root, 'distribution', 'catalog.json'), 'utf8'));
-const indexPath = join(root, 'distribution', 'qodo-skills-index.json');
+const indexPath = join(outputDirectory, 'qodo-skills-index.json');
 const checksumPath = `${indexPath}.sha256`;
 
 const packageBySkill = new Map();
@@ -21,11 +36,12 @@ const skills = Object.fromEntries(catalog.skills.map((skill) => {
   return [skill.name, { version: skill.version, package: packageName }];
 }));
 const index = {
-  schemaVersion: 1,
+  schemaVersion: sourceCommit ? 2 : 1,
   instructionMode: catalog.instructionMode,
   packageVersion: catalog.package.version,
   minimumCliVersion: catalog.runtime.minimumCliVersion,
   repository: catalog.package.repository,
+  ...(sourceCommit ? { sourceCommit } : {}),
   skills,
 };
 const output = `${JSON.stringify(index, null, 2)}\n`;
@@ -38,6 +54,7 @@ if (check) {
     readFileSync(checksumPath, 'utf8').replace(/\r\n/g, '\n') !== checksum
   ) throw new Error('Skill release index is stale; run npm run index:build');
 } else {
+  mkdirSync(outputDirectory, { recursive: true });
   writeFileSync(indexPath, output);
   writeFileSync(checksumPath, checksum);
 }

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -3,6 +3,7 @@
 # Usage: GH_TOKEN=<contents-write-token> GITHUB_REPOSITORY=owner/repo GITHUB_SHA=<sha> \
 #   RUNNER_TEMP=<dir> QODO_ENTERPRISE_RELEASE_DIR=<prepared-assets-dir> \
 #   QODO_RELEASE_NOTES_FILE=<prepared-notes> QODO_RELEASE_SOURCE_DIR=<tagged-worktree> \
+#   QODO_RELEASE_INDEX_DIR=<prepared-index-dir> \
 #   scripts/publish-release.sh
 set -euo pipefail
 
@@ -67,6 +68,12 @@ fi
 TAG="v${VERSION}"
 NOTES="${QODO_RELEASE_NOTES_FILE:?QODO_RELEASE_NOTES_FILE is required}"
 ENTERPRISE_DIR="${QODO_ENTERPRISE_RELEASE_DIR:?QODO_ENTERPRISE_RELEASE_DIR is required}"
+INDEX_DIR="${QODO_RELEASE_INDEX_DIR:?QODO_RELEASE_INDEX_DIR is required}"
+if [[ ! -d "${INDEX_DIR}" ]]; then
+  echo 'QODO_RELEASE_INDEX_DIR must name the prepared release-index directory.' >&2
+  exit 1
+fi
+INDEX_DIR="$(cd "${INDEX_DIR}" && pwd -P)"
 ARCHIVE_NAME="qodo-enterprise-bundle-v${VERSION}.tar.gz"
 RELEASE_ASSETS=(
   "${ENTERPRISE_DIR}/${ARCHIVE_NAME}"
@@ -75,8 +82,8 @@ RELEASE_ASSETS=(
   "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json.sha256"
   "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json"
   "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json.sha256"
-  "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json"
-  "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json.sha256"
+  "${INDEX_DIR}/qodo-skills-index.json"
+  "${INDEX_DIR}/qodo-skills-index.json.sha256"
 )
 if ! DISCOVERY_ASSET_ROWS="$(node -e '
   const fs = require("node:fs");
@@ -115,6 +122,24 @@ EXPECTED_ASSETS="$(node -e \
 for asset in "${RELEASE_ASSETS[@]}"; do
   test -f "${asset}" || { echo "Release asset is missing: ${asset}" >&2; exit 1; }
 done
+(
+  cd "${INDEX_DIR}"
+  verify_sha256 qodo-skills-index.json.sha256
+)
+node -e '
+  const fs = require("node:fs");
+  const crypto = require("node:crypto");
+  const index = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const manifest = JSON.parse(fs.readFileSync(process.argv[4], "utf8"));
+  if (index.schemaVersion !== 2) throw new Error("release index schemaVersion must be 2");
+  if (index.sourceCommit !== process.argv[2]) throw new Error("release index sourceCommit does not match QODO_RELEASE_COMMIT");
+  if (index.packageVersion !== process.argv[3]) throw new Error("release index packageVersion does not match the release version");
+  const digest = crypto.createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex");
+  if (manifest.index?.name !== "qodo-skills-index.json" || manifest.index?.sha256 !== digest) {
+    throw new Error("enterprise manifest does not bind the published release index");
+  }
+  if (manifest.source?.commit !== process.argv[2]) throw new Error("enterprise manifest source does not match QODO_RELEASE_COMMIT");
+' "${INDEX_DIR}/qodo-skills-index.json" "${RELEASE_COMMIT}" "${VERSION}" "${ENTERPRISE_DIR}/qodo-enterprise-manifest.json"
 verify_discovery_digest() {
   local asset="$1" expected="$2" actual
   actual="$(node -e '
@@ -146,8 +171,8 @@ verify_release_assets() {
     verify_sha256 "${ARCHIVE_NAME}.sha256"
     verify_sha256 qodo-enterprise-manifest.json.sha256
   )
-  cmp --silent "${directory}/qodo-skills-index.json" "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json"
-  cmp --silent "${directory}/qodo-skills-index.json.sha256" "${RELEASE_SOURCE_DIR}/distribution/qodo-skills-index.json.sha256"
+  cmp --silent "${directory}/qodo-skills-index.json" "${INDEX_DIR}/qodo-skills-index.json"
+  cmp --silent "${directory}/qodo-skills-index.json.sha256" "${INDEX_DIR}/qodo-skills-index.json.sha256"
   cmp --silent "${directory}/qodo-cli-managed-bundle.json" "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json"
   cmp --silent "${directory}/qodo-cli-managed-bundle.json.sha256" "${RELEASE_SOURCE_DIR}/distribution/qodo-cli-managed-bundle.json.sha256"
   cmp --silent "${directory}/${ARCHIVE_NAME}" "${ENTERPRISE_DIR}/${ARCHIVE_NAME}"

--- a/scripts/release-index-test-helpers.mjs
+++ b/scripts/release-index-test-helpers.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function buildReleaseIndexFixture(sourceRoot, outputDirectory, sourceCommit) {
+  execFileSync(process.execPath, [
+    join(sourceRoot, 'scripts', 'build-release-index.mjs'),
+    '--output-dir', outputDirectory,
+    '--source-commit', sourceCommit,
+  ], { cwd: sourceRoot, stdio: 'pipe' });
+}
+
+export function assertReleaseIndexWorkflowContract(workflow) {
+  assert.match(workflow, /qodo-release-source\/scripts\/build-release-index\.mjs/);
+  assert.match(workflow, /--source-commit "\$\{RELEASE_COMMIT\}"/);
+  assert.match(workflow, /--release-index "\$\{RUNNER_TEMP\}\/qodo-release-index\/qodo-skills-index\.json"/);
+  assert.ok(
+    workflow.indexOf('build-release-index.mjs') < workflow.indexOf('build-enterprise-bundle.mjs'),
+    'the enterprise manifest must consume the already-generated release index',
+  );
+  assert.match(workflow, /QODO_RELEASE_INDEX_DIR: \$\{\{ runner\.temp \}\}\/qodo-release-index/);
+}
+
+export function assertMismatchedReleaseIndexRejected({
+  checkout, indexDirectory, publishEnvironment, publishPath, releaseSource, releaseCommit, runShell,
+}) {
+  const indexPath = join(indexDirectory, 'qodo-skills-index.json');
+  const index = JSON.parse(readFileSync(indexPath, 'utf8'));
+  index.sourceCommit = '0'.repeat(40);
+  const text = `${JSON.stringify(index, null, 2)}\n`;
+  writeFileSync(indexPath, text);
+  writeFileSync(`${indexPath}.sha256`,
+    `${createHash('sha256').update(text).digest('hex')}  qodo-skills-index.json\n`);
+  assert.throws(() => runShell(checkout, publishPath, publishEnvironment),
+    /release index sourceCommit does not match QODO_RELEASE_COMMIT/);
+  buildReleaseIndexFixture(releaseSource, indexDirectory, releaseCommit);
+}

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -16,33 +16,33 @@ import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { buildEnterpriseBundle } from './build-enterprise-bundle.mjs';
 import { assertDiscoveryManifestFailures } from './test-release-discovery-assets.mjs';
+import {
+  assertMismatchedReleaseIndexRejected,
+  assertReleaseIndexWorkflowContract,
+  buildReleaseIndexFixture,
+} from './release-index-test-helpers.mjs';
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const workflow = readFileSync(join(root, '.github', 'workflows', 'release.yml'), 'utf8');
 const preflight = readFileSync(join(root, 'scripts', 'verify-release-prerequisites.sh'), 'utf8');
 const publisher = readFileSync(join(root, 'scripts', 'publish-release.sh'), 'utf8');
 const protectionAudit = readFileSync(join(root, 'scripts', 'audit-release-protections.sh'), 'utf8');
 const releaseSource = `${workflow}\n${preflight}\n${publisher}`;
-const packageVersion = JSON.parse(
-  readFileSync(join(root, 'package.json'), 'utf8'),
-).version;
+const packageVersion = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version;
 const releaseTag = `v${packageVersion}`;
 const escapedReleaseTag = releaseTag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-assert.doesNotMatch(releaseSource, /^\s+push:/m,
-  'source merge must not bypass the CLI-first release order or an unmet credential gate');
+assert.doesNotMatch(releaseSource, /^\s+push:/m, 'source merge must not bypass the CLI-first release order or an unmet credential gate');
 assert.match(releaseSource, /^\s+workflow_dispatch:/m);
-assert.match(workflow, /github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\)/,
-  'the write-scoped release job must run only from the default branch');
+assert.match(workflow, /github\.ref == format\('refs\/heads\/\{0\}', github\.event\.repository\.default_branch\)/, 'the write-scoped release job must run only from the default branch');
 assert.match(workflow, /run: scripts\/verify-release-prerequisites\.sh/);
 assert.match(workflow, /run: scripts\/publish-release\.sh/);
 assert.match(workflow, /qodo-release-source\/scripts\/build-enterprise-bundle\.mjs/);
+assertReleaseIndexWorkflowContract(workflow);
 assert.match(workflow, /git worktree add --detach/);
 assert.match(workflow, /QODO_RELEASE_SOURCE_DIR: \$\{\{ runner\.temp \}\}\/qodo-release-source/);
 assert.match(workflow, /QODO_RELEASE_NOTES_FILE: \$\{\{ runner\.temp \}\}\/qodo-release-notes\.md/);
 assert.match(workflow, /QODO_ENTERPRISE_RELEASE_DIR/);
-assert.match(readFileSync(join(root, 'scripts', 'verify-release-prerequisites.cmd'), 'utf8'),
-  /bash "%~dp0verify-release-prerequisites\.sh"/);
-assert.match(readFileSync(join(root, 'scripts', 'publish-release.cmd'), 'utf8'),
-  /bash "%~dp0publish-release\.sh"/);
+assert.match(readFileSync(join(root, 'scripts', 'verify-release-prerequisites.cmd'), 'utf8'), /bash "%~dp0verify-release-prerequisites\.sh"/);
+assert.match(readFileSync(join(root, 'scripts', 'publish-release.cmd'), 'utf8'), /bash "%~dp0publish-release\.sh"/);
 
 const tagCreation = releaseSource.indexOf('git tag --no-sign -a');
 const releaseCreation = releaseSource.indexOf('gh release create');
@@ -73,34 +73,26 @@ const draftVerification = releaseSource.indexOf('verify_release_assets "${VERIFY
 const remoteTagCheck = releaseSource.indexOf('require_annotated_release_tag', draftCreation);
 const publishedDownload = releaseSource.indexOf('gh release download', draftPublish);
 const publishedVerification = releaseSource.indexOf('verify_release_assets "${PUBLISHED_VERIFY_DIR}"', publishedDownload);
-assert.match(protectionAudit, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/,
-  'the administrator audit must check repository immutability');
-assert.match(preflight, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/,
-  'the protected App token must verify immutability before publication');
+assert.match(protectionAudit, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/, 'the administrator audit must check repository immutability');
+assert.match(preflight, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/, 'the protected App token must verify immutability before publication');
 assert.match(workflow, /environment:\s*\n\s*name: marketplace-kiro/);
 assert.match(workflow, /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
 assert.match(workflow, /permission-administration: read/);
 assert.match(workflow, /Mint installation-wide read-only release preflight token/);
-assert.doesNotMatch(workflow, /repositories: qodo-skills/,
-  'the read-only preflight token must see the complete installation repository set');
+assert.doesNotMatch(workflow, /repositories: qodo-skills/, 'the read-only preflight token must see the complete installation repository set');
 assert.match(workflow, /GH_TOKEN: \$\{\{ steps\.release-preflight-token\.outputs\.token \}\}/);
 assert.match(preflight, /installation\/repositories\?per_page=100/);
-assert.ok(exactMainGuard >= 0 && exactMainGuard < tagCreation,
-  'release workflow must require the exact merged main commit before creating a tag');
+assert.ok(exactMainGuard >= 0 && exactMainGuard < tagCreation, 'release workflow must require the exact merged main commit before creating a tag');
 assert.match(releaseSource, /git fetch origin main --no-tags/);
 assert.match(releaseSource, /git rev-parse origin\/main/);
 assert.match(releaseSource, /git tag --no-sign -a/);
-assert.ok(validationInstall >= 0 && validationInstall < validationRun,
-  'locked validation dependencies must be installed before release validation');
-assert.ok(firstMainGuard > validationRun && firstMainGuard < existingReleaseBranch,
-  'the verified release commit must still be the exact main head before release handling');
-assert.ok(checkoutGuard >= 0 && checkoutGuard < catalogRead,
-  'the publisher must bind a clean local checkout to GITHUB_SHA before reading release assets');
+assert.ok(validationInstall >= 0 && validationInstall < validationRun, 'locked validation dependencies must be installed before release validation');
+assert.ok(firstMainGuard > validationRun && firstMainGuard < existingReleaseBranch, 'the verified release commit must still be the exact main head before release handling');
+assert.ok(checkoutGuard >= 0 && checkoutGuard < catalogRead, 'the publisher must bind a clean local checkout to GITHUB_SHA before reading release assets');
 assert.match(publisher, /git rev-parse HEAD/);
 assert.match(publisher, /git diff --quiet --ignore-submodules --/);
 assert.match(publisher, /git diff --cached --quiet --ignore-submodules --/);
-assert.ok(toolChecks >= 0 && toolChecks < exactMainGuard,
-  'external release tools must be checked before their first use');
+assert.ok(toolChecks >= 0 && toolChecks < exactMainGuard, 'external release tools must be checked before their first use');
 assert.match(releaseSource, /command -v "\$\{tool\}"/);
 assert.match(publisher, /command -v sha256sum/);
 assert.match(publisher, /command -v shasum/);
@@ -269,6 +261,7 @@ try {
   }
   copyFileSync(join(root, 'releases', `${releaseTag}.json`), join(checkout, 'releases', `${releaseTag}.json`));
   copyFileSync(join(root, 'scripts', 'release-notes.mjs'), join(checkout, 'scripts', 'release-notes.mjs'));
+  copyFileSync(join(root, 'scripts', 'build-release-index.mjs'), join(checkout, 'scripts', 'build-release-index.mjs'));
   copyFileSync(join(root, 'scripts', 'publish-release.sh'), join(checkout, 'scripts', 'publish-release.sh'));
   copyFileSync(join(root, 'scripts', 'publish-release.cmd'), join(checkout, 'scripts', 'publish-release.cmd'));
   chmodSync(join(checkout, 'scripts', 'publish-release.sh'), 0o755);
@@ -276,12 +269,14 @@ try {
   run(checkout, 'git', ['-c', 'commit.gpgsign=false', 'commit', '-m', 'release fixture']);
   const releaseSha = run(checkout, 'git', ['rev-parse', 'HEAD']).trim();
   const enterpriseDir = join(harness, 'enterprise-assets');
-  buildEnterpriseBundle({ output: enterpriseDir, commit: releaseSha });
   run(harness, 'git', ['init', '--bare', '--initial-branch=main', behaviorOrigin]);
   run(checkout, 'git', ['remote', 'add', 'origin', behaviorOrigin]);
   run(checkout, 'git', ['push', '-u', 'origin', 'main']);
   const releaseSourceCheckout = join(harness, 'release-source');
   run(checkout, 'git', ['worktree', 'add', '--detach', releaseSourceCheckout, releaseSha]);
+  const releaseIndexDir = join(harness, 'release-index');
+  buildReleaseIndexFixture(releaseSourceCheckout, releaseIndexDir, releaseSha);
+  buildEnterpriseBundle({ output: enterpriseDir, commit: releaseSha, releaseIndex: join(releaseIndexDir, 'qodo-skills-index.json') });
   const releaseNotes = join(harness, 'release-notes.md');
   run(releaseSourceCheckout, process.execPath, [join(releaseSourceCheckout, 'scripts', 'release-notes.mjs'), releaseNotes]);
   // The publisher owns the tag format even when the runner prefers signed tags.
@@ -295,8 +290,13 @@ try {
     QODO_ENTERPRISE_RELEASE_DIR: enterpriseDir,
     QODO_RELEASE_NOTES_FILE: releaseNotes,
     QODO_RELEASE_SOURCE_DIR: releaseSourceCheckout,
+    QODO_RELEASE_INDEX_DIR: releaseIndexDir,
   };
   const publishPath = join(checkout, 'scripts', 'publish-release.sh');
+  assertMismatchedReleaseIndexRejected({
+    checkout, indexDirectory: releaseIndexDir, publishEnvironment: publishEnv, publishPath,
+    releaseSource: releaseSourceCheckout, releaseCommit: releaseSha, runShell,
+  });
   assert.throws(() => runShell(checkout, publishPath, {
     ...publishEnv,
     FAKE_RELEASE_LOOKUP_ERROR: 'true',


### PR DESCRIPTION
## Outcome

Publishes Qodo skills `v1.0.10` with an immutable source identity that the public CLI installer can trust.

## What changed

- builds the release index from the detached release worktree and records its exact commit in schema v2
- verifies the index checksum, package version, and source commit before draft creation or resume
- keeps tracked development indexes deterministic while release assets are generated separately
- updates the cutover and release strategy to the consented, verified onboarding UX
- adds recovery and corruption coverage for the new release input

## Validation

- `npm test`
- `git diff --check`

## Release order

1. merge and deploy qodo-ai/qodo-agent-runtime#587 (schema compatibility only; no repin)
2. merge this PR
3. publish and verify immutable `v1.0.10`
4. merge qodo-ai/qodo-in-cli#229
5. publish CLI `.40`, validate development, then promote protected production

Implements CLI-322 and the Qodo marketplace cutover strategy.
