### PR TITLE
feat(kiro): add root plugin display metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
-    "version": "2.0.0"
+    "version": "2.0.1"
   },
   "plugins": [
     {

--- a/codex-packages/qodo-standards/.codex-plugin/plugin.json
+++ b/codex-packages/qodo-standards/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo-standards/plugin.json
+++ b/codex-packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/.codex-plugin/plugin.json
+++ b/codex-packages/qodo/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/codex-packages/qodo/plugin.json
+++ b/codex-packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/distribution/catalog.json
+++ b/distribution/catalog.json
@@ -5,7 +5,7 @@
   "package": {
     "name": "qodo",
     "displayName": "Qodo for coding agents",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Qodo code intelligence, review, and organizational standards for local coding agents.",
     "repository": "https://github.com/qodo-ai/qodo-skills",
     "homepage": "https://www.qodo.ai",

--- a/distribution/marketplaces.json
+++ b/distribution/marketplaces.json
@@ -52,7 +52,9 @@
         {
           "package": "qodo",
           "id": "qodo",
-          "sourcePath": "kiro-power"
+          "sourcePath": "kiro-power",
+          "displayName": "Qodo Code Review",
+          "description": "Qodo code review, code intelligence, and PR resolution workflows for your local agent."
         },
         {
           "package": "qodo-standards",

--- a/distribution/marketplaces.json
+++ b/distribution/marketplaces.json
@@ -53,8 +53,8 @@
           "package": "qodo",
           "id": "qodo",
           "sourcePath": "kiro-power",
-          "displayName": "Qodo Code Review",
-          "description": "Qodo code review, code intelligence, and PR resolution workflows for your local agent."
+          "displayName": "Qodo AI Code Review and Governance",
+          "description": "AI code review inside Kiro. Catches bugs, cross-repo breakages, and standards gaps in local changes before a PR is opened, then resolves findings on PRs already in flight with fix suggestions you apply in Kiro. Shorter review cycles, fewer issues reaching main."
         },
         {
           "package": "qodo-standards",

--- a/distribution/marketplaces.schema.json
+++ b/distribution/marketplaces.schema.json
@@ -35,7 +35,9 @@
               "properties": {
                 "package": { "type": "string", "pattern": "^qodo(?:-[a-z0-9-]+)?$" },
                 "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
-                "sourcePath": { "type": "string", "pattern": "^[a-zA-Z0-9._/-]+$" }
+                "sourcePath": { "type": "string", "pattern": "^[a-zA-Z0-9._/-]+$" },
+                "displayName": { "type": "string", "minLength": 1 },
+                "description": { "type": "string", "minLength": 1 }
               }
             }
           }

--- a/distribution/qodo-cli-managed-bundle.json
+++ b/distribution/qodo-cli-managed-bundle.json
@@ -2,11 +2,11 @@
   "schemaVersion": 1,
   "distribution": "qodo-cli-managed",
   "instructionMode": "embedded",
-  "packageVersion": "2.0.0",
+  "packageVersion": "2.0.1",
   "minimumCliVersion": "0.1.0-next.37",
   "source": {
     "repository": "https://github.com/qodo-ai/qodo-skills",
-    "tag": "v2.0.0"
+    "tag": "v2.0.1"
   },
   "aliases": {
     "codebase-wisdom": "qodo-codebase-wisdom",

--- a/distribution/qodo-cli-managed-bundle.json.sha256
+++ b/distribution/qodo-cli-managed-bundle.json.sha256
@@ -1,1 +1,1 @@
-80ecbeea48dfbffe424c877f59c21b18218727cb0158a1f5c6eb490d212047ad  qodo-cli-managed-bundle.json
+3c67c096956288ed9a7a76a26b81ab88fdd9ae0210791e287a617451f5c8e71b  qodo-cli-managed-bundle.json

--- a/distribution/qodo-skills-index.json
+++ b/distribution/qodo-skills-index.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "instructionMode": "embedded",
-  "packageVersion": "2.0.0",
+  "packageVersion": "2.0.1",
   "minimumCliVersion": "0.1.0-next.37",
   "repository": "https://github.com/qodo-ai/qodo-skills",
   "skills": {

--- a/distribution/qodo-skills-index.json.sha256
+++ b/distribution/qodo-skills-index.json.sha256
@@ -1,1 +1,1 @@
-a0b3fb483e73bd3acfd4b8621444d76f16778d5644fecab15422c0052b764e1d  qodo-skills-index.json
+bc7628824f5c487b120f81b81957f6a65a34aae38402c7f39b0648e9767deb96  qodo-skills-index.json

--- a/kiro-power-standards/plugin.json
+++ b/kiro-power-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "2.0.0",
-  "description": "Qodo setup, code intelligence, and review workflows.",
+  "displayName": "Qodo Code Review",
+  "version": "2.0.1",
+  "description": "Qodo code review, code intelligence, and PR resolution workflows for your local agent.",
   "author": {
     "name": "Qodo",
     "email": "support@qodo.ai",

--- a/kiro-power/plugin.json
+++ b/kiro-power/plugin.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "displayName": "Qodo Code Review",
+  "displayName": "Qodo AI Code Review and Governance",
   "version": "2.0.1",
-  "description": "Qodo code review, code intelligence, and PR resolution workflows for your local agent.",
+  "description": "AI code review inside Kiro. Catches bugs, cross-repo breakages, and standards gaps in local changes before a PR is opened, then resolves findings on PRs already in flight with fix suggestions you apply in Kiro. Shorter review cycles, fewer issues reaching main.",
   "author": {
     "name": "Qodo",
     "email": "support@qodo.ai",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qodo/agent-skills",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "ajv": "8.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qodo/agent-skills",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Canonical Qodo skills and local coding-agent marketplace adapters.",
   "type": "module",
@@ -15,7 +15,7 @@
     "release:notes": "node scripts/release-notes.mjs",
     "enterprise:build": "node scripts/build-enterprise-bundle.mjs",
     "check": "node scripts/validate.mjs && node scripts/build-release-index.mjs --check && node scripts/build-cli-managed-bundle.mjs --check",
-    "test": "npm run check && node --test test/marketplace-auto-start.test.mjs test/codex-portal-contract.test.mjs test/skill-delivery.test.mjs && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
+    "test": "npm run check && node --test test/marketplace-auto-start.test.mjs test/codex-portal-contract.test.mjs test/kiro-power-manifest.test.mjs test/skill-delivery.test.mjs && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/qodo-standards/.claude-plugin/plugin.json
+++ b/packages/qodo-standards/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo-standards",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo-standards/plugin.json
+++ b/packages/qodo-standards/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo-standards",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Optional Qodo rules discovery and standards administration workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/.claude-plugin/plugin.json
+++ b/packages/qodo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qodo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/packages/qodo/plugin.json
+++ b/packages/qodo/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "qodo",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Qodo setup, code intelligence, and review workflows.",
   "author": {
     "name": "Qodo",

--- a/releases/v2.0.1.json
+++ b/releases/v2.0.1.json
@@ -1,0 +1,10 @@
+{
+  "version": "2.0.1",
+  "summary": "Add Kiro display names and descriptions to root plugin manifests.",
+  "package": {
+    "change": "patch"
+  },
+  "runtimeProtocolVersion": 2,
+  "minimumCliVersion": "0.1.0-next.37",
+  "skills": []
+}

--- a/scripts/sync-adapters.mjs
+++ b/scripts/sync-adapters.mjs
@@ -98,12 +98,14 @@ function installPackage(name) {
   return value;
 }
 
-function pluginManifest(value) {
+function pluginManifest(value, adapterSet) {
+  const kiroListing = adapterSet === 'kiro' ? listing('kiro', value.name) : undefined;
   return {
     $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
     name: value.name,
+    ...(kiroListing ? { displayName: kiroListing.displayName } : {}),
     version: pkg.version,
-    description: value.description,
+    description: kiroListing?.description ?? value.description,
     author,
     homepage: pkg.homepage,
     repository: pkg.repository,
@@ -166,7 +168,7 @@ function kiroReadPermissionProfile() {
 
 function generatedPackageFiles(value, adapterSet = 'claude') {
   const files = new Map([
-    ['plugin.json', `${JSON.stringify(pluginManifest(value), null, 2)}\n`],
+    ['plugin.json', `${JSON.stringify(pluginManifest(value, adapterSet), null, 2)}\n`],
   ]);
   if (adapterSet === 'codex') {
     const manifest = codexManifest(value);

--- a/test/kiro-power-manifest.test.mjs
+++ b/test/kiro-power-manifest.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const marketplaces = JSON.parse(readFileSync(join(root, 'distribution', 'marketplaces.json'), 'utf8'));
+const kiro = marketplaces.providers.find((provider) => provider.id === 'kiro');
+
+test('the core Kiro Power uses the requested review metadata', () => {
+  const listing = kiro.listings.find((entry) => entry.package === 'qodo');
+  const manifest = JSON.parse(readFileSync(join(root, listing.sourcePath, 'plugin.json'), 'utf8'));
+
+  assert.equal(manifest.name, listing.id);
+  assert.equal(manifest.displayName, listing.displayName);
+  assert.equal(manifest.description, listing.description);
+  assert.equal(listing.displayName, 'Qodo Code Review');
+  assert.equal(
+    listing.description,
+    'Qodo code review, code intelligence, and PR resolution workflows for your local agent.',
+  );
+});

--- a/test/kiro-power-manifest.test.mjs
+++ b/test/kiro-power-manifest.test.mjs
@@ -15,9 +15,9 @@ test('the core Kiro Power uses the requested review metadata', () => {
   assert.equal(manifest.name, listing.id);
   assert.equal(manifest.displayName, listing.displayName);
   assert.equal(manifest.description, listing.description);
-  assert.equal(listing.displayName, 'Qodo Code Review');
+  assert.equal(listing.displayName, 'Qodo AI Code Review and Governance');
   assert.equal(
     listing.description,
-    'Qodo code review, code intelligence, and PR resolution workflows for your local agent.',
+    'AI code review inside Kiro. Catches bugs, cross-repo breakages, and standards gaps in local changes before a PR is opened, then resolves findings on PRs already in flight with fix suggestions you apply in Kiro. Shorter review cycles, fewer issues reaching main.',
   );
 });


### PR DESCRIPTION
## Summary

- add Kiro-specific `displayName` and `description` metadata for the core `qodo` listing
- generate the exact requested fields into `kiro-power/plugin.json`
- add regression coverage and prepare the repository-required package-only `v2.0.1` release
- leave `POWER.md` and canonical skill behavior unchanged

## Validation

- `npm test`
- `npm run adapters -- --check`
- `node scripts/validate-diff.mjs origin/main`
- `git diff --check`