### PR TITLE
ci(release): start marketplace promotion automatically

### DIFF
--- a/.github/workflows/marketplace-auto-start.yml
+++ b/.github/workflows/marketplace-auto-start.yml
@@ -72,9 +72,6 @@ jobs:
     needs: plan
     if: needs.plan.outputs.needed == 'true'
     runs-on: ubuntu-latest
-    concurrency:
-      group: qodo-marketplaces-${{ needs.plan.outputs.tag }}
-      cancel-in-progress: false
     steps:
       - name: Check out reviewed automation
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/marketplace-auto-start.yml
+++ b/.github/workflows/marketplace-auto-start.yml
@@ -23,11 +23,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  enqueue:
+  plan:
     if: >-
       github.repository == 'qodo-ai/qodo-skills' &&
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
+    outputs:
+      needed: ${{ steps.plan.outputs.needed }}
+      tag: ${{ steps.plan.outputs.tag }}
     steps:
       - name: Check out reviewed automation
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -65,14 +68,36 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Enqueue every configured marketplace
-        if: steps.plan.outputs.needed == 'true'
+  enqueue:
+    needs: plan
+    if: needs.plan.outputs.needed == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: qodo-marketplaces-${{ needs.plan.outputs.tag }}
+      cancel-in-progress: false
+    steps:
+      - name: Check out reviewed automation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Recheck and enqueue every configured marketplace
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.plan.outputs.tag }}
-        run: >-
-          gh workflow run ship-marketplaces.yml
-          --ref main
-          -f release_tag="${RELEASE_TAG}"
-          -f all=true
-
+          RELEASE_TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          set -euo pipefail
+          plan="$(node scripts/plan-marketplace-auto-start.mjs --tag "${RELEASE_TAG}")"
+          if [[ "$(jq -r '.needed' <<<"$plan")" == 'true' ]]; then
+            gh workflow run ship-marketplaces.yml \
+              --ref main \
+              -f release_tag="${RELEASE_TAG}" \
+              -f all=true
+          else
+            echo 'A default-branch marketplace run appeared before enqueue; no duplicate was created.'
+          fi

--- a/.github/workflows/marketplace-auto-start.yml
+++ b/.github/workflows/marketplace-auto-start.yml
@@ -1,0 +1,78 @@
+name: Start marketplace release when compatibility is live
+
+on:
+  schedule:
+    # qodo-in-cli checks for immutable skills releases at :17. This target-owned
+    # watcher observes only the protected production pointer, so providers never
+    # start from a canary-only or unpublished release.
+    - cron: '43 * * * *'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Production-compatible tag to enqueue (empty uses get.qodo.ai)'
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: qodo-marketplace-auto-start
+  cancel-in-progress: false
+
+jobs:
+  enqueue:
+    if: >-
+      github.repository == 'qodo-ai/qodo-skills' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out reviewed automation
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          ref: main
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+
+      - name: Resolve production-compatible marketplace release
+        id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          plan="$(node scripts/plan-marketplace-auto-start.mjs --tag "${REQUESTED_TAG:-}")"
+          echo "tag=$(jq -r '.tag' <<<"$plan")" >> "$GITHUB_OUTPUT"
+          echo "needed=$(jq -r '.needed' <<<"$plan")" >> "$GITHUB_OUTPUT"
+          echo "existing_url=$(jq -r '.existingRun.url // ""' <<<"$plan")" >> "$GITHUB_OUTPUT"
+          {
+            echo '## Marketplace release plan'
+            echo
+            echo "Release: \`$(jq -r '.tag' <<<"$plan")\`"
+            echo
+            echo "Source: \`$(jq -r '.sourceCommit' <<<"$plan")\`"
+            if [[ "$(jq -r '.needed' <<<"$plan")" == 'true' ]]; then
+              echo
+              echo 'No marketplace workflow exists for this production-compatible release; enqueueing all providers.'
+            else
+              echo
+              echo "Already started: $(jq -r '.existingRun.url // "run URL unavailable"' <<<"$plan")"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Enqueue every configured marketplace
+        if: steps.plan.outputs.needed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.plan.outputs.tag }}
+        run: >-
+          gh workflow run ship-marketplaces.yml
+          --ref main
+          -f release_tag="${RELEASE_TAG}"
+          -f all=true
+

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -257,9 +257,10 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
-import at Node 20.6; two independent uncached sampling rounds over the same complete set of declared
-MP1 replicas, each reporting the release commit and promoted image digest; fresh authenticated
-clean-machine import of exactly the four core skills into Codex and Claude; Standards and unrelated
+import at Node 20.6; a content-addressed `tag@sha256:digest` MP1 deployment; two independent
+uncached sampling rounds over the same complete set of declared MP1 replicas, with at least four
+consecutive probes and each replica reporting the release commit and promoted image digest; fresh
+authenticated clean-machine import of exactly the four core skills into Codex and Claude; Standards and unrelated
 skills absent; CLI and installer bytes verified before execution; explicit owner-only file storage
 for headless login with the MP1 key scoped only to that step; an authenticated same-origin identity
 request after installation; live runtime

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -80,7 +80,7 @@ immutable qodo-skills release
 QAR Release Please merge
         ↓ automatic build-once beta promotion
 MP1 rollout
-        ↓ readiness + exact QAR/CLI/skills digest acceptance
+        ↓ four stable probes + authenticated clean install + exact tuple receipt
 protected production + ST + on-prem distribution promotion
 ```
 
@@ -88,8 +88,9 @@ The pull model is idempotent. A watcher does nothing when its target already adv
 release. The marketplace watcher byte-verifies the protected compatibility assets against the
 immutable release, rejects releases below its successful default-branch run watermark, and rechecks
 immediately before dispatch. The downstream atomic release lock safely arbitrates a simultaneous
-manual launch. The QAR synchronizer uses one stable branch and PR for the complete distribution
-tuple. The original manual compatibility,
+manual launch. The QAR synchronizer validates and executes downloaded artifacts on a credential-free
+runner, then regenerates the same data-only locks on a fresh runner before minting its scoped PR
+token. It uses one stable branch and PR for the complete distribution tuple. The original manual compatibility,
 marketplace, CLI-pin, and skills-pin workflows remain recovery controls. Production environments,
 provider publication, PR merge, and customer deployment remain human-owned gates.
 
@@ -224,7 +225,10 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 - QAR's hourly target-owned synchronizer, delivered by `qodo-agent-runtime#594`, reads the protected
   public CLI pointer and newest immutable GitHub skills release, updates
   the CLI lock before validating the skills minimum, verifies and smoke-tests the combined tuple,
-  and opens or refreshes one dependency PR. Until that PR is merged, the separate single-pin
+  and opens or refreshes one dependency PR. Public artifacts never execute on the runner that holds
+  the repository write token: a fresh writer regenerates and binds the data-only locks to the
+  credential-free validation result first. An unchanged automation branch preserves its head,
+  reviews, and approvals. Until that PR is merged, the separate single-pin
   workflows remain authoritative; afterward they remain manual recovery controls.
 - The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
   public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
@@ -250,7 +254,10 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
-import at Node 20.6; fresh clean-machine core import into Codex and Claude; Standards absent;
+import at Node 20.6; four consecutive uncached MP1 tuple probes; fresh authenticated clean-machine
+import of exactly the four core skills into Codex and Claude; Standards and unrelated skills absent;
+an immutable acceptance receipt binding QAR image digest, commit, CLI, and skills; production
+promotion of that accepted image digest only;
 prompted upgrade; retry; new-session activation; and a pre-`.40` CLI accepting the generated
 schema-v1 pointer and checksum. A later QAR **repin** PR cannot become merge-ready
 until the immutable qodo-skills release exists at the exact bytes in its lock; the backward-compatible
@@ -362,13 +369,13 @@ optional skills are discoverable but never auto-installed.
 |---|---|---|
 | Source | exact merged heads, full CI, generated-drift checks | GitHub release |
 | Repository | successful administrator audit, dedicated repository-scoped release App, immutable releases enabled, no-bypass `v*` tag ruleset, protected `marketplace-kiro` branch, protected tag SHA, and post-publication immutable asset bytes | all promotion |
-| Automation | protected compatibility pointer, one marketplace run per tag, one reviewed QAR tuple PR | downstream promotion |
+| Automation | protected compatibility pointer, one marketplace run per tag, one reviewed QAR tuple PR, credential-isolated tuple validation | downstream promotion |
 | Claude | official catalog exact SHA/path | Claude completion |
 | Kiro | live Agent Plugins power on `marketplace-kiro` at the exact release SHA/path | Kiro completion |
 | Codex | portal review + publish + protected attestation | Codex completion and old-repo deprecation |
 | Behavior | fresh install, upgrade, package isolation, setup/read/write/update | provider sign-off |
 | Migration | no duplicate/shadowed skill; cleanup preserves user changes | broad rollout |
-| On-prem | immutable enterprise asset hashes, QAR pin/routes, no-egress, core-only import and upgrade | enterprise rollout |
+| On-prem | immutable enterprise asset hashes, QAR pin/routes, no-egress, MP1 authenticated exact-core install receipt, accepted image digest, core-only customer import and upgrade | enterprise rollout |
 
 No gate is satisfied by an announcement, packet, or green workflow that does not prove the named
 external state.

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -80,7 +80,7 @@ immutable qodo-skills release
 QAR Release Please merge
         ↓ automatic build-once beta promotion
 MP1 rollout
-        ↓ all replicas digest-bound + authenticated clean install + exact tuple receipt
+        ↓ stable all-replica digest quorum + authenticated clean install + exact tuple receipt
 protected production + ST + on-prem distribution promotion
 ```
 
@@ -257,10 +257,12 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
-import at Node 20.6; uncached digest-bound MP1 tuple evidence from every declared replica; fresh
-authenticated clean-machine import of exactly the four core skills into Codex and Claude; Standards
-and unrelated skills absent; CLI and installer bytes verified before execution; the MP1 key scoped
-only to login; an authenticated same-origin identity request after installation; live runtime
+import at Node 20.6; two independent uncached sampling rounds over the same complete set of declared
+MP1 replicas, each reporting the release commit and promoted image digest; fresh authenticated
+clean-machine import of exactly the four core skills into Codex and Claude; Standards and unrelated
+skills absent; CLI and installer bytes verified before execution; explicit owner-only file storage
+for headless login with the MP1 key scoped only to that step; an authenticated same-origin identity
+request after installation; live runtime
 evidence of the promoted image digest; an immutable acceptance receipt binding QAR image digest,
 commit, CLI, and skills; production promotion of that accepted image digest only;
 prompted upgrade; retry; new-session activation; and a pre-`.40` CLI accepting the generated

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -85,8 +85,10 @@ protected production + ST + on-prem distribution promotion
 ```
 
 The pull model is idempotent. A watcher does nothing when its target already advertises the selected
-release, an existing marketplace run suppresses duplicate dispatch, and the QAR synchronizer uses
-one stable branch and PR for the complete distribution tuple. The original manual compatibility,
+release. The marketplace watcher byte-verifies the protected compatibility assets, rejects releases
+below its default-branch run watermark, and rechecks inside the downstream per-tag concurrency group
+before dispatch. The QAR synchronizer uses one stable branch and PR for the complete distribution
+tuple. The original manual compatibility,
 marketplace, CLI-pin, and skills-pin workflows remain recovery controls. Production environments,
 provider publication, PR merge, and customer deployment remain human-owned gates.
 
@@ -218,10 +220,11 @@ Rollback: publish a new immutable patch. Never replace the release asset.
   `/toolbox/skills/<package>/.well-known/agent-skills/index.json` and its digest-pinned archives at
   `/toolbox/skills/<package>/artifacts/<asset>`. The index-relative `../../artifacts/<asset>` URL
   resolves to that same package-scoped route; it does not escape `/toolbox/skills/<package>`.
-- QAR's hourly target-owned synchronizer reads the protected public CLI and skills pointers, updates
+- QAR's hourly target-owned synchronizer, delivered by `qodo-agent-runtime#594`, reads the protected
+  public CLI and skills pointers, updates
   the CLI lock before validating the skills minimum, verifies and smoke-tests the combined tuple,
-  and opens or refreshes one dependency PR. The separate single-pin workflows remain manual
-  recovery controls.
+  and opens or refreshes one dependency PR. Until that PR is merged, the separate single-pin
+  workflows remain authoritative; afterward they remain manual recovery controls.
 - The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
   public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
   lifecycle owners.
@@ -257,14 +260,17 @@ unchanged unless runtime compatibility independently requires it.
 
 ### 3. Promote Claude and Kiro
 
-After the protected compatibility pointer is live, the hourly marketplace watcher automatically
-starts one **Ship marketplaces** run with all providers selected. Selection is provider-level: the action
+After the protected compatibility pointer is live, the hourly marketplace watcher verifies the
+advertised index and bundle checksums and release identity, then automatically starts one **Ship
+marketplaces** run with all providers selected. Selection is provider-level: the action
 ships every configured listing for each selected provider, including both `qodo` and the separately
 installable `qodo-standards`. It then pauses each provider verification in its protected environment
 while the release owner completes any provider submission. Approve a provider only when its listing
 is expected to be visible; the resumed job verifies the exact release and fails closed otherwise.
-An existing run for the tag suppresses duplicate automatic dispatch, including after failure; release
-owners use the manual provider selector to retry or recover only the required providers.
+An existing default-branch run for the tag suppresses duplicate automatic dispatch, including after
+failure. The watcher rejects a tag below the highest prior default-branch release and rechecks inside
+the downstream per-tag concurrency group before dispatch, closing the schedule/manual launch race.
+Release owners use the manual provider selector to retry or recover only the required providers.
 Only one release tag may be active across providers: any attempt fails visibly while a different
 tag owns the atomic `refs/heads/qodo-marketplace-release-lock`. The owner holds it through provider
 approval. Acquire, stale recovery, and release append commits with non-force fast-forward updates,

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -70,12 +70,12 @@ cross-repository administrator token is stored in the public skills repository.
 
 ```text
 immutable qodo-skills release
-        ↓ hourly target-owned discovery
-qodo-in-cli compatibility canary
-        ↓ protected production approval
-get.qodo.ai skills pointer
-        ├── qodo-skills enqueues one all-provider marketplace run
-        └── QAR opens or refreshes one compatible CLI + skills pin PR
+        ├── hourly qodo-in-cli compatibility canary
+        │       ↓ protected production approval
+        │   get.qodo.ai skills pointer
+        │       └── qodo-skills enqueues one all-provider marketplace run
+        └── QAR combines it with the protected CLI pointer
+                └── opens or refreshes one compatible CLI + skills pin PR
 
 QAR Release Please merge
         ↓ automatic build-once beta promotion
@@ -85,9 +85,10 @@ protected production + ST + on-prem distribution promotion
 ```
 
 The pull model is idempotent. A watcher does nothing when its target already advertises the selected
-release. The marketplace watcher byte-verifies the protected compatibility assets, rejects releases
-below its default-branch run watermark, and rechecks inside the downstream per-tag concurrency group
-before dispatch. The QAR synchronizer uses one stable branch and PR for the complete distribution
+release. The marketplace watcher byte-verifies the protected compatibility assets against the
+immutable release, rejects releases below its successful default-branch run watermark, and rechecks
+immediately before dispatch. The downstream atomic release lock safely arbitrates a simultaneous
+manual launch. The QAR synchronizer uses one stable branch and PR for the complete distribution
 tuple. The original manual compatibility,
 marketplace, CLI-pin, and skills-pin workflows remain recovery controls. Production environments,
 provider publication, PR merge, and customer deployment remain human-owned gates.
@@ -221,7 +222,7 @@ Rollback: publish a new immutable patch. Never replace the release asset.
   `/toolbox/skills/<package>/artifacts/<asset>`. The index-relative `../../artifacts/<asset>` URL
   resolves to that same package-scoped route; it does not escape `/toolbox/skills/<package>`.
 - QAR's hourly target-owned synchronizer, delivered by `qodo-agent-runtime#594`, reads the protected
-  public CLI and skills pointers, updates
+  public CLI pointer and newest immutable GitHub skills release, updates
   the CLI lock before validating the skills minimum, verifies and smoke-tests the combined tuple,
   and opens or refreshes one dependency PR. Until that PR is merged, the separate single-pin
   workflows remain authoritative; afterward they remain manual recovery controls.
@@ -261,15 +262,18 @@ unchanged unless runtime compatibility independently requires it.
 ### 3. Promote Claude and Kiro
 
 After the protected compatibility pointer is live, the hourly marketplace watcher verifies the
-advertised index and bundle checksums and release identity, then automatically starts one **Ship
+advertised index and bundle checksums, release identity, and exact equality with the immutable
+GitHub release assets, then automatically starts one **Ship
 marketplaces** run with all providers selected. Selection is provider-level: the action
 ships every configured listing for each selected provider, including both `qodo` and the separately
 installable `qodo-standards`. It then pauses each provider verification in its protected environment
 while the release owner completes any provider submission. Approve a provider only when its listing
 is expected to be visible; the resumed job verifies the exact release and fails closed otherwise.
 An existing default-branch run for the tag suppresses duplicate automatic dispatch, including after
-failure. The watcher rejects a tag below the highest prior default-branch release and rechecks inside
-the downstream per-tag concurrency group before dispatch, closing the schedule/manual launch race.
+failure. The watcher rejects a tag below the highest successful default-branch release, serializes
+automatic launches, and rechecks immediately before dispatch. A simultaneous manual dispatch may
+create a second run, but the downstream atomic release lock admits exactly one owner without using
+GitHub Actions' lossy pending-run concurrency.
 Release owners use the manual provider selector to retry or recover only the required providers.
 Only one release tag may be active across providers: any attempt fails visibly while a different
 tag owns the atomic `refs/heads/qodo-marketplace-release-lock`. The owner holds it through provider

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -63,6 +63,33 @@ QAR /toolbox ── independently pinned CLI + enterprise skills assets
              └── path-scoped v0.2 feeds and digest-pinned archives; no runtime public egress
 ```
 
+## Automated release train
+
+The repositories pull verified state from the lifecycle owner immediately upstream; no
+cross-repository administrator token is stored in the public skills repository.
+
+```text
+immutable qodo-skills release
+        ↓ hourly target-owned discovery
+qodo-in-cli compatibility canary
+        ↓ protected production approval
+get.qodo.ai skills pointer
+        ├── qodo-skills enqueues one all-provider marketplace run
+        └── QAR opens or refreshes one compatible CLI + skills pin PR
+
+QAR Release Please merge
+        ↓ automatic build-once beta promotion
+MP1 rollout
+        ↓ readiness + exact QAR/CLI/skills digest acceptance
+protected production + ST + on-prem distribution promotion
+```
+
+The pull model is idempotent. A watcher does nothing when its target already advertises the selected
+release, an existing marketplace run suppresses duplicate dispatch, and the QAR synchronizer uses
+one stable branch and PR for the complete distribution tuple. The original manual compatibility,
+marketplace, CLI-pin, and skills-pin workflows remain recovery controls. Production environments,
+provider publication, PR merge, and customer deployment remain human-owned gates.
+
 ## Cutover sequence
 
 The architecture is final; the operational rollout is staged so every step has an independent
@@ -162,12 +189,13 @@ copy and recoverable predecessor; marketplace skills remain owned by their host.
   schema-v2 compact index generated from the detached release worktree with its exact source commit,
   the data-only CLI-managed bundle, the enterprise bundle, and their checksums. Publication rejects
   an index whose commit or package version differs from the resolved release.
-- After the immutable GitHub release is verified, dispatch **release: publish skills compatibility
-  channel** in `qodo-ai/qodo-in-cli` with that exact tag. Its canary job verifies the immutable
+- After the immutable GitHub release is verified, the hourly **release: publish skills compatibility
+  channel** watcher in `qodo-ai/qodo-in-cli` selects that newest immutable release. Its canary job verifies the immutable
   release and checksums, copies the compact index and CLI-managed bundle to tag-scoped
   `get.qodo.ai` paths, and advances only the `skills` pointers in `version.json`. The protected
-  production job promotes the exact canary bytes. CLI release jobs preserve those pointers when
-  they update the independent runtime channel.
+  production job still requires approval and promotes the exact canary bytes. An exact tag may be
+  dispatched manually for recovery. CLI release jobs preserve those pointers when they update the
+  independent runtime channel.
 - Smoke-test skills.sh core installation on representative non-marketplace agents before provider
   promotion.
 
@@ -190,6 +218,10 @@ Rollback: publish a new immutable patch. Never replace the release asset.
   `/toolbox/skills/<package>/.well-known/agent-skills/index.json` and its digest-pinned archives at
   `/toolbox/skills/<package>/artifacts/<asset>`. The index-relative `../../artifacts/<asset>` URL
   resolves to that same package-scoped route; it does not escape `/toolbox/skills/<package>`.
+- QAR's hourly target-owned synchronizer reads the protected public CLI and skills pointers, updates
+  the CLI lock before validating the skills minimum, verifies and smoke-tests the combined tuple,
+  and opens or refreshes one dependency PR. The separate single-pin workflows remain manual
+  recovery controls.
 - The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
   public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
   lifecycle owners.
@@ -225,11 +257,14 @@ unchanged unless runtime compatibility independently requires it.
 
 ### 3. Promote Claude and Kiro
 
-Run **Ship marketplaces** with Claude and Kiro selected. Selection is provider-level: the action
+After the protected compatibility pointer is live, the hourly marketplace watcher automatically
+starts one **Ship marketplaces** run with all providers selected. Selection is provider-level: the action
 ships every configured listing for each selected provider, including both `qodo` and the separately
 installable `qodo-standards`. It then pauses each provider verification in its protected environment
 while the release owner completes any provider submission. Approve a provider only when its listing
 is expected to be visible; the resumed job verifies the exact release and fails closed otherwise.
+An existing run for the tag suppresses duplicate automatic dispatch, including after failure; release
+owners use the manual provider selector to retry or recover only the required providers.
 Only one release tag may be active across providers: any attempt fails visibly while a different
 tag owns the atomic `refs/heads/qodo-marketplace-release-lock`. The owner holds it through provider
 approval. Acquire, stale recovery, and release append commits with non-force fast-forward updates,
@@ -258,7 +293,7 @@ strictly forward-only because the protected release branch cannot be rewound.
 
 ### 4. Promote Codex and deprecate the old source
 
-Run **Ship marketplaces** with Codex selected, download the exact packet, update the existing Qodo
+Use the all-provider run's Codex packet, update the existing Qodo
 listing through the OpenAI portal, wait for review, and publish. Only after publication may the
 release owner approve `marketplace-codex`.
 
@@ -317,6 +352,7 @@ optional skills are discoverable but never auto-installed.
 |---|---|---|
 | Source | exact merged heads, full CI, generated-drift checks | GitHub release |
 | Repository | successful administrator audit, dedicated repository-scoped release App, immutable releases enabled, no-bypass `v*` tag ruleset, protected `marketplace-kiro` branch, protected tag SHA, and post-publication immutable asset bytes | all promotion |
+| Automation | protected compatibility pointer, one marketplace run per tag, one reviewed QAR tuple PR | downstream promotion |
 | Claude | official catalog exact SHA/path | Claude completion |
 | Kiro | live Agent Plugins power on `marketplace-kiro` at the exact release SHA/path | Kiro completion |
 | Codex | portal review + publish + protected attestation | Codex completion and old-repo deprecation |

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -88,11 +88,13 @@ The pull model is idempotent. A watcher does nothing when its target already adv
 release. The marketplace watcher byte-verifies the protected compatibility assets against the
 immutable release, rejects releases below its successful default-branch run watermark, and rechecks
 immediately before dispatch. The downstream atomic release lock safely arbitrates a simultaneous
-manual launch. The QAR synchronizer validates and executes downloaded artifacts on a credential-free
-runner, then regenerates the same data-only locks on a fresh runner before minting its scoped PR
-token. It uses one stable branch and PR for the complete distribution tuple. The original manual compatibility,
-marketplace, CLI-pin, and skills-pin workflows remain recovery controls. Production environments,
-provider publication, PR merge, and customer deployment remain human-owned gates.
+manual launch. The QAR synchronizer resolves and verifies data-only locks without credentials,
+attests their path-independent tuple digest in a run-scoped artifact, and restores those exact bytes
+on separate validation and writer runners. Only the writer mints the scoped PR token, after the
+artifact has passed the composed distribution smoke test. It uses one stable branch and PR for the
+complete distribution tuple. The original manual compatibility, marketplace, CLI-pin, and
+skills-pin workflows remain recovery controls. Production environments, provider publication, PR
+merge, and customer deployment remain human-owned gates.
 
 ## Cutover sequence
 
@@ -226,9 +228,10 @@ Rollback: publish a new immutable patch. Never replace the release asset.
   public CLI pointer and newest immutable GitHub skills release, updates
   the CLI lock before validating the skills minimum, verifies and smoke-tests the combined tuple,
   and opens or refreshes one dependency PR. Public artifacts never execute on the runner that holds
-  the repository write token: a fresh writer regenerates and binds the data-only locks to the
-  credential-free validation result first. An unchanged automation branch preserves its head,
-  reviews, and approvals. Until that PR is merged, the separate single-pin
+  the repository write token: a credential-free resolver publishes the exact verified locks as a
+  run-scoped artifact, a separate validator restores and smoke-tests those bytes, and only then does
+  a fresh writer restore the same tuple and mint its scoped token. An unchanged automation branch
+  preserves its head, reviews, and approvals. Until that PR is merged, the separate single-pin
   workflows remain authoritative; afterward they remain manual recovery controls.
 - The compatible CLI fetches from the recorded QAR origin, so an on-prem client never falls back to
   public GitHub. Historical CLI-managed roots and new enterprise roots retain separate receipts and
@@ -254,13 +257,12 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
-import at Node 20.6; uncached digest-bound MP1 tuple evidence from every declared replica; fresh authenticated clean-machine
-import of exactly the four core skills into Codex and Claude; Standards and unrelated skills absent;
-CLI and installer bytes verified before execution; the MP1 key scoped only to login; an authenticated
-same-origin identity request after installation;
-live runtime evidence of the promoted image digest; an immutable acceptance receipt binding QAR
-image digest, commit, CLI, and skills; production
-promotion of that accepted image digest only;
+import at Node 20.6; uncached digest-bound MP1 tuple evidence from every declared replica; fresh
+authenticated clean-machine import of exactly the four core skills into Codex and Claude; Standards
+and unrelated skills absent; CLI and installer bytes verified before execution; the MP1 key scoped
+only to login; an authenticated same-origin identity request after installation; live runtime
+evidence of the promoted image digest; an immutable acceptance receipt binding QAR image digest,
+commit, CLI, and skills; production promotion of that accepted image digest only;
 prompted upgrade; retry; new-session activation; and a pre-`.40` CLI accepting the generated
 schema-v1 pointer and checksum. A later QAR **repin** PR cannot become merge-ready
 until the immutable qodo-skills release exists at the exact bytes in its lock; the backward-compatible

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -80,7 +80,7 @@ immutable qodo-skills release
 QAR Release Please merge
         ↓ automatic build-once beta promotion
 MP1 rollout
-        ↓ four stable probes + authenticated clean install + exact tuple receipt
+        ↓ all replicas digest-bound + authenticated clean install + exact tuple receipt
 protected production + ST + on-prem distribution promotion
 ```
 
