### PR TITLE
feat(release): package Codex portal uploads

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
-    "version": "1.0.11"
+    "version": "1.0.12"
   },
   "plugins": [
     {

--- a/.github/workflows/ship-marketplaces.yml
+++ b/.github/workflows/ship-marketplaces.yml
@@ -307,7 +307,8 @@ jobs:
           {
             echo '## Codex portal publication required'
             echo
-            echo "Download \`marketplace-codex-${RELEASE_TAG}\`, upload the two listing packets through the OpenAI plugin portal, wait for review, and publish the approved version."
+            echo "Download \`marketplace-codex-${RELEASE_TAG}\`. From its packet root, run \`node verify-codex-packet.mjs\`, then upload the ZIP named by each \`submissions/<listing>.json\`."
+            echo 'Update the existing `qodo` listing; submit `qodo-standards` separately as an optional initial listing. Wait for review, then explicitly publish each approved version.'
             echo 'Approve the protected `marketplace-codex` environment only after that external step is complete.'
           } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/codex-packages/qodo-standards/.codex-plugin/plugin.json
+++ b/codex-packages/qodo-standards/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo-standards/plugin.json
+++ b/codex-packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/.codex-plugin/plugin.json
+++ b/codex-packages/qodo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/plugin.json
+++ b/codex-packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/distribution/catalog.json
+++ b/distribution/catalog.json
@@ -5,7 +5,7 @@
   "package": {
     "name": "qodo",
     "displayName": "Qodo for coding agents",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
     "repository": "https://github.com/qodo-ai/qodo-skills",
     "homepage": "https://www.qodo.ai",

--- a/distribution/qodo-cli-managed-bundle.json
+++ b/distribution/qodo-cli-managed-bundle.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "distribution": "qodo-cli-managed",
   "instructionMode": "embedded",
-  "packageVersion": "1.0.11",
+  "packageVersion": "1.0.12",
   "minimumCliVersion": "0.1.0-next.37",
   "source": {
     "repository": "https://github.com/qodo-ai/qodo-skills",
-    "tag": "v1.0.11"
+    "tag": "v1.0.12"
   },
   "aliases": {
     "codebase-wisdom": "qodo-codebase-wisdom",

--- a/distribution/qodo-cli-managed-bundle.json.sha256
+++ b/distribution/qodo-cli-managed-bundle.json.sha256
@@ -1,1 +1,1 @@
-781b3003f558e8aed6429bb18f1219445e875f5500e5643890c8ca6198b3d1ae  qodo-cli-managed-bundle.json
+39a8fe3822c9b2af04f703746e79eb3b1bf43e7aabb286c0e6ff3498e0d525d9  qodo-cli-managed-bundle.json

--- a/distribution/qodo-skills-index.json
+++ b/distribution/qodo-skills-index.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "instructionMode": "embedded",
-  "packageVersion": "1.0.11",
+  "packageVersion": "1.0.12",
   "minimumCliVersion": "0.1.0-next.37",
   "repository": "https://github.com/qodo-ai/qodo-skills",
   "skills": {

--- a/distribution/qodo-skills-index.json.sha256
+++ b/distribution/qodo-skills-index.json.sha256
@@ -1,1 +1,1 @@
-994bdb673875194c8719dcb2d6d19f32eb1ba4b96db86e7526d5831055c5adde  qodo-skills-index.json
+d7ba427a6bb5890e87b99398c226333b504adf83c1c0c953bc940a81749a69d6  qodo-skills-index.json

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -322,6 +322,13 @@ Use the all-provider run's Codex packet, update the existing Qodo
 listing through the OpenAI portal, wait for review, and publish. Only after publication may the
 release owner approve `marketplace-codex`.
 
+The packet contains one deterministic, checksum-bound upload archive per listing. Upload the archive
+named in `submissions/qodo.json` to the existing `qodo` record. Treat
+`submissions/qodo-standards.json` and its archive as a separate initial listing; never fold Standards
+into core or install it by default. Immediately before each upload, run
+`node verify-codex-packet.mjs` from the packet root; it requires the archive bytes and every recorded
+digest, size, listing id, and release identity to agree.
+
 Gate: provider-visible identity unchanged; exact qodo-skills release snapshot; fresh install;
 upgrade from the current qodo-in-harness-backed version; core-only membership; optional standards
 separate; normal CLI login/runtime behavior.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -153,7 +153,7 @@ cross-tag releases.
 | Provider | Automation | Completion evidence |
 |---|---|---|
 | Claude Code | packet generation, protected submission pause, then official catalog verification | both selected listings expose the released commit/path |
-| Codex | exact portal packet plus protected release-owner gate | portal review/publish completed, then protected environment approved |
+| Codex | exact portal packet with deterministic per-listing ZIPs, SHA-256 checksums, and protected release-owner gate | portal review/publish completed, then protected environment approved |
 | Kiro | packet generation, protected release-branch promotion, then live directory verification | selected Powers expose `marketplace-kiro` at the released commit and paths |
 
 The action prepares every selected packet first. Claude and Kiro verification jobs then wait in
@@ -162,6 +162,14 @@ without starting a second workflow; after approval, the job verifies the live li
 it is not the selected release. Codex stays human-gated because its documented flow requires portal
 submission, review, and explicit publication. Its `marketplace-codex` approval is an attestation
 after provider publication, not a substitute for it. All three environments require reviewers.
+
+For Codex, upload the archive named by each `submissions/<listing>.json` record and verify it against
+`release.json`, its submission record, and `bundles/SHA256SUMS` by running
+`node verify-codex-packet.mjs` from the packet root. The verifier is included in the packet, uses
+only Node built-ins, and rejects inconsistent metadata, hashes, sizes, missing archives, and extra
+archives. Each archive root contains `.codex-plugin/plugin.json`
+directly, with no extra wrapper directory. Update the existing `qodo` listing rather than creating a
+duplicate. `qodo-standards` is a separate initial listing and remains optional for users.
 
 Kiro's provider listing must point to `marketplace-kiro`, not `main`. After protected-environment
 approval, the workflow advances that protected branch without force to the immutable release SHA

--- a/kiro-power-standards/plugin.json
+++ b/kiro-power-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qodo/agent-skills",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "devDependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "description": "Canonical Qodo skills and local coding-agent marketplace adapters.",
   "type": "module",

--- a/packages/qodo-standards/.claude-plugin/plugin.json
+++ b/packages/qodo-standards/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo-standards/plugin.json
+++ b/packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/.claude-plugin/plugin.json
+++ b/packages/qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/plugin.json
+++ b/packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/releases/v1.0.12.json
+++ b/releases/v1.0.12.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.12",
+  "summary": "Add deterministic checksum-bound Codex portal upload bundles.",
+  "package": {
+    "change": "patch"
+  },
+  "runtimeProtocolVersion": 2,
+  "minimumCliVersion": "0.1.0-next.37",
+  "skills": []
+}

--- a/scripts/deterministic-zip.mjs
+++ b/scripts/deterministic-zip.mjs
@@ -1,0 +1,137 @@
+/** Create a deterministic, uncompressed ZIP archive using only Node built-ins. */
+import {
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+
+const UTF8_FLAG = 0x0800;
+const STORED_METHOD = 0;
+const DOS_TIME = 0;
+const DOS_DATE = (1 << 5) | 1; // 1980-01-01, the earliest ZIP timestamp.
+const UNIX_REGULAR_FILE_0644 = (0o100644 << 16) >>> 0;
+const ZIP32_MAX = 0xffffffff;
+
+function compareNames(left, right) {
+  return left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+}
+
+const crcTable = Array.from({ length: 256 }, (_, value) => {
+  let crc = value;
+  for (let bit = 0; bit < 8; bit += 1) {
+    crc = (crc & 1) === 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+  }
+  return crc >>> 0;
+});
+
+function crc32(buffer) {
+  let crc = 0xffffffff;
+  for (const byte of buffer) crc = (crc >>> 8) ^ crcTable[(crc ^ byte) & 0xff];
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function archiveName(root, path) {
+  const name = relative(root, path).split(sep).join('/');
+  if (!name || name.startsWith('/') || name.split('/').includes('..') || name.includes('\\')) {
+    throw new Error(`${path}: unsafe ZIP entry name`);
+  }
+  return name;
+}
+
+function collectFiles(root, directory = root, files = []) {
+  const entries = readdirSync(directory, { withFileTypes: true })
+    .sort(compareNames);
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) throw new Error(`${path}: symbolic links are not allowed in provider bundles`);
+    if (stat.isDirectory()) collectFiles(root, path, files);
+    else if (stat.isFile()) files.push({ name: archiveName(root, path), path });
+    else throw new Error(`${path}: unsupported filesystem entry in provider bundle`);
+  }
+  return files;
+}
+
+function localHeader(name, data, checksum) {
+  const header = Buffer.alloc(30);
+  header.writeUInt32LE(0x04034b50, 0);
+  header.writeUInt16LE(20, 4);
+  header.writeUInt16LE(UTF8_FLAG, 6);
+  header.writeUInt16LE(STORED_METHOD, 8);
+  header.writeUInt16LE(DOS_TIME, 10);
+  header.writeUInt16LE(DOS_DATE, 12);
+  header.writeUInt32LE(checksum, 14);
+  header.writeUInt32LE(data.length, 18);
+  header.writeUInt32LE(data.length, 22);
+  header.writeUInt16LE(name.length, 26);
+  return header;
+}
+
+function centralHeader(name, data, checksum, offset) {
+  const header = Buffer.alloc(46);
+  header.writeUInt32LE(0x02014b50, 0);
+  header.writeUInt16LE(0x0314, 4); // ZIP 2.0, created on Unix.
+  header.writeUInt16LE(20, 6);
+  header.writeUInt16LE(UTF8_FLAG, 8);
+  header.writeUInt16LE(STORED_METHOD, 10);
+  header.writeUInt16LE(DOS_TIME, 12);
+  header.writeUInt16LE(DOS_DATE, 14);
+  header.writeUInt32LE(checksum, 16);
+  header.writeUInt32LE(data.length, 20);
+  header.writeUInt32LE(data.length, 24);
+  header.writeUInt16LE(name.length, 28);
+  header.writeUInt32LE(UNIX_REGULAR_FILE_0644, 38);
+  header.writeUInt32LE(offset, 42);
+  return header;
+}
+
+function endRecord(entryCount, centralSize, centralOffset) {
+  const record = Buffer.alloc(22);
+  record.writeUInt32LE(0x06054b50, 0);
+  record.writeUInt16LE(entryCount, 8);
+  record.writeUInt16LE(entryCount, 10);
+  record.writeUInt32LE(centralSize, 12);
+  record.writeUInt32LE(centralOffset, 16);
+  return record;
+}
+
+export function createDeterministicZip(sourceRoot, outputPath) {
+  const root = resolve(sourceRoot);
+  const stat = lstatSync(root);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`${sourceRoot}: ZIP source must be a directory`);
+  const files = collectFiles(root).sort(compareNames);
+  if (files.length === 0) throw new Error(`${sourceRoot}: refusing to create an empty provider bundle`);
+  if (files.length > 0xffff) throw new Error(`${sourceRoot}: too many files for a ZIP32 archive`);
+
+  const localParts = [];
+  const centralParts = [];
+  let offset = 0;
+  for (const file of files) {
+    const name = Buffer.from(file.name, 'utf8');
+    const data = readFileSync(file.path);
+    if (name.length > 0xffff || data.length > ZIP32_MAX) throw new Error(`${file.path}: too large for a ZIP32 archive`);
+    const checksum = crc32(data);
+    const local = localHeader(name, data, checksum);
+    if (offset + local.length + name.length + data.length > ZIP32_MAX) {
+      throw new Error(`${sourceRoot}: provider bundle exceeds the ZIP32 archive limit`);
+    }
+    localParts.push(local, name, data);
+    centralParts.push(centralHeader(name, data, checksum, offset), name);
+    offset += local.length + name.length + data.length;
+  }
+
+  const central = Buffer.concat(centralParts);
+  if (central.length > ZIP32_MAX) throw new Error(`${sourceRoot}: ZIP central directory exceeds the ZIP32 limit`);
+  const archive = Buffer.concat([...localParts, central, endRecord(files.length, central.length, offset)]);
+  mkdirSync(dirname(outputPath), { recursive: true });
+  writeFileSync(outputPath, archive);
+  return {
+    files: files.map((file) => file.name),
+    sha256: createHash('sha256').update(archive).digest('hex'),
+    sizeBytes: archive.length,
+  };
+}

--- a/scripts/marketplace-release.mjs
+++ b/scripts/marketplace-release.mjs
@@ -2,6 +2,8 @@
 import { appendFileSync, cpSync, existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createDeterministicZip } from './deterministic-zip.mjs';
+import { verifyCodexPacket } from './verify-codex-packet.mjs';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const catalog = JSON.parse(readFileSync(join(root, 'distribution', 'catalog.json'), 'utf8'));
@@ -93,8 +95,15 @@ function desiredClaudeEntry(listing, context) {
   };
 }
 
-function submissionMarkdown(selectedProvider, context) {
+function submissionMarkdown(selectedProvider, context, artifacts = []) {
   const packages = selectedProvider.listings.map((listing) => `- \`${listing.id}\` from \`${listing.sourcePath}\``).join('\n');
+  const uploadFiles = artifacts.length === 0 ? [] : [
+    '',
+    '## Upload files',
+    '',
+    ...artifacts.map((artifact) => `- \`${artifact.path}\` — SHA-256 \`${artifact.sha256}\``),
+    '- Verify every digest against `bundles/SHA256SUMS` immediately before upload.',
+  ];
   const completion = selectedProvider.mode === 'reviewed-portal-snapshot'
     ? 'Publication requires review and an explicit publish action in the provider portal. The protected GitHub environment approval is the release-owner attestation for that external step.'
     : 'Publication is complete only after the provider-visible directory resolves every listing to this exact release commit.';
@@ -113,6 +122,7 @@ function submissionMarkdown(selectedProvider, context) {
     '## Listings',
     '',
     packages,
+    ...uploadFiles,
     '',
     '## Completion rule',
     '',
@@ -132,6 +142,26 @@ export function prepareMarketplace(providerId, context, outputPath) {
       errorOnExist: true,
     });
   }
+  const artifacts = [];
+  if (providerId === 'codex') {
+    const bundlesRoot = join(output, 'bundles');
+    mkdirSync(bundlesRoot);
+    for (const listing of selectedProvider.listings) {
+      const archiveName = `${listing.id}-codex-plugin-${context.version}.zip`;
+      const path = join(bundlesRoot, archiveName);
+      const bundle = createDeterministicZip(join(listingsRoot, listing.id), path);
+      artifacts.push({
+        listingId: listing.id,
+        path: `bundles/${archiveName}`,
+        sha256: bundle.sha256,
+        sizeBytes: bundle.sizeBytes,
+      });
+    }
+    writeFileSync(
+      join(bundlesRoot, 'SHA256SUMS'),
+      `${artifacts.map((artifact) => `${artifact.sha256}  ${artifact.path.slice('bundles/'.length)}`).join('\n')}\n`,
+    );
+  }
   const release = {
     schemaVersion: 1,
     provider: providerId,
@@ -146,9 +176,10 @@ export function prepareMarketplace(providerId, context, outputPath) {
       termsOfService: catalog.package.termsOfServiceUrl,
     },
     listings: selectedProvider.listings,
+    artifacts,
   };
   writeJson(join(output, 'release.json'), release);
-  writeFileSync(join(output, 'SUBMISSION.md'), submissionMarkdown(selectedProvider, context));
+  writeFileSync(join(output, 'SUBMISSION.md'), submissionMarkdown(selectedProvider, context, artifacts));
   if (providerId === 'claude') {
     writeJson(join(output, 'directory-entries.json'), selectedProvider.listings.map((entry) => desiredClaudeEntry(entry, context)));
   }
@@ -179,8 +210,11 @@ export function prepareMarketplace(providerId, context, outputPath) {
           starterPrompts: skills.map((skill) => skill.defaultPrompt),
         },
         ...submission,
+        artifact: artifacts.find((artifact) => artifact.listingId === listing.id),
       });
     }