@@ -254,9 +254,12 @@ Rollback: publish a new immutable patch. Never replace the release asset.
 
 Gate: deterministic archive and discovery-feed rebuild; exact manifest/archive/index digests; QAR
 offline image build and route tests; private-origin no-egress; telemetry-disabled pinned-helper
-import at Node 20.6; four consecutive uncached MP1 tuple probes; fresh authenticated clean-machine
+import at Node 20.6; uncached digest-bound MP1 tuple evidence from every declared replica; fresh authenticated clean-machine
 import of exactly the four core skills into Codex and Claude; Standards and unrelated skills absent;
-an immutable acceptance receipt binding QAR image digest, commit, CLI, and skills; production
+CLI and installer bytes verified before execution; the MP1 key scoped only to login; an authenticated
+same-origin identity request after installation;
+live runtime evidence of the promoted image digest; an immutable acceptance receipt binding QAR
+image digest, commit, CLI, and skills; production
 promotion of that accepted image digest only;
 prompted upgrade; retry; new-session activation; and a pre-`.40` CLI accepting the generated
 schema-v1 pointer and checksum. A later QAR **repin** PR cannot become merge-ready

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -133,10 +133,11 @@ patch release; it is never accepted as a successful release.
 Once the protected compatibility pointer advertises the immutable tag, the hourly
 **Marketplace auto-start** watcher dispatches **Ship marketplaces** once with `all`. The action
 validates the tag/version, downloads the advertised compatibility index and bundle, verifies their
-checksums and release identity, regenerates the exact provider packet, and uploads one artifact per
-provider. It rejects a tag below the highest default-branch marketplace run. The watcher rechecks
-inside the same per-tag concurrency group used by **Ship marketplaces**, so simultaneous schedules
-cannot create duplicate runs. If any default-branch workflow run already exists for the tag,
+checksums and release identity, and byte-compares all four files with the immutable GitHub release
+assets before regenerating the exact provider packet. It rejects a tag below the highest successful
+default-branch marketplace run. The watcher serializes automatic launches and rechecks immediately
+before dispatch; a simultaneous manual launch is safely arbitrated by the downstream atomic release
+lock rather than Actions' lossy pending-run concurrency. If any default-branch workflow run already exists for the tag,
 automatic dispatch does not loop; use the manual `claude`, `codex`, `kiro`, or `all` selector for a
 deliberate retry or partial recovery.
 
@@ -211,8 +212,9 @@ indexes, and one digest-pinned archive per skill. The manifest carries the packa
 its CLI pin, verifies every byte while building the backend image, and serves it from the existing
 `/toolbox` origin. The hourly **distribution bundles: sync promoted CLI + skills pins** workflow,
 delivered by `qodo-agent-runtime#594`,
-updates the CLI lock first, validates the skills minimum against that selected runtime, builds and
-tests both bundles, and opens or refreshes one reviewed dependency PR. The separate CLI-only and
+reads the protected public CLI pointer and the newest immutable GitHub skills release. It updates
+the CLI lock first, validates the skills minimum against that selected runtime, builds and tests
+both bundles, and opens or refreshes one reviewed dependency PR. The separate CLI-only and
 skills-only workflows remain manual recovery controls. Until that QAR change is merged, the manual
 pin workflows remain the authoritative path.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -132,9 +132,13 @@ patch release; it is never accepted as a successful release.
 
 Once the protected compatibility pointer advertises the immutable tag, the hourly
 **Marketplace auto-start** watcher dispatches **Ship marketplaces** once with `all`. The action
-validates the tag/version, regenerates the exact provider packet, and uploads one artifact per
-provider. If any workflow run already exists for the tag, automatic dispatch does not loop; use the
-manual `claude`, `codex`, `kiro`, or `all` selector for a deliberate retry or partial recovery.
+validates the tag/version, downloads the advertised compatibility index and bundle, verifies their
+checksums and release identity, regenerates the exact provider packet, and uploads one artifact per
+provider. It rejects a tag below the highest default-branch marketplace run. The watcher rechecks
+inside the same per-tag concurrency group used by **Ship marketplaces**, so simultaneous schedules
+cannot create duplicate runs. If any default-branch workflow run already exists for the tag,
+automatic dispatch does not loop; use the manual `claude`, `codex`, `kiro`, or `all` selector for a
+deliberate retry or partial recovery.
 
 Only one release tag may be active across providers. Same-tag retries are grouped idempotently; any
 attempt atomically advances `refs/heads/qodo-marketplace-release-lock` to an owner commit before
@@ -205,10 +209,12 @@ Every immutable skills release carries `qodo-enterprise-manifest.json`, the dete
 indexes, and one digest-pinned archive per skill. The manifest carries the package's
 `minimumCliVersion`; QAR must reject the bundle when its independent CLI lock is older. QAR pins that release independently from
 its CLI pin, verifies every byte while building the backend image, and serves it from the existing
-`/toolbox` origin. QAR's hourly **distribution bundles: sync promoted CLI + skills pins** workflow
+`/toolbox` origin. The hourly **distribution bundles: sync promoted CLI + skills pins** workflow,
+delivered by `qodo-agent-runtime#594`,
 updates the CLI lock first, validates the skills minimum against that selected runtime, builds and
 tests both bundles, and opens or refreshes one reviewed dependency PR. The separate CLI-only and
-skills-only workflows remain manual recovery controls.
+skills-only workflows remain manual recovery controls. Until that QAR change is merged, the manual
+pin workflows remain the authoritative path.
 
 The discovery section has its own runtime minimum. QAR enforces the greater of the package-wide
 minimum and the discovery minimum, so compatibility assets can retain their older floor without

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -99,8 +99,8 @@ asset must match before the draft can become public. Draft uploads and downloads
 release and asset REST endpoints because GitHub's tag-oriented CLI cannot resolve drafts. An older
 tag without its draft fails closed; tags and assets are never moved, deleted, or overwritten.
 
-After that workflow succeeds, dispatch **release: publish skills compatibility channel** in
-`qodo-ai/qodo-in-cli` with the immutable `v<package-version>` tag. The workflow verifies the public
+After that workflow succeeds, `qodo-ai/qodo-in-cli`'s hourly **release: publish skills compatibility
+channel** watcher selects the newest immutable release. The workflow verifies the public
 release again, publishes the compact index and CLI-managed bundle under tag-scoped paths in the
 canary bucket, and then waits at the existing protected production environment before copying the
 same bytes to `get.qodo.ai`. It updates only these same-origin `version.json` fields:
@@ -112,6 +112,10 @@ same bytes to `get.qodo.ai`. It updates only these same-origin `version.json` fi
 Do not promote marketplaces until the production pointers resolve to the selected tag and both
 checksums verify. CLI releases preserve the `skills` object while changing their separate
 `channels` entry.
+
+The protected production approval remains mandatory. For recovery, a release owner may manually
+dispatch the same workflow with an exact immutable tag; the watcher becomes a no-op once production
+advertises that tag and rejects rollback to an older release.
 
 The index is metadata for stale-version notices. The CLI-managed bundle keeps only proven roots
 from earlier Qodo CLI releases current; it is never a new-install source. The enterprise archive contains the complete
@@ -126,9 +130,11 @@ patch release; it is never accepted as a successful release.
 
 ## 3. Ship selected marketplaces
 
-Run **Ship marketplaces** with the immutable tag and any combination of `claude`, `codex`, `kiro`,
-or `all`. The action validates the tag/version, regenerates the exact provider packet, and uploads
-one artifact per selected provider.
+Once the protected compatibility pointer advertises the immutable tag, the hourly
+**Marketplace auto-start** watcher dispatches **Ship marketplaces** once with `all`. The action
+validates the tag/version, regenerates the exact provider packet, and uploads one artifact per
+provider. If any workflow run already exists for the tag, automatic dispatch does not loop; use the
+manual `claude`, `codex`, `kiro`, or `all` selector for a deliberate retry or partial recovery.
 
 Only one release tag may be active across providers. Same-tag retries are grouped idempotently; any
 attempt atomically advances `refs/heads/qodo-marketplace-release-lock` to an owner commit before
@@ -199,7 +205,10 @@ Every immutable skills release carries `qodo-enterprise-manifest.json`, the dete
 indexes, and one digest-pinned archive per skill. The manifest carries the package's
 `minimumCliVersion`; QAR must reject the bundle when its independent CLI lock is older. QAR pins that release independently from
 its CLI pin, verifies every byte while building the backend image, and serves it from the existing
-`/toolbox` origin. Its separate dependency workflow opens the reviewed skills-pin PR.
+`/toolbox` origin. QAR's hourly **distribution bundles: sync promoted CLI + skills pins** workflow
+updates the CLI lock first, validates the skills minimum against that selected runtime, builds and
+tests both bundles, and opens or refreshes one reviewed dependency PR. The separate CLI-only and
+skills-only workflows remain manual recovery controls.
 
 The discovery section has its own runtime minimum. QAR enforces the greater of the package-wide
 minimum and the discovery minimum, so compatibility assets can retain their older floor without

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:notes": "node scripts/release-notes.mjs",
     "enterprise:build": "node scripts/build-enterprise-bundle.mjs",
     "check": "node scripts/validate.mjs && node scripts/build-release-index.mjs --check && node scripts/build-cli-managed-bundle.mjs --check",
-    "test": "npm run check && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
+    "test": "npm run check && node --test test/marketplace-auto-start.test.mjs && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/plan-marketplace-auto-start.mjs
+++ b/scripts/plan-marketplace-auto-start.mjs
@@ -30,9 +30,15 @@ function compareTags(left, right) {
   return 0;
 }
 
-async function readBytes(fetchImpl, url, token = '', maximumBytes = MAX_JSON_BYTES) {
+async function readBytes(
+  fetchImpl,
+  url,
+  token = '',
+  maximumBytes = MAX_JSON_BYTES,
+  accept = 'application/vnd.github+json',
+) {
   const headers = {
-    accept: 'application/vnd.github+json',
+    accept,
     'user-agent': 'qodo-marketplace-auto-start',
     'x-github-api-version': '2022-11-28',
   };
@@ -83,14 +89,18 @@ async function readWorkflowRuns(fetchImpl, baseUrl, token) {
 }
 
 function releaseTagFromRun(run) {
-  if (run?.head_branch !== DEFAULT_BRANCH || typeof run.display_title !== 'string') return null;
+  if (
+    run?.head_branch !== DEFAULT_BRANCH ||
+    run?.conclusion !== 'success' ||
+    typeof run.display_title !== 'string'
+  ) return null;
   const prefix = 'Ship marketplaces ';
   if (!run.display_title.startsWith(prefix)) return null;
   const tag = run.display_title.slice(prefix.length);
   return TAG_PATTERN.test(tag) ? tag : null;
 }
 
-async function verifyCompatibilityAssets(fetchImpl, versionUrl, skills, tag, sourceCommit) {
+async function verifyCompatibilityAssets(fetchImpl, versionUrl, skills, tag, sourceCommit, release, token) {
   const version = tag.slice(1);
   const expected = {
     releaseIndex: `skills/releases/${tag}/qodo-skills-index.json`,
@@ -107,12 +117,37 @@ async function verifyCompatibilityAssets(fetchImpl, versionUrl, skills, tag, sou
     if (url.origin !== base.origin) throw new Error(`production compatibility asset escaped ${base.origin}`);
     return readBytes(fetchImpl, url.href, '', maximumBytes);
   };
-  const [index, indexChecksum, bundle, bundleChecksum] = await Promise.all([
+  const productionAssets = await Promise.all([
     load(expected.releaseIndex, MAX_COMPATIBILITY_ASSET_BYTES),
     load(expected.releaseIndexChecksum, 512),
     load(expected.cliManagedBundle, MAX_COMPATIBILITY_ASSET_BYTES),
     load(expected.cliManagedChecksum, 512),
   ]);
+  const assetNames = [
+    'qodo-skills-index.json',
+    'qodo-skills-index.json.sha256',
+    'qodo-cli-managed-bundle.json',
+    'qodo-cli-managed-bundle.json.sha256',
+  ];
+  if (!Array.isArray(release?.assets)) throw new Error(`skills release ${tag} has no asset inventory`);
+  const releaseAssets = await Promise.all(assetNames.map(async (name, index) => {
+    const candidates = release.assets.filter((asset) => asset?.name === name);
+    if (candidates.length !== 1 || typeof candidates[0].url !== 'string') {
+      throw new Error(`skills release ${tag} must contain exactly one ${name}`);
+    }
+    const body = await readBytes(
+      fetchImpl,
+      candidates[0].url,
+      token,
+      index % 2 === 0 ? MAX_COMPATIBILITY_ASSET_BYTES : 512,
+      'application/octet-stream',
+    );
+    if (!body.equals(productionAssets[index])) {
+      throw new Error(`production compatibility ${name} differs from immutable release ${tag}`);
+    }
+    return body;
+  }));
+  const [index, indexChecksum, bundle, bundleChecksum] = releaseAssets;
   const verifyDigest = (name, body, checksum) => {
     const expectedDigest = checksum.toString('utf8').trim().split(/\s+/u)[0];
     if (!/^[a-f0-9]{64}$/.test(expectedDigest)) throw new Error(`invalid production checksum for ${name}`);
@@ -184,7 +219,7 @@ export async function planMarketplaceAutoStart({
     throw new Error(`could not resolve the immutable commit for ${tag}`);
   }
 
-  await verifyCompatibilityAssets(fetchImpl, versionUrl, version.skills, tag, commit.sha);
+  await verifyCompatibilityAssets(fetchImpl, versionUrl, version.skills, tag, commit.sha, release, token);
 
   const runsUrl =
     `${githubApi}/repos/${repository}/actions/workflows/${WORKFLOW}/runs?` +

--- a/scripts/plan-marketplace-auto-start.mjs
+++ b/scripts/plan-marketplace-auto-start.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from 'node:crypto';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -7,7 +8,10 @@ const DEFAULT_REPOSITORY = 'qodo-ai/qodo-skills';
 const DEFAULT_GITHUB_API = 'https://api.github.com';
 const DEFAULT_VERSION_URL = 'https://get.qodo.ai/version.json';
 const WORKFLOW = 'ship-marketplaces.yml';
+const DEFAULT_BRANCH = 'main';
 const TAG_PATTERN = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const MAX_JSON_BYTES = 2 * 1024 * 1024;
+const MAX_COMPATIBILITY_ASSET_BYTES = 8 * 1024 * 1024;
 
 function requireTag(tag) {
   if (typeof tag !== 'string' || !TAG_PATTERN.test(tag)) {
@@ -16,7 +20,17 @@ function requireTag(tag) {
   return tag;
 }
 
-async function readJson(fetchImpl, url, token = '') {
+function compareTags(left, right) {
+  const a = TAG_PATTERN.exec(requireTag(left)).slice(1).map(BigInt);
+  const b = TAG_PATTERN.exec(requireTag(right)).slice(1).map(BigInt);
+  for (let index = 0; index < a.length; index += 1) {
+    if (a[index] < b[index]) return -1;
+    if (a[index] > b[index]) return 1;
+  }
+  return 0;
+}
+
+async function readBytes(fetchImpl, url, token = '', maximumBytes = MAX_JSON_BYTES) {
   const headers = {
     accept: 'application/vnd.github+json',
     'user-agent': 'qodo-marketplace-auto-start',
@@ -25,24 +39,110 @@ async function readJson(fetchImpl, url, token = '') {
   if (token && url.startsWith('https://api.github.com/')) headers.authorization = `Bearer ${token}`;
   const response = await fetchImpl(url, { headers, signal: AbortSignal.timeout(30_000) });
   if (!response.ok) throw new Error(`could not read ${url}: HTTP ${response.status}`);
+  const declaredLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declaredLength) && declaredLength > maximumBytes) {
+    throw new Error(`response from ${url} exceeds ${maximumBytes} bytes`);
+  }
+  if (!response.body) return Buffer.alloc(0);
+  const reader = response.body.getReader();
+  const chunks = [];
+  let length = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    length += value.byteLength;
+    if (length > maximumBytes) {
+      await reader.cancel();
+      throw new Error(`response from ${url} exceeds ${maximumBytes} bytes`);
+    }
+    chunks.push(Buffer.from(value));
+  }
+  return Buffer.concat(chunks, length);
+}
+
+async function readJson(fetchImpl, url, token = '') {
   try {
-    return await response.json();
+    return JSON.parse((await readBytes(fetchImpl, url, token)).toString('utf8'));
   } catch (error) {
+    if (error instanceof Error && error.message.startsWith('could not read ')) throw error;
     throw new Error(`could not parse JSON from ${url}`, { cause: error });
   }
 }
 
-async function findExistingRun(fetchImpl, baseUrl, title, token) {
+async function readWorkflowRuns(fetchImpl, baseUrl, token) {
+  const runs = [];
   for (let page = 1; page <= 100; page += 1) {
     const payload = await readJson(fetchImpl, `${baseUrl}&page=${page}`, token);
     if (!payload || !Array.isArray(payload.workflow_runs)) {
       throw new Error('GitHub returned an invalid marketplace workflow-run list');
     }
-    const existing = payload.workflow_runs.find((run) => run?.display_title === title);
-    if (existing) return existing;
-    if (payload.workflow_runs.length < 100) return null;
+    runs.push(...payload.workflow_runs);
+    if (payload.workflow_runs.length < 100) return runs;
   }
   throw new Error('GitHub marketplace workflow-run pagination exceeded 100 pages');
+}
+
+function releaseTagFromRun(run) {
+  if (run?.head_branch !== DEFAULT_BRANCH || typeof run.display_title !== 'string') return null;
+  const prefix = 'Ship marketplaces ';
+  if (!run.display_title.startsWith(prefix)) return null;
+  const tag = run.display_title.slice(prefix.length);
+  return TAG_PATTERN.test(tag) ? tag : null;
+}
+
+async function verifyCompatibilityAssets(fetchImpl, versionUrl, skills, tag, sourceCommit) {
+  const version = tag.slice(1);
+  const expected = {
+    releaseIndex: `skills/releases/${tag}/qodo-skills-index.json`,
+    releaseIndexChecksum: `skills/releases/${tag}/qodo-skills-index.json.sha256`,
+    cliManagedBundle: `skills/releases/${tag}/qodo-cli-managed-bundle.json`,
+    cliManagedChecksum: `skills/releases/${tag}/qodo-cli-managed-bundle.json.sha256`,
+  };
+  for (const [key, path] of Object.entries(expected)) {
+    if (skills?.[key] !== path) throw new Error(`production compatibility ${key} does not match ${tag}`);
+  }
+  const base = new URL(versionUrl);
+  const load = async (path, maximumBytes) => {
+    const url = new URL(path, base);
+    if (url.origin !== base.origin) throw new Error(`production compatibility asset escaped ${base.origin}`);
+    return readBytes(fetchImpl, url.href, '', maximumBytes);
+  };
+  const [index, indexChecksum, bundle, bundleChecksum] = await Promise.all([
+    load(expected.releaseIndex, MAX_COMPATIBILITY_ASSET_BYTES),
+    load(expected.releaseIndexChecksum, 512),
+    load(expected.cliManagedBundle, MAX_COMPATIBILITY_ASSET_BYTES),
+    load(expected.cliManagedChecksum, 512),
+  ]);
+  const verifyDigest = (name, body, checksum) => {
+    const expectedDigest = checksum.toString('utf8').trim().split(/\s+/u)[0];
+    if (!/^[a-f0-9]{64}$/.test(expectedDigest)) throw new Error(`invalid production checksum for ${name}`);
+    const actual = createHash('sha256').update(body).digest('hex');
+    if (actual !== expectedDigest) throw new Error(`production checksum mismatch for ${name}`);
+  };
+  verifyDigest('qodo-skills-index.json', index, indexChecksum);
+  verifyDigest('qodo-cli-managed-bundle.json', bundle, bundleChecksum);
+
+  let indexDocument;
+  let bundleDocument;
+  try {
+    indexDocument = JSON.parse(index.toString('utf8'));
+    bundleDocument = JSON.parse(bundle.toString('utf8'));
+  } catch (error) {
+    throw new Error('production compatibility assets are not valid JSON', { cause: error });
+  }
+  if (![1, 2].includes(indexDocument?.schemaVersion) || indexDocument.packageVersion !== version) {
+    throw new Error(`production compatibility index identity does not match ${tag}`);
+  }
+  if (indexDocument.schemaVersion === 2 && indexDocument.sourceCommit !== sourceCommit) {
+    throw new Error(`production compatibility index source does not match ${sourceCommit}`);
+  }
+  if (
+    bundleDocument?.distribution !== 'qodo-cli-managed' ||
+    bundleDocument.packageVersion !== version ||
+    bundleDocument.source?.tag !== tag
+  ) {
+    throw new Error(`production compatibility bundle identity does not match ${tag}`);
+  }
 }
 
 export async function planMarketplaceAutoStart({
@@ -84,20 +184,30 @@ export async function planMarketplaceAutoStart({
     throw new Error(`could not resolve the immutable commit for ${tag}`);
   }
 
+  await verifyCompatibilityAssets(fetchImpl, versionUrl, version.skills, tag, commit.sha);
+
+  const runsUrl =
+    `${githubApi}/repos/${repository}/actions/workflows/${WORKFLOW}/runs?` +
+    `event=workflow_dispatch&branch=${DEFAULT_BRANCH}&per_page=100`;
   const title = `Ship marketplaces ${tag}`;
-  const existing = await findExistingRun(
-    fetchImpl,
-    `${githubApi}/repos/${repository}/actions/workflows/${WORKFLOW}/runs?event=workflow_dispatch&per_page=100`,
-    title,
-    token,
+  const workflowRuns = await readWorkflowRuns(fetchImpl, runsUrl, token);
+  const existing = workflowRuns.find(
+    (run) => run?.display_title === title && run?.head_branch === DEFAULT_BRANCH,
   );
+  const priorTags = workflowRuns.map(releaseTagFromRun).filter(Boolean);
+  const watermark = priorTags.sort(compareTags).at(-1) ?? null;
+  if (watermark && compareTags(tag, watermark) < 0) {
+    throw new Error(`refusing marketplace rollback from ${watermark} to ${tag}`);
+  }
 
   return {
     schemaVersion: 1,
     repository,
     tag,
     sourceCommit: commit.sha,
-    needed: existing === null,
+    compatibilityVerified: true,
+    watermark,
+    needed: existing === undefined,
     existingRun: existing
       ? {
           id: existing.id,

--- a/scripts/plan-marketplace-auto-start.mjs
+++ b/scripts/plan-marketplace-auto-start.mjs
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_REPOSITORY = 'qodo-ai/qodo-skills';
+const DEFAULT_GITHUB_API = 'https://api.github.com';
+const DEFAULT_VERSION_URL = 'https://get.qodo.ai/version.json';
+const WORKFLOW = 'ship-marketplaces.yml';
+const TAG_PATTERN = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function requireTag(tag) {
+  if (typeof tag !== 'string' || !TAG_PATTERN.test(tag)) {
+    throw new Error(`invalid stable skills tag: ${JSON.stringify(tag)}`);
+  }
+  return tag;
+}
+
+async function readJson(fetchImpl, url, token = '') {
+  const headers = {
+    accept: 'application/vnd.github+json',
+    'user-agent': 'qodo-marketplace-auto-start',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token && url.startsWith('https://api.github.com/')) headers.authorization = `Bearer ${token}`;
+  const response = await fetchImpl(url, { headers, signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) throw new Error(`could not read ${url}: HTTP ${response.status}`);
+  try {
+    return await response.json();
+  } catch (error) {
+    throw new Error(`could not parse JSON from ${url}`, { cause: error });
+  }
+}
+
+async function findExistingRun(fetchImpl, baseUrl, title, token) {
+  for (let page = 1; page <= 100; page += 1) {
+    const payload = await readJson(fetchImpl, `${baseUrl}&page=${page}`, token);
+    if (!payload || !Array.isArray(payload.workflow_runs)) {
+      throw new Error('GitHub returned an invalid marketplace workflow-run list');
+    }
+    const existing = payload.workflow_runs.find((run) => run?.display_title === title);
+    if (existing) return existing;
+    if (payload.workflow_runs.length < 100) return null;
+  }
+  throw new Error('GitHub marketplace workflow-run pagination exceeded 100 pages');
+}
+
+export async function planMarketplaceAutoStart({
+  requestedTag = '',
+  repository = DEFAULT_REPOSITORY,
+  githubApi = DEFAULT_GITHUB_API,
+  versionUrl = DEFAULT_VERSION_URL,
+  token = '',
+  fetchImpl = fetch,
+} = {}) {
+  const version = await readJson(fetchImpl, versionUrl);
+  const publicTag = requireTag(version?.skills?.releaseTag);
+  const tag = requestedTag ? requireTag(requestedTag) : publicTag;
+  if (tag !== publicTag) {
+    throw new Error(`marketplace release ${tag} is not production-ready; public compatibility is ${publicTag}`);
+  }
+
+  const release = await readJson(
+    fetchImpl,
+    `${githubApi}/repos/${repository}/releases/tags/${encodeURIComponent(tag)}`,
+    token,
+  );
+  if (
+    !release ||
+    release.tag_name !== tag ||
+    release.draft !== false ||
+    release.prerelease !== false ||
+    release.immutable !== true
+  ) {
+    throw new Error(`skills release ${tag} is not published, stable, and immutable`);
+  }
+
+  const commit = await readJson(
+    fetchImpl,
+    `${githubApi}/repos/${repository}/commits/${encodeURIComponent(tag)}`,
+    token,
+  );
+  if (!commit || typeof commit.sha !== 'string' || !/^[a-f0-9]{40}$/.test(commit.sha)) {
+    throw new Error(`could not resolve the immutable commit for ${tag}`);
+  }
+
+  const title = `Ship marketplaces ${tag}`;
+  const existing = await findExistingRun(
+    fetchImpl,
+    `${githubApi}/repos/${repository}/actions/workflows/${WORKFLOW}/runs?event=workflow_dispatch&per_page=100`,
+    title,
+    token,
+  );
+
+  return {
+    schemaVersion: 1,
+    repository,
+    tag,
+    sourceCommit: commit.sha,
+    needed: existing === null,
+    existingRun: existing
+      ? {
+          id: existing.id,
+          status: existing.status,
+          conclusion: existing.conclusion ?? null,
+          url: existing.html_url ?? null,
+        }
+      : null,
+  };
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const name = argv[index];
+    const value = argv[index + 1];
+    if (!['--tag', '--repository', '--github-api', '--version-url'].includes(name) || value === undefined) {
+      throw new Error(`unknown or incomplete argument: ${name}`);
+    }
+    const key = {
+      '--tag': 'requestedTag',
+      '--repository': 'repository',
+      '--github-api': 'githubApi',
+      '--version-url': 'versionUrl',
+    }[name];
+    options[key] = value;
+    index += 1;
+  }
+  return options;
+}
+
+async function main() {
+  const plan = await planMarketplaceAutoStart({
+    ...parseArgs(process.argv.slice(2)),
+    token: process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '',
+  });
+  process.stdout.write(`${JSON.stringify(plan)}\n`);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    process.stderr.write(`marketplace-auto-start: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/marketplace-auto-start.test.mjs
+++ b/test/marketplace-auto-start.test.mjs
@@ -17,6 +17,17 @@ const bundle = Buffer.from(
   }),
 );
 const digest = (body) => `${createHash('sha256').update(body).digest('hex')}  artifact\n`;
+const assetBodies = {
+  'qodo-skills-index.json': index,
+  'qodo-skills-index.json.sha256': Buffer.from(digest(index)),
+  'qodo-cli-managed-bundle.json': bundle,
+  'qodo-cli-managed-bundle.json.sha256': Buffer.from(digest(bundle)),
+};
+const releaseAssets = Object.keys(assetBodies).map((name) => ({
+  name,
+  url: `https://github.test/assets/${name}`,
+}));
+release.assets = releaseAssets;
 
 function skillsPointer(publicTag = 'v1.0.10') {
   return {
@@ -42,6 +53,13 @@ function fakeFetch({ publicTag = 'v1.0.10', runs = [], releaseBody = release, co
     }
     if (url.endsWith('/qodo-cli-managed-bundle.json')) return new Response(bundle);
     if (url.endsWith('/qodo-cli-managed-bundle.json.sha256')) return new Response(digest(bundle));
+    if (url.includes('/assets/')) {
+      const name = url.split('/').at(-1);
+      if (name === 'qodo-skills-index.json.sha256' && corruptIndex) {
+        return new Response(`${'0'.repeat(64)}  artifact\n`);
+      }
+      return new Response(assetBodies[name]);
+    }
     if (url.includes('/releases/tags/')) return response(releaseBody);
     if (url.includes('/commits/')) return response({ sha });
     if (url.includes('/actions/workflows/')) {
@@ -62,7 +80,7 @@ test('the watcher uses same-repository workflow dispatch and keeps provider gate
   assert.match(workflow, /actions: write/);
   assert.match(workflow, /gh workflow run ship-marketplaces\.yml/);
   assert.match(workflow, /-f all=true/);
-  assert.match(workflow, /group: qodo-marketplaces-\$\{\{ needs\.plan\.outputs\.tag \}\}/);
+  assert.doesNotMatch(workflow, /group: qodo-marketplaces-\$\{\{ needs\.plan\.outputs\.tag \}\}/);
   assert.equal((workflow.match(/plan-marketplace-auto-start\.mjs/g) ?? []).length, 2);
   assert.doesNotMatch(workflow, /PRIVATE_KEY|repository_dispatch/);
 
@@ -127,6 +145,7 @@ test('finds an earlier workflow run beyond the first API page', async () => {
     if (url.endsWith('/qodo-skills-index.json.sha256')) return new Response(digest(index));
     if (url.endsWith('/qodo-cli-managed-bundle.json')) return new Response(bundle);
     if (url.endsWith('/qodo-cli-managed-bundle.json.sha256')) return new Response(digest(bundle));
+    if (url.includes('/assets/')) return new Response(assetBodies[url.split('/').at(-1)]);
     if (url.includes('/releases/tags/')) return response(release);
     if (url.includes('/commits/')) return response({ sha });
     if (url.includes('/actions/workflows/')) {
@@ -173,10 +192,43 @@ test('rejects marketplace rollback below the highest default-branch release', as
       githubApi: 'https://github.test',
       versionUrl: 'https://distribution.test/version.json',
       fetchImpl: fakeFetch({
-        runs: [{ id: 43, display_title: 'Ship marketplaces v999999999999999999999.0.0', head_branch: 'main' }],
+        runs: [{
+          id: 43,
+          display_title: 'Ship marketplaces v999999999999999999999.0.0',
+          head_branch: 'main',
+          conclusion: 'success',
+        }],
       }),
     }),
     /refusing marketplace rollback/,
+  );
+});
+
+test('does not let an invalid failed future dispatch poison the rollback watermark', async () => {
+  const plan = await planMarketplaceAutoStart({
+    githubApi: 'https://github.test',
+    versionUrl: 'https://distribution.test/version.json',
+    fetchImpl: fakeFetch({
+      runs: [{ id: 44, display_title: 'Ship marketplaces v999.0.0', head_branch: 'main', conclusion: 'failure' }],
+    }),
+  });
+  assert.equal(plan.watermark, null);
+  assert.equal(plan.needed, true);
+});
+
+test('rejects production bytes that differ from the immutable release asset', async () => {
+  const altered = Buffer.from(JSON.stringify({ schemaVersion: 2, packageVersion: '1.0.10', sourceCommit: sha, drift: true }));
+  const fetchImpl = fakeFetch();
+  await assert.rejects(
+    planMarketplaceAutoStart({
+      githubApi: 'https://github.test',
+      versionUrl: 'https://distribution.test/version.json',
+      fetchImpl: async (input, init) => {
+        if (String(input).includes('/assets/qodo-skills-index.json')) return new Response(altered);
+        return fetchImpl(input, init);
+      },
+    }),
+    /differs from immutable release/,
   );
 });
 

--- a/test/marketplace-auto-start.test.mjs
+++ b/test/marketplace-auto-start.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { planMarketplaceAutoStart } from '../scripts/plan-marketplace-auto-start.mjs';
+
+const sha = 'b'.repeat(40);
+const release = { tag_name: 'v1.0.10', draft: false, prerelease: false, immutable: true };
+
+function response(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function fakeFetch({ publicTag = 'v1.0.10', runs = [], releaseBody = release } = {}) {
+  return async (input) => {
+    const url = String(input);
+    if (url.endsWith('/version.json')) return response({ skills: { releaseTag: publicTag } });
+    if (url.includes('/releases/tags/')) return response(releaseBody);
+    if (url.includes('/commits/')) return response({ sha });
+    if (url.includes('/actions/workflows/')) {
+      const page = Number(new URL(url).searchParams.get('page'));
+      return response({ workflow_runs: page === 1 ? runs : [] });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+}
+
+test('the watcher uses same-repository workflow dispatch and keeps provider gates intact', () => {
+  const workflow = readFileSync(
+    fileURLToPath(new URL('../.github/workflows/marketplace-auto-start.yml', import.meta.url)),
+    'utf8',
+  );
+
+  assert.match(workflow, /schedule:/);
+  assert.match(workflow, /actions: write/);
+  assert.match(workflow, /gh workflow run ship-marketplaces\.yml/);
+  assert.doesNotMatch(workflow, /PRIVATE_KEY|repository_dispatch/);
+
+  const ship = readFileSync(fileURLToPath(new URL('../.github/workflows/ship-marketplaces.yml', import.meta.url)), 'utf8');
+  assert.match(ship, /environment:\n\s+name: marketplace-/);
+});
+
+test('enqueues an immutable release only after its compatibility pointer is live', async () => {
+  const plan = await planMarketplaceAutoStart({
+    requestedTag: 'v1.0.10',
+    githubApi: 'https://github.test',
+    versionUrl: 'https://distribution.test/version.json',
+    fetchImpl: fakeFetch(),
+  });
+
+  assert.deepEqual(
+    { tag: plan.tag, sourceCommit: plan.sourceCommit, needed: plan.needed },
+    { tag: 'v1.0.10', sourceCommit: sha, needed: true },
+  );
+});
+
+test('does not enqueue the same marketplace release twice', async () => {
+  const run = {
+    id: 42,
+    display_title: 'Ship marketplaces v1.0.10',
+    status: 'in_progress',
+    conclusion: null,
+    html_url: 'https://github.test/run/42',
+  };
+  const plan = await planMarketplaceAutoStart({
+    githubApi: 'https://github.test',
+    versionUrl: 'https://distribution.test/version.json',
+    fetchImpl: fakeFetch({ runs: [run] }),
+  });
+
+  assert.equal(plan.needed, false);
+  assert.equal(plan.existingRun.id, 42);
+});
+
+test('finds an earlier workflow run beyond the first API page', async () => {
+  const page = Array.from({ length: 100 }, (_, id) => ({
+    id,
+    display_title: `Ship marketplaces v0.9.${id}`,
+  }));
+  const existing = { id: 101, display_title: 'Ship marketplaces v1.0.10', status: 'completed' };
+  const fetchImpl = async (input) => {
+    const url = String(input);
+    if (url.endsWith('/version.json')) return response({ skills: { releaseTag: 'v1.0.10' } });
+    if (url.includes('/releases/tags/')) return response(release);
+    if (url.includes('/commits/')) return response({ sha });
+    if (url.includes('/actions/workflows/')) {
+      return response({ workflow_runs: Number(new URL(url).searchParams.get('page')) === 1 ? page : [existing] });
+    }
+    throw new Error(`unexpected request: ${url}`);
+  };
+
+  const plan = await planMarketplaceAutoStart({
+    githubApi: 'https://github.test',
+    versionUrl: 'https://distribution.test/version.json',
+    fetchImpl,
+  });
+
+  assert.equal(plan.needed, false);
+  assert.equal(plan.existingRun.id, 101);
+});
+
+test('rejects a requested release before its production compatibility pointer advances', async () => {
+  await assert.rejects(
+    planMarketplaceAutoStart({
+      requestedTag: 'v1.0.11',
+      githubApi: 'https://github.test',
+      versionUrl: 'https://distribution.test/version.json',
+      fetchImpl: fakeFetch(),
+    }),
+    /is not production-ready/,
+  );
+});
+
+test('rejects mutable release metadata', async () => {
+  await assert.rejects(
+    planMarketplaceAutoStart({
+      githubApi: 'https://github.test',
+      versionUrl: 'https://distribution.test/version.json',
+      fetchImpl: fakeFetch({ releaseBody: { ...release, immutable: false } }),
+    }),
+    /not published, stable, and immutable/,
+  );
+});

--- a/test/marketplace-auto-start.test.mjs
+++ b/test/marketplace-auto-start.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -7,15 +8,40 @@ import { planMarketplaceAutoStart } from '../scripts/plan-marketplace-auto-start
 
 const sha = 'b'.repeat(40);
 const release = { tag_name: 'v1.0.10', draft: false, prerelease: false, immutable: true };
+const index = Buffer.from(JSON.stringify({ schemaVersion: 2, packageVersion: '1.0.10', sourceCommit: sha }));
+const bundle = Buffer.from(
+  JSON.stringify({
+    distribution: 'qodo-cli-managed',
+    packageVersion: '1.0.10',
+    source: { repository: 'https://github.com/qodo-ai/qodo-skills', tag: 'v1.0.10' },
+  }),
+);
+const digest = (body) => `${createHash('sha256').update(body).digest('hex')}  artifact\n`;
+
+function skillsPointer(publicTag = 'v1.0.10') {
+  return {
+    releaseTag: publicTag,
+    releaseIndex: `skills/releases/${publicTag}/qodo-skills-index.json`,
+    releaseIndexChecksum: `skills/releases/${publicTag}/qodo-skills-index.json.sha256`,
+    cliManagedBundle: `skills/releases/${publicTag}/qodo-cli-managed-bundle.json`,
+    cliManagedChecksum: `skills/releases/${publicTag}/qodo-cli-managed-bundle.json.sha256`,
+  };
+}
 
 function response(body, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
 }
 
-function fakeFetch({ publicTag = 'v1.0.10', runs = [], releaseBody = release } = {}) {
+function fakeFetch({ publicTag = 'v1.0.10', runs = [], releaseBody = release, corruptIndex = false } = {}) {
   return async (input) => {
     const url = String(input);
-    if (url.endsWith('/version.json')) return response({ skills: { releaseTag: publicTag } });
+    if (url.endsWith('/version.json')) return response({ skills: skillsPointer(publicTag) });
+    if (url.endsWith('/qodo-skills-index.json')) return new Response(index);
+    if (url.endsWith('/qodo-skills-index.json.sha256')) {
+      return new Response(corruptIndex ? `${'0'.repeat(64)}  artifact\n` : digest(index));
+    }
+    if (url.endsWith('/qodo-cli-managed-bundle.json')) return new Response(bundle);
+    if (url.endsWith('/qodo-cli-managed-bundle.json.sha256')) return new Response(digest(bundle));
     if (url.includes('/releases/tags/')) return response(releaseBody);
     if (url.includes('/commits/')) return response({ sha });
     if (url.includes('/actions/workflows/')) {
@@ -35,6 +61,9 @@ test('the watcher uses same-repository workflow dispatch and keeps provider gate
   assert.match(workflow, /schedule:/);
   assert.match(workflow, /actions: write/);
   assert.match(workflow, /gh workflow run ship-marketplaces\.yml/);
+  assert.match(workflow, /-f all=true/);
+  assert.match(workflow, /group: qodo-marketplaces-\$\{\{ needs\.plan\.outputs\.tag \}\}/);
+  assert.equal((workflow.match(/plan-marketplace-auto-start\.mjs/g) ?? []).length, 2);
   assert.doesNotMatch(workflow, /PRIVATE_KEY|repository_dispatch/);
 
   const ship = readFileSync(fileURLToPath(new URL('../.github/workflows/ship-marketplaces.yml', import.meta.url)), 'utf8');
@@ -50,8 +79,13 @@ test('enqueues an immutable release only after its compatibility pointer is live
   });
 
   assert.deepEqual(
-    { tag: plan.tag, sourceCommit: plan.sourceCommit, needed: plan.needed },
-    { tag: 'v1.0.10', sourceCommit: sha, needed: true },
+    {
+      tag: plan.tag,
+      sourceCommit: plan.sourceCommit,
+      compatibilityVerified: plan.compatibilityVerified,
+      needed: plan.needed,
+    },
+    { tag: 'v1.0.10', sourceCommit: sha, compatibilityVerified: true, needed: true },
   );
 });
 
@@ -62,6 +96,7 @@ test('does not enqueue the same marketplace release twice', async () => {
     status: 'in_progress',
     conclusion: null,
     html_url: 'https://github.test/run/42',
+    head_branch: 'main',
   };
   const plan = await planMarketplaceAutoStart({
     githubApi: 'https://github.test',
@@ -77,11 +112,21 @@ test('finds an earlier workflow run beyond the first API page', async () => {
   const page = Array.from({ length: 100 }, (_, id) => ({
     id,
     display_title: `Ship marketplaces v0.9.${id}`,
+    head_branch: 'main',
   }));
-  const existing = { id: 101, display_title: 'Ship marketplaces v1.0.10', status: 'completed' };
+  const existing = {
+    id: 101,
+    display_title: 'Ship marketplaces v1.0.10',
+    head_branch: 'main',
+    status: 'completed',
+  };
   const fetchImpl = async (input) => {
     const url = String(input);
-    if (url.endsWith('/version.json')) return response({ skills: { releaseTag: 'v1.0.10' } });
+    if (url.endsWith('/version.json')) return response({ skills: skillsPointer() });
+    if (url.endsWith('/qodo-skills-index.json')) return new Response(index);
+    if (url.endsWith('/qodo-skills-index.json.sha256')) return new Response(digest(index));
+    if (url.endsWith('/qodo-cli-managed-bundle.json')) return new Response(bundle);
+    if (url.endsWith('/qodo-cli-managed-bundle.json.sha256')) return new Response(digest(bundle));
     if (url.includes('/releases/tags/')) return response(release);
     if (url.includes('/commits/')) return response({ sha });
     if (url.includes('/actions/workflows/')) {
@@ -98,6 +143,41 @@ test('finds an earlier workflow run beyond the first API page', async () => {
 
   assert.equal(plan.needed, false);
   assert.equal(plan.existingRun.id, 101);
+});
+
+test('ignores a same-title run from a feature branch', async () => {
+  const plan = await planMarketplaceAutoStart({
+    githubApi: 'https://github.test',
+    versionUrl: 'https://distribution.test/version.json',
+    fetchImpl: fakeFetch({
+      runs: [{ id: 42, display_title: 'Ship marketplaces v1.0.10', head_branch: 'feature' }],
+    }),
+  });
+  assert.equal(plan.needed, true);
+});
+
+test('rejects a compatibility asset that does not match its published checksum', async () => {
+  await assert.rejects(
+    planMarketplaceAutoStart({
+      githubApi: 'https://github.test',
+      versionUrl: 'https://distribution.test/version.json',
+      fetchImpl: fakeFetch({ corruptIndex: true }),
+    }),
+    /checksum mismatch/,
+  );
+});
+
+test('rejects marketplace rollback below the highest default-branch release', async () => {
+  await assert.rejects(
+    planMarketplaceAutoStart({
+      githubApi: 'https://github.test',
+      versionUrl: 'https://distribution.test/version.json',
+      fetchImpl: fakeFetch({
+        runs: [{ id: 43, display_title: 'Ship marketplaces v999999999999999999999.0.0', head_branch: 'main' }],
+      }),
+    }),
+    /refusing marketplace rollback/,
+  );
 });
 
 test('rejects a requested release before its production compatibility pointer advances', async () => {


### PR DESCRIPTION
## Summary

- watch the protected public compatibility pointer hourly
- download and byte-verify the advertised index, bundle, checksums, release identity, immutable tag, and source commit against GitHub release assets
- reject rollback below the highest successful default-branch marketplace release
- recheck inside the downstream per-tag atomic lock before dispatching one all-provider run
- ignore feature-branch lookalikes while suppressing same-tag automatic retries
- retain manual provider selection for deliberate recovery
- keep the canonical cutover strategy current, including the credential-free exact-lock QAR handoff, content-addressed MP1 deployment, stable all-replica proof, isolated authenticated install, and accepted-digest production promotion

## Trust boundary

The workflow dispatches only another workflow in this repository. It stores no cross-repository administrator credential, and every Claude, Codex, and Kiro protected-environment/provider gate remains in place.

## Validation

- full qodo-skills release suite: green
- watcher tests: 11 passed, including checksum failure, GitHub release-asset byte mismatch, pagination, branch identity, rollback, poisoned watermark, and duplicate-race contracts
- live planner: v1.0.10 and source 3f017b1f2e13dbf9feb532143dc39fa4eea12479 verified; existing run 33732510179 correctly suppresses redispatch

Tracks [CLI-326](https://linear.app/qodo/issue/CLI-326/automate-the-cross-repository-cli-skills-and-qar-release-train).