+    cpSync(join(root, 'scripts', 'verify-codex-packet.mjs'), join(output, 'verify-codex-packet.mjs'));
+    verifyCodexPacket(output);
   }
   return { output, release };
 }

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -1,5 +1,6 @@
 /** Test marketplace selection, packaging, provider verification, and workflow gates. */
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { delimiter, join } from 'node:path';
@@ -21,6 +22,25 @@ const context = {
   commit: '0123456789abcdef0123456789abcdef01234567',
   release: {},
 };
+
+function storedZipEntries(path) {
+  const archive = readFileSync(path);
+  const entries = new Map();
+  let offset = 0;
+  while (archive.readUInt32LE(offset) === 0x04034b50) {
+    assert.equal(archive.readUInt16LE(offset + 8), 0, 'provider bundle entries must use stored mode');
+    const size = archive.readUInt32LE(offset + 18);
+    const nameLength = archive.readUInt16LE(offset + 26);
+    const extraLength = archive.readUInt16LE(offset + 28);
+    const nameStart = offset + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    const name = archive.subarray(nameStart, nameStart + nameLength).toString('utf8');
+    entries.set(name, archive.subarray(dataStart, dataStart + size));
+    offset = dataStart + size;
+  }
+  assert.equal(archive.readUInt32LE(offset), 0x02014b50, 'local entries must end at the central directory');
+  return entries;
+}
 
 assert.deepEqual(
   resolveSelection({ claude: 'true', codex: false, kiro: true, all: false }),
@@ -106,8 +126,10 @@ try {
   const release = JSON.parse(readFileSync(join(prepared.output, 'release.json'), 'utf8'));
   assert.equal(release.providerMode, 'reviewed-portal-snapshot');
   assert.equal(release.listings.length, 2);
+  assert.equal(release.artifacts.length, 2);
   assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /protected GitHub environment approval/);
   assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /Privacy:/);
+  assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /qodo-codex-plugin-1\.0\.2\.zip/);
   assert.equal(
     JSON.parse(readFileSync(join(prepared.output, 'listings', 'qodo', '.codex-plugin', 'plugin.json'), 'utf8')).name,
     'qodo',
@@ -127,6 +149,8 @@ try {
   const standardsSubmission = JSON.parse(readFileSync(join(prepared.output, 'submissions', 'qodo-standards.json'), 'utf8'));
   assert.equal(coreSubmission.releaseType, 'update');
   assert.equal(standardsSubmission.releaseType, 'initial');
+  assert.equal(coreSubmission.artifact.listingId, 'qodo');
+  assert.equal(standardsSubmission.artifact.listingId, 'qodo-standards');
   assert.equal(coreSubmission.positiveTests.length, 5);
   assert.equal(coreSubmission.negativeTests.length, 3);
   assert.equal(standardsSubmission.positiveTests.length, 5);
@@ -134,6 +158,96 @@ try {
   assert.equal(coreSubmission.listing.starterPrompts.length, 4);
   assert.equal(standardsSubmission.listing.starterPrompts.length, 2);
   assert.ok(!JSON.stringify(coreSubmission).includes('password'));
+  const coreArchivePath = join(prepared.output, coreSubmission.artifact.path);
+  const coreArchive = readFileSync(coreArchivePath);
+  assert.equal(createHash('sha256').update(coreArchive).digest('hex'), coreSubmission.artifact.sha256);
+  assert.match(
+    readFileSync(join(prepared.output, 'bundles', 'SHA256SUMS'), 'utf8'),
+    new RegExp(`^${coreSubmission.artifact.sha256}  qodo-codex-plugin-1\\.0\\.2\\.zip`, 'm'),
+  );
+  for (const line of readFileSync(join(prepared.output, 'bundles', 'SHA256SUMS'), 'utf8').trim().split('\n')) {
+    const match = line.match(/^([0-9a-f]{64})  ([a-z0-9.-]+\.zip)$/);
+    assert.ok(match, `invalid checksum record: ${line}`);
+    assert.equal(
+      createHash('sha256').update(readFileSync(join(prepared.output, 'bundles', match[2]))).digest('hex'),
+      match[1],
+    );
+  }
+  const sha256sumProbe = spawnSync('sha256sum', ['--version'], { encoding: 'utf8', timeout: 5_000 });
+  if (!sha256sumProbe.error && sha256sumProbe.status === 0) {
+    const verification = spawnSync('sha256sum', ['-c', 'SHA256SUMS'], {
+      cwd: join(prepared.output, 'bundles'),
+      encoding: 'utf8',
+      timeout: 5_000,
+    });
+    assert.equal(verification.status, 0, verification.stderr);
+  } else if (process.platform !== 'win32') {
+    const verification = spawnSync('shasum', ['-a', '256', '-c', 'SHA256SUMS'], {
+      cwd: join(prepared.output, 'bundles'),
+      encoding: 'utf8',
+      timeout: 5_000,
+    });
+    if (verification.error && verification.error.code !== 'ENOENT') throw verification.error;
+    if (!verification.error) assert.equal(verification.status, 0, verification.stderr);
+  }
+  const packetVerification = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
+    cwd: prepared.output,
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  assert.equal(packetVerification.status, 0, packetVerification.stderr);
+  assert.equal(JSON.parse(packetVerification.stdout).verified.length, 2);
+  const coreEntries = storedZipEntries(coreArchivePath);
+  assert.deepEqual(
+    coreEntries.get('.codex-plugin/plugin.json'),
+    readFileSync(join(prepared.output, 'listings', 'qodo', '.codex-plugin', 'plugin.json')),
+  );
+  assert.ok(coreEntries.has('skills/qodo-review/SKILL.md'));
+  assert.ok(!coreEntries.has('skills/qodo-get-rules/SKILL.md'));
+  assert.ok(!coreEntries.has('skills/find-skills/SKILL.md'));
+  const standardsEntries = storedZipEntries(join(prepared.output, standardsSubmission.artifact.path));
+  assert.ok(standardsEntries.has('skills/qodo-get-rules/SKILL.md'));
+  assert.ok(!standardsEntries.has('skills/qodo-review/SKILL.md'));
+
+  const repeat = prepareMarketplace('codex', context, join(temporaryRoot, 'repeat'));
+  for (const artifact of release.artifacts) {
+    assert.deepEqual(
+      readFileSync(join(prepared.output, artifact.path)),
+      readFileSync(join(repeat.output, artifact.path)),
+      `${artifact.listingId} provider bundle must be byte-for-byte deterministic`,
+    );
+  }
+  const repeatSubmissionPath = join(repeat.output, 'submissions', 'qodo.json');
+  const repeatSubmission = JSON.parse(readFileSync(repeatSubmissionPath, 'utf8'));
+  repeatSubmission.artifact.sha256 = '0'.repeat(64);
+  writeFileSync(repeatSubmissionPath, `${JSON.stringify(repeatSubmission, null, 2)}\n`);
+  const tamperedVerification = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
+    cwd: repeat.output,
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  assert.equal(tamperedVerification.status, 1);
+  assert.match(tamperedVerification.stderr, /submission artifact metadata mismatch/);
+
+  const incomplete = prepareMarketplace('codex', context, join(temporaryRoot, 'incomplete'));
+  const incompleteReleasePath = join(incomplete.output, 'release.json');
+  const incompleteRelease = JSON.parse(readFileSync(incompleteReleasePath, 'utf8'));
+  const removedArtifact = incompleteRelease.artifacts.pop();
+  writeFileSync(incompleteReleasePath, `${JSON.stringify(incompleteRelease, null, 2)}\n`);
+  rmSync(join(incomplete.output, removedArtifact.path));
+  rmSync(join(incomplete.output, 'submissions', `${removedArtifact.listingId}.json`));
+  const checksumPath = join(incomplete.output, 'bundles', 'SHA256SUMS');
+  const retainedChecksums = readFileSync(checksumPath, 'utf8')
+    .split('\n')
+    .filter((line) => line && !line.endsWith(`  ${removedArtifact.path.slice('bundles/'.length)}`));
+  writeFileSync(checksumPath, `${retainedChecksums.join('\n')}\n`);
+  const incompleteVerification = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
+    cwd: incomplete.output,
+    encoding: 'utf8',
+    timeout: 5_000,
+  });
+  assert.equal(incompleteVerification.status, 1);
+  assert.match(incompleteVerification.stderr, /exactly one artifact per Codex listing/);
   assert.throws(() => prepareMarketplace('codex', context, output), /already exists/);
 } finally {
   rmSync(temporaryRoot, { recursive: true, force: true });
@@ -147,6 +261,9 @@ assert.ok((workflow.match(/type: boolean/g) ?? []).length >= 4);
 assert.match(workflow, /fromJSON\(needs\.plan\.outputs\.matrix\)/);
 assert.match(workflow, /has_verifiable/);
 assert.match(workflow, /name: marketplace-codex/);
+assert.match(workflow, /node verify-codex-packet\.mjs/);
+assert.match(workflow, /Update the existing `qodo` listing/);
+assert.match(workflow, /qodo-standards.*optional initial listing/);
 assert.match(workflow, /name: marketplace-\$\{\{ matrix\.provider \}\}/);
 assert.match(workflow, /required_reviewers/);
 assert.match(workflow, /verify-provider-visible/);

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -17,8 +17,8 @@ import {
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
 const releasePreflight = readFileSync(join(root, 'scripts', 'verify-release-prerequisites.sh'), 'utf8');
 const context = {
-  tag: 'v1.0.2',
-  version: '1.0.2',
+  tag: 'v1.0.12',
+  version: '1.0.12',
   commit: '0123456789abcdef0123456789abcdef01234567',
   release: {},
 };
@@ -40,6 +40,14 @@ function storedZipEntries(path) {
   }
   assert.equal(archive.readUInt32LE(offset), 0x02014b50, 'local entries must end at the central directory');
   return entries;
+}
+
+function verifyPacketFails(output, pattern) {
+  const result = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
+    cwd: output, encoding: 'utf8', timeout: 5_000,
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, pattern);
 }
 
 assert.deepEqual(
@@ -129,7 +137,7 @@ try {
   assert.equal(release.artifacts.length, 2);
   assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /protected GitHub environment approval/);
   assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /Privacy:/);
-  assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /qodo-codex-plugin-1\.0\.2\.zip/);
+  assert.match(readFileSync(join(prepared.output, 'SUBMISSION.md'), 'utf8'), /qodo-codex-plugin-1\.0\.12\.zip/);
   assert.equal(
     JSON.parse(readFileSync(join(prepared.output, 'listings', 'qodo', '.codex-plugin', 'plugin.json'), 'utf8')).name,
     'qodo',
@@ -163,7 +171,7 @@ try {
   assert.equal(createHash('sha256').update(coreArchive).digest('hex'), coreSubmission.artifact.sha256);
   assert.match(
     readFileSync(join(prepared.output, 'bundles', 'SHA256SUMS'), 'utf8'),
-    new RegExp(`^${coreSubmission.artifact.sha256}  qodo-codex-plugin-1\\.0\\.2\\.zip`, 'm'),
+    new RegExp(`^${coreSubmission.artifact.sha256}  qodo-codex-plugin-1\\.0\\.12\\.zip`, 'm'),
   );
   for (const line of readFileSync(join(prepared.output, 'bundles', 'SHA256SUMS'), 'utf8').trim().split('\n')) {
     const match = line.match(/^([0-9a-f]{64})  ([a-z0-9.-]+\.zip)$/);
@@ -172,23 +180,6 @@ try {
       createHash('sha256').update(readFileSync(join(prepared.output, 'bundles', match[2]))).digest('hex'),
       match[1],
     );
-  }
-  const sha256sumProbe = spawnSync('sha256sum', ['--version'], { encoding: 'utf8', timeout: 5_000 });
-  if (!sha256sumProbe.error && sha256sumProbe.status === 0) {
-    const verification = spawnSync('sha256sum', ['-c', 'SHA256SUMS'], {
-      cwd: join(prepared.output, 'bundles'),
-      encoding: 'utf8',
-      timeout: 5_000,
-    });
-    assert.equal(verification.status, 0, verification.stderr);
-  } else if (process.platform !== 'win32') {
-    const verification = spawnSync('shasum', ['-a', '256', '-c', 'SHA256SUMS'], {
-      cwd: join(prepared.output, 'bundles'),
-      encoding: 'utf8',
-      timeout: 5_000,
-    });
-    if (verification.error && verification.error.code !== 'ENOENT') throw verification.error;
-    if (!verification.error) assert.equal(verification.status, 0, verification.stderr);
   }
   const packetVerification = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
     cwd: prepared.output,
@@ -221,13 +212,7 @@ try {
   const repeatSubmission = JSON.parse(readFileSync(repeatSubmissionPath, 'utf8'));
   repeatSubmission.artifact.sha256 = '0'.repeat(64);
   writeFileSync(repeatSubmissionPath, `${JSON.stringify(repeatSubmission, null, 2)}\n`);
-  const tamperedVerification = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
-    cwd: repeat.output,
-    encoding: 'utf8',
-    timeout: 5_000,
-  });
-  assert.equal(tamperedVerification.status, 1);
-  assert.match(tamperedVerification.stderr, /submission artifact metadata mismatch/);
+  verifyPacketFails(repeat.output, /submission artifact metadata mismatch/);
 
   const incomplete = prepareMarketplace('codex', context, join(temporaryRoot, 'incomplete'));
   const incompleteReleasePath = join(incomplete.output, 'release.json');
@@ -241,13 +226,22 @@ try {
     .split('\n')
     .filter((line) => line && !line.endsWith(`  ${removedArtifact.path.slice('bundles/'.length)}`));
   writeFileSync(checksumPath, `${retainedChecksums.join('\n')}\n`);
-  const incompleteVerification = spawnSync(process.execPath, ['verify-codex-packet.mjs'], {
-    cwd: incomplete.output,
-    encoding: 'utf8',
-    timeout: 5_000,
-  });
-  assert.equal(incompleteVerification.status, 1);
-  assert.match(incompleteVerification.stderr, /exactly one artifact per Codex listing/);
+  verifyPacketFails(incomplete.output, /exactly one artifact per Codex listing/);
+
+  const swapped = prepareMarketplace('codex', context, join(temporaryRoot, 'swapped'));
+  const swappedReleasePath = join(swapped.output, 'release.json');
+  const swappedRelease = JSON.parse(readFileSync(swappedReleasePath, 'utf8'));
+  const [firstArtifact, secondArtifact] = swappedRelease.artifacts;
+  [firstArtifact.listingId, secondArtifact.listingId] = [secondArtifact.listingId, firstArtifact.listingId];
+  writeFileSync(swappedReleasePath, `${JSON.stringify(swappedRelease, null, 2)}\n`);
+  for (const artifact of swappedRelease.artifacts) {
+    const submissionPath = join(swapped.output, 'submissions', `${artifact.listingId}.json`);
+    const submission = JSON.parse(readFileSync(submissionPath, 'utf8'));
+    submission.listingId = artifact.listingId;
+    submission.artifact = artifact;
+    writeFileSync(submissionPath, `${JSON.stringify(submission, null, 2)}\n`);
+  }
+  verifyPacketFails(swapped.output, /internal plugin identity does not match/);
   assert.throws(() => prepareMarketplace('codex', context, output), /already exists/);
 } finally {
   rmSync(temporaryRoot, { recursive: true, force: true });

--- a/scripts/validate-diff.mjs
+++ b/scripts/validate-diff.mjs
@@ -143,7 +143,7 @@ const versionedPackagePaths = [
   /^kiro-power(?:-standards)?\//,
   /^packages\//,
   /^distribution\/(?:(?:catalog|codex-submissions|marketplaces)\.schema|codex-submissions|marketplaces)\.json$/,
-  /^scripts\/(?:build-cli-managed-bundle|build-enterprise-bundle|build-release-index|marketplace-release(?:-lock)?|prepare-release|release-notes|skill-provenance|sync-adapters)\.mjs$/,
+  /^scripts\/(?:build-cli-managed-bundle|build-enterprise-bundle|build-release-index|deterministic-zip|marketplace-release(?:-lock)?|prepare-release|release-notes|skill-provenance|sync-adapters|verify-codex-packet)\.mjs$/,
   /^scripts\/(?:audit-release-protections|verify-kiro-release-source|verify-release-prerequisites)\.(?:cmd|sh)$/,
 ];
 const packagingChanged = files.some((path) => versionedPackagePaths.some((pattern) => pattern.test(path)));

--- a/scripts/verify-codex-packet.mjs
+++ b/scripts/verify-codex-packet.mjs
@@ -1,0 +1,134 @@
+/** Verify a downloaded Codex marketplace packet before portal upload. */
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { basename, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+function readRegularFile(path) {
+  const stat = lstatSync(path);
+  if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`${path}: expected a regular file`);
+  return { bytes: readFileSync(path), sizeBytes: stat.size };
+}
+
+function readJson(path) {
+  const { bytes } = readRegularFile(path);
+  try {
+    return JSON.parse(bytes.toString('utf8'));
+  } catch (error) {
+    throw new Error(`${path}: invalid JSON: ${error.message}`);
+  }
+}
+
+function sha256(bytes) {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function artifactPath(value) {
+  if (!/^bundles\/[a-z0-9][a-z0-9.-]*\.zip$/.test(value ?? '')) {
+    throw new Error(`Unsafe Codex artifact path: ${value ?? '<missing>'}`);
+  }
+  return value;
+}
+
+function checksumRecords(path) {
+  const { bytes } = readRegularFile(path);
+  const records = new Map();
+  for (const line of bytes.toString('utf8').trim().split('\n')) {
+    const match = line.match(/^([0-9a-f]{64})  ([a-z0-9][a-z0-9.-]*\.zip)$/);
+    if (!match) throw new Error(`${path}: invalid checksum record: ${line}`);
+    if (records.has(match[2])) throw new Error(`${path}: duplicate checksum record for ${match[2]}`);
+    records.set(match[2], match[1]);
+  }
+  if (records.size === 0) throw new Error(`${path}: checksum inventory is empty`);
+  return records;
+}
+
+function sameJson(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
+export function verifyCodexPacket(packetRoot) {
+  const root = resolve(packetRoot);
+  const release = readJson(join(root, 'release.json'));
+  if (release.provider !== 'codex' || release.providerMode !== 'reviewed-portal-snapshot') {
+    throw new Error('release.json is not a reviewed Codex portal packet');
+  }
+  if (!Array.isArray(release.listings) || release.listings.length === 0) {
+    throw new Error('release.json has no Codex listings');
+  }
+  const listingIds = new Set();
+  for (const listing of release.listings) {
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(listing.id ?? '')) throw new Error('release.json has an invalid listing id');
+    if (listingIds.has(listing.id)) throw new Error(`release.json has a duplicate listing: ${listing.id}`);
+    listingIds.add(listing.id);
+  }
+  if (!Array.isArray(release.artifacts) || release.artifacts.length !== listingIds.size) {
+    throw new Error('release.json must have exactly one artifact per Codex listing');
+  }
+  if (release.artifacts.length === 0) {
+    throw new Error('release.json has no Codex upload artifacts');
+  }
+  const checksums = checksumRecords(join(root, 'bundles', 'SHA256SUMS'));
+  const expectedArchives = new Set();
+  const artifactListingIds = new Set();
+  const verified = [];
+
+  for (const artifact of release.artifacts) {
+    if (!listingIds.has(artifact.listingId)) throw new Error(`Unknown listing artifact: ${artifact.listingId}`);
+    if (artifactListingIds.has(artifact.listingId)) {
+      throw new Error(`Duplicate artifact for Codex listing: ${artifact.listingId}`);
+    }
+    artifactListingIds.add(artifact.listingId);
+    const relativePath = artifactPath(artifact.path);
+    const archiveName = basename(relativePath);
+    if (expectedArchives.has(archiveName)) throw new Error(`Duplicate Codex artifact: ${archiveName}`);
+    expectedArchives.add(archiveName);
+    const archive = readRegularFile(join(root, relativePath));
+    const digest = sha256(archive.bytes);
+    if (artifact.sha256 !== digest) throw new Error(`${archiveName}: release.json SHA-256 mismatch`);
+    if (artifact.sizeBytes !== archive.sizeBytes) throw new Error(`${archiveName}: release.json size mismatch`);
+    if (checksums.get(archiveName) !== digest) throw new Error(`${archiveName}: SHA256SUMS mismatch`);
+
+    const submission = readJson(join(root, 'submissions', `${artifact.listingId}.json`));
+    if (submission.listingId !== artifact.listingId || !sameJson(submission.artifact, artifact)) {
+      throw new Error(`${artifact.listingId}: submission artifact metadata mismatch`);
+    }
+    if (!sameJson(submission.release, {
+      tag: release.tag,
+      commit: release.commit,
+      version: release.version,
+    })) {
+      throw new Error(`${artifact.listingId}: submission release identity mismatch`);
+    }
+    verified.push({ listingId: artifact.listingId, path: relativePath, sha256: digest });
+  }
+
+  if ([...listingIds].some((listingId) => !artifactListingIds.has(listingId))) {
+    throw new Error('release.json is missing a Codex listing artifact');
+  }
+  if (checksums.size !== expectedArchives.size) throw new Error('SHA256SUMS contains an undeclared archive');
+  const actualArchives = readdirSync(join(root, 'bundles'), { withFileTypes: true })
+    .filter((entry) => entry.name.endsWith('.zip'));
+  if (actualArchives.some((entry) => !entry.isFile() || entry.isSymbolicLink())) {
+    throw new Error('bundles contains a non-regular ZIP entry');
+  }
+  const actualNames = new Set(actualArchives.map((entry) => entry.name));
+  if (actualNames.size !== expectedArchives.size || [...actualNames].some((name) => !expectedArchives.has(name))) {
+    throw new Error('bundles contains an undeclared or missing ZIP archive');
+  }
+  return { provider: 'codex', tag: release.tag, commit: release.commit, verified };
+}
+
+if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    console.log(JSON.stringify(verifyCodexPacket(process.argv[2] ?? process.cwd())));
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/verify-codex-packet.mjs
+++ b/scripts/verify-codex-packet.mjs
@@ -52,6 +52,37 @@ function sameJson(left, right) {
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+function storedZipEntry(archive, targetName) {
+  let offset = 0;
+  let target;
+  while (offset + 30 <= archive.length && archive.readUInt32LE(offset) === 0x04034b50) {
+    const flags = archive.readUInt16LE(offset + 6);
+    const method = archive.readUInt16LE(offset + 8);
+    const compressedSize = archive.readUInt32LE(offset + 18);
+    const uncompressedSize = archive.readUInt32LE(offset + 22);
+    const nameLength = archive.readUInt16LE(offset + 26);
+    const extraLength = archive.readUInt16LE(offset + 28);
+    if ((flags & 0x0008) !== 0 || method !== 0 || compressedSize !== uncompressedSize) {
+      throw new Error('Codex bundle must use deterministic stored ZIP entries');
+    }
+    const nameStart = offset + 30;
+    const dataStart = nameStart + nameLength + extraLength;
+    const dataEnd = dataStart + compressedSize;
+    if (dataEnd > archive.length) throw new Error('Codex bundle contains a truncated ZIP entry');
+    const name = archive.subarray(nameStart, nameStart + nameLength).toString('utf8');
+    if (name === targetName) {
+      if (target) throw new Error(`Codex bundle contains duplicate ${targetName} entries`);
+      target = archive.subarray(dataStart, dataEnd);
+    }
+    offset = dataEnd;
+  }
+  if (offset + 4 > archive.length || archive.readUInt32LE(offset) !== 0x02014b50) {
+    throw new Error('Codex bundle local entries do not end at a central directory');
+  }
+  if (!target) throw new Error(`Codex bundle is missing ${targetName}`);
+  return target;
+}
+
 export function verifyCodexPacket(packetRoot) {
   const root = resolve(packetRoot);
   const release = readJson(join(root, 'release.json'));
@@ -93,6 +124,15 @@ export function verifyCodexPacket(packetRoot) {
     if (artifact.sha256 !== digest) throw new Error(`${archiveName}: release.json SHA-256 mismatch`);
     if (artifact.sizeBytes !== archive.sizeBytes) throw new Error(`${archiveName}: release.json size mismatch`);
     if (checksums.get(archiveName) !== digest) throw new Error(`${archiveName}: SHA256SUMS mismatch`);
+    let plugin;
+    try {
+      plugin = JSON.parse(storedZipEntry(archive.bytes, '.codex-plugin/plugin.json').toString('utf8'));
+    } catch (error) {
+      throw new Error(`${archiveName}: invalid internal plugin manifest: ${error.message}`);
+    }
+    if (plugin.name !== artifact.listingId || plugin.version !== release.version) {
+      throw new Error(`${archiveName}: internal plugin identity does not match ${artifact.listingId}@${release.version}`);
+    }
 
     const submission = readJson(join(root, 'submissions', `${artifact.listingId}.json`));
     if (submission.listingId !== artifact.listingId || !sameJson(submission.artifact, artifact)) {


### PR DESCRIPTION
## Summary

- generate deterministic, dependency-free ZIP bundles for each Codex listing
- bind every upload archive to SHA-256 metadata in the provider packet and give release owners an exact verification command
- preserve the existing `qodo` update identity while keeping `qodo-standards` a separate optional initial listing
- prepare package-only skills release `v1.0.12`

## Safety

- archives have sorted locale-independent paths, fixed timestamps and modes, and reject symlinks or unsupported entries
- the core archive excludes Qodo Standards and unrelated third-party skills
- the portal gate now names the exact upload and checksum workflow
- `v1.0.11` is already prepared and must be published before this PR merges; after this PR, publish `v1.0.12` and use its generated Codex packet

## Validation

- `npm test`
- `node scripts/validate-diff.mjs origin/main`
- `git diff --check`
- generated both ZIPs, verified `SHA256SUMS`, extracted them, and passed the Codex plugin validator on each root
- Qodo deep/fast local review findings were either implemented or independently disproven by executable release/topology validation
