### PR TITLE
fix(setup): smooth marketplace onboarding and shrink skill prompt

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "release:notes": "node scripts/release-notes.mjs",
     "enterprise:build": "node scripts/build-enterprise-bundle.mjs",
     "check": "node scripts/validate.mjs && node scripts/build-release-index.mjs --check && node scripts/build-cli-managed-bundle.mjs --check",
-    "test": "npm run check && node --test test/kiro-marketplace.test.mjs test/marketplace-auto-start.test.mjs test/marketplace-verification.test.mjs test/codex-portal-contract.test.mjs test/kiro-power-manifest.test.mjs test/skill-delivery.test.mjs test/skill-release.test.mjs test/skill-release-driver.test.mjs && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
+    "test": "npm run check && node --test test/kiro-marketplace.test.mjs test/marketplace-auto-start.test.mjs test/marketplace-verification.test.mjs test/codex-portal-contract.test.mjs test/kiro-power-manifest.test.mjs test/skill-delivery.test.mjs test/setup-packaging.test.mjs test/skill-release.test.mjs test/skill-release-driver.test.mjs && node scripts/test-cli-managed-bundle.mjs && node scripts/test-release-transaction.mjs && node scripts/test-release.mjs && node scripts/test-release-workflow.mjs && node scripts/test-marketplace-release.mjs && node scripts/test-marketplace-release-lock.mjs && node scripts/test-enterprise-bundle.mjs"
   },
   "license": "MIT",
   "devDependencies": {

--- a/scripts/test-enterprise-bundle.mjs
+++ b/scripts/test-enterprise-bundle.mjs
@@ -110,6 +110,11 @@ try {
       const skillArchiveFiles = tarFiles(firstSkillArchive);
       assert.ok(skillArchiveFiles.has('SKILL.md'));
       assert.match(skillArchiveFiles.get('SKILL.md').toString(), /  distribution: "enterprise-bundle"/);
+      // Progressive disclosure must work after installing an individual skill archive.
+      for (const [, reference] of skillArchiveFiles.get('SKILL.md').toString().matchAll(/\]\((references\/[^)]+\.md)\)/g)) {
+        const source = readFileSync(join(root, 'skills', entry.name, reference), 'utf8').replace(/\r\n/g, '\n');
+        assert.equal(skillArchiveFiles.get(reference)?.toString().replace(/\r\n/g, '\n'), source);
+      }
       assert.ok([...skillArchiveFiles.keys()].every((path) => !path.startsWith('qodo-enterprise/')));
     }
   }

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -285,10 +285,15 @@ for (const skill of catalog.skills ?? []) {
     fail(`${skill.name}: runtime gate must name catalog minimumCliVersion`);
   }
   if (skill.name === 'qodo-setup') {
-    const chooseLogin = skillText.indexOf('Choose the login command before opening a browser:');
-    const cloudLogin = skillText.indexOf('For Qodo Cloud, run `<qodo> login`.');
-    const customerLogin = skillText.indexOf('For a customer deployment, preserve the exact deployment-specific command');
-    const failClosed = skillText.indexOf('Never probe or fall back to Qodo Cloud.');
+    // Our entrypoint regression budget; conditional procedures are loaded on demand.
+    if (Buffer.byteLength(skillText, 'utf8') > 4000) {
+      fail('qodo-setup: main prompt exceeds 4000 UTF-8 bytes; move conditional detail to references');
+    }
+    const authentication = readFileSync(join(root, 'skills', skill.name, 'references', 'authentication.md'), 'utf8');
+    const chooseLogin = authentication.indexOf('Choose the login command before opening a browser:');
+    const cloudLogin = authentication.indexOf('For Qodo Cloud, run `<qodo> login`.');
+    const customerLogin = authentication.indexOf('For a customer deployment, preserve the exact deployment-specific command');
+    const failClosed = authentication.indexOf('Never probe or fall back to Qodo Cloud.');
     if (!(chooseLogin >= 0 && cloudLogin > chooseLogin && customerLogin > cloudLogin && failClosed > customerLogin)) {
       fail('qodo-setup: login guidance must branch by deployment and fail closed before opening a browser');
     }
@@ -426,7 +431,9 @@ for (const installPackage of catalog.installPackages ?? []) {
       });
       if (text !== expected) fail(`${path}: generated skill differs from the canonical embedded playbook`);
       if (text.includes('qodo help workflow ')) fail(`${path}: released skill must not load instructions at runtime`);
-      if (!text.includes('## Handle a skill update notice')) fail(`${path}: embedded playbook is incomplete`);
+      const notice = skillName === 'qodo-setup'
+        ? readFileSync(join(dirname(join(root, path)), 'references', 'host-recovery.md'), 'utf8') : text;
+      if (!notice.includes('## Handle a skill update notice')) fail(`${path}: embedded playbook is incomplete`);
       if (!text.includes(`--distribution ${distribution} --host ${host}`)) {
         fail(`${path}: missing exact lifecycle and host provenance`);
       }

--- a/skills/qodo-setup/SKILL.md
+++ b/skills/qodo-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qodo-setup
-description: Connect Qodo to the current local coding agent — verify the Qodo CLI, guide a secure installation when it is missing, complete browser login, and confirm managed tools are ready. Use after installing the Qodo plugin, when the user asks to set up or connect Qodo, or when another Qodo skill reports that the CLI is missing or logged out.
+description: Set up Qodo in a local coding agent — install the CLI, sign in, and verify tools. Use after plugin installation, on a setup request, or when another Qodo skill finds a missing CLI or login.
 owner: Qodo
 metadata:
   vendor: qodo
@@ -14,34 +14,16 @@ metadata:
 
 ## Description
 
-Turn a marketplace install into one guided first-use flow: find the local runtime,
-authenticate the human through Qodo's browser login, and verify that this agent can use
-the managed tools. Never ask the user to paste credentials into chat.
+Complete setup in this conversation: find or install the CLI, sign in, and verify tools.
+Plugin installation does not connect an account.
 
 ## Prerequisites
 
-- The Qodo plugin or skills.sh package is installed for the current coding agent.
-- The user is present to approve a checksum-verified CLI install and complete browser login.
-- No credential, token, or invented installer checksum is copied into the conversation.
+A local shell and a user for browser sign-in. Never request or read credentials.
 
 ## Instructions
 
-Follow the four-stage workflow below: preserve lifecycle notices, resolve the runtime, authenticate
-the user, verify identity and tool readiness, then give a concise handoff with one next action.
-
-## Handle a skill update notice
-
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
-`code` is `qodo_skill_update_available`, keep the command's result and finish the current
-task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
-Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
-
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
-implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
-
-## 1. Find the runtime
+### 1. Find or install the runtime
 
 Run:
 
@@ -49,131 +31,66 @@ Run:
 qodo --version
 ```
 
-If a POSIX shell reports `qodo: command not found`, retry the standard user-scoped location:
+If missing, try `"${QODO_HOME:-$HOME/.qodo}/bin/qodo" --version` on POSIX.
+For PowerShell or a missing CLI, read [runtime.md](references/runtime.md).
+Install through that procedure and continue here without requiring a second setup request.
+A setup request covers the CLI install; honor host approvals and user restrictions.
+Plugin installation alone does not authorize installing software.
 
-```sh
-"${QODO_HOME:-$HOME/.qodo}/bin/qodo" --version
-```
+Keep the working executable as `<qodo>`. Require Qodo CLI **0.1.0-next.37 or newer**.
+If older or unparseable, follow the runtime reference before any authenticated command.
 
-In Windows PowerShell, use the native launcher:
+### 2. Connect
 
-```powershell
-$qodoHome = if ($env:QODO_HOME) { $env:QODO_HOME } else { Join-Path $HOME '.qodo' }
-& (Join-Path $qodoHome 'bin/qodo.cmd') --version
-```
-
-Keep the working command for every later step. Do not rewrite PATH automatically.
-
-If neither command exists, tell the user:
-
-> The Qodo skill is installed, but its local runtime is not. Obtain the checksum-verified Qodo CLI
-> from https://get.qodo.ai or your organization's Qodo administrator, then ask me to “Set up Qodo”
-> again.
-
-Stop there. Do not invent a checksum, pipe a remote script into a shell, use a package from
-an unofficial registry, or install software without the user's approval.
-
-If an executable was found, evaluate its output before continuing. The unadorned version probe is
-intentionally compatible with older Qodo CLIs. This skill requires Qodo CLI **0.1.0-next.37 or newer**.
-If the version is older or cannot be parsed, do not run `whoami` or `login` and do not
-describe the failure as an authentication problem. Explain that the skill is newer than the runtime,
-show `<qodo> update` as the update command for the runtime's already-recorded origin, and ask once
-before running it. For a customer deployment, keep its organization-provided update origin; never
-switch it to the public service. After an approved update, rerun the unadorned version probe and
-continue only when it satisfies the minimum. If the user declines or the update fails, stop with the
-current skill and user files unchanged.
-
-## 2. Check authentication
-
-Run `<qodo> read whoami --json --skill qodo-setup --skill-version 1.0.6 --distribution skills-sh`.
-
-In a sandboxed environment, any failed `whoami` can be a blocked keychain rather than a logged-out
-user. Ask for approval to retry that exact read-only command once outside the sandbox. The approval
-applies only to that diagnostic retry. If it succeeds, continue normally; only treat the user as
-logged out when the approved retry also fails.
-
-- Success and an identified account: continue to verification.
-- After the sandbox diagnostic above when applicable, `Not logged in`, missing credentials, or a
-  non-zero authentication result: choose the login path below. Do not run login until its
-  deployment endpoint is resolved.
-- An `unknown command` or `unknown option` after the successful version gate is a runtime-contract
-  failure, not an authentication failure. Report the exact error and stop; do not send the user
-  through login.
-
-Choose the login command before opening a browser:
-
-- For Qodo Cloud, run `<qodo> login`.
-- For a customer deployment, preserve the exact deployment-specific command the installer,
-  administrator, or user provided, such as `<qodo> login --auth-url <their-url>`.
-- Plain `<qodo> login` is also safe for a customer deployment only when this interaction has
-  explicit evidence that CLI 0.1.0-next.37 or newer already retained that endpoint—for example,
-  an earlier `qodo logout` reported that it kept the auth endpoint. The CLI resolves a retained
-  endpoint before the cloud default; never merely assume one was retained.
-- If a customer deployment is known but no exact command, endpoint, or retained-endpoint evidence
-  is available, stop and tell the user to obtain the login command from their Qodo administrator.
-  Never probe or fall back to Qodo Cloud.
-
-`qodo login` may open a browser. Tell the user what is happening before you run it. Wait for
-the command to finish; never claim login succeeded from a browser opening alone. If the
-user cancels or login fails, preserve the error message, explain that Qodo is still not
-connected, and stop without invoking other Qodo skills.
-
-## 3. Verify readiness
-
-After login, run both:
+Run:
 
 ```sh
 <qodo> read whoami --json --skill qodo-setup --skill-version 1.0.6 --distribution skills-sh
+```
+
+If successful, retain the verified identity and continue to step 3 without repeating it.
+For a failed check, read [authentication.md](references/authentication.md) to distinguish
+missing credentials, sandbox access, and other failures before choosing login.
+
+For Qodo Cloud, announce and run `<qodo> login` when signed out. For any customer deployment,
+read the authentication reference first: preserve its exact login endpoint and never guess
+or fall back to Cloud. Wait for login to finish, then rerun the identity command above.
+Browser opening alone is not success.
+
+Remember the execution context where identity or login worked. Use that context for later
+credential-dependent commands, requesting each required host approval; a diagnostic approval
+does not grant blanket permission. Do not repeat a known-failing sandbox probe after login.
+Stop on cancellation or denied permission.
+
+### 3. Verify tools
+
+Only after identity succeeds, run:
+
+```sh
 <qodo> tools --refresh --json --skill qodo-setup --skill-version 1.0.6 --distribution skills-sh
 ```
 
-Read the structured results. Readiness requires both a successful authenticated identity
-and a usable tool catalog. A successful process launch by itself is not enough.
-
-If catalog refresh fails while `whoami` succeeds, report that authentication is complete
-but managed tools are not ready, including the returned error and the safe retry
-`qodo tools --refresh`. Do not send the user through login again unless `whoami` fails.
+Require a successful, nonempty usable catalog. Inspect structured results with bounded output
+(exit status, error, tool count and relevant names); do not dump every tool schema.
+If refresh fails, report that sign-in succeeded but tools are unavailable, with the exact error
+and `<qodo> tools --refresh` as the retry. Do not log in again for a catalog failure.
 
 ## Configuration
 
-Keep the first working Qodo executable path and any explicit `--auth-url` for the entire setup.
-Stamp exact skill/version/distribution provenance on the first Qodo call. Marketplace or skills.sh
-owns this skill package; the CLI owns login, runtime, and tool-catalog refresh.
-
-When the host is Kiro and safe reads prompt repeatedly, explain the optional persistent rule before
-the next read. The only broad pattern to offer is `<qodo> read *`: that CLI gateway rejects every
-managed tool not explicitly marked non-mutating by the live catalog. Keep the version probe as its
-own exact `<qodo> --version` rule. Never suggest `<qodo> *` or `<qodo> codebase *`, and never edit
-Kiro permission files from the agent. The user may choose Kiro's **Always allow** action and scope,
-or review the generated `qodo-read-only.permissions.yaml` supplied with the Qodo Power.
+Keep executable, deployment, execution context and provenance throughout setup.
+The CLI owns credentials, transport and runtime updates; the package's
+lifecycle owner updates skills. For `QODO_NOTICE` updates or repeated Kiro read approvals,
+read [host-recovery.md](references/host-recovery.md) only when encountered.
 
 ## Error Handling
 
-Stop on missing runtime, canceled login, failed identity, or unavailable tools and report the exact
-safe next action. Never convert a browser opening, process launch, or partial catalog refresh into a
-successful readiness claim.
+Give the actual error and one next action. Never report readiness after a failed
+identity, canceled login or unavailable catalog. Never disable the keychain, copy credentials,
+change host permission files, or offer unrestricted command approvals to make setup pass.
 
 ## 4. Hand off
 
-Use **verified readiness → one relevant next action** in plain prose. Confirm that Qodo is
-connected and ready only after both identity and tool-catalog checks succeed. For example,
-when local review is available: “Qodo is connected and ready. To start, ask ‘Review my local
-changes.’” Mention Qodo naturally once; no branded headings, emoji banners, slogans, badges,
-footers, or repeated summary blocks.
-
-Include workspace or deployment details when they help confirm the correct connection. Keep
-tool counts and runtime versions out of the normal success response; use them for diagnostics
-when relevant. For partial setup, name the actual blocker and safe next step without claiming
-readiness. Choose one relevant next action from capabilities actually available to this user
-and skills loaded in this session; the following are alternatives, not a menu to print:
-
-- “Review my local changes” → `qodo-review`
-- “Load our coding standards” → use `qodo-get-rules` only when it is available. Otherwise,
-  explain that it belongs to the optional **Qodo Standards** add-on; install that add-on through
-  the current agent marketplace, or use `qodo agents install --standards --json` to detect local
-  compatible agents and print their separate exact skills.sh commands without installing anything.
-- “Explain this codebase” → `qodo-codebase-wisdom`
-- “Show the Qodo findings on this PR” → `qodo-review-resolver`
-
-Do not run one of those workflows until the user asks. Setup establishes capability; it
-does not infer permission to review, edit, post, or administer standards.
+Confirm verified readiness in plain prose, then suggest one next action supported by the
+catalog and loaded skills, e.g. “Qodo is connected and ready. Ask ‘Explain this codebase.’”
+Mention account or deployment when useful. Omit routine versions, counts and repeated summaries.
+Do not launch another workflow or install optional Standards during setup.

--- a/skills/qodo-setup/SKILL.md
+++ b/skills/qodo-setup/SKILL.md
@@ -23,6 +23,8 @@ A local shell and a user for browser sign-in. Never request or read credentials.
 
 ## Instructions
 
+Resolve `references/...` links relative to this installed `SKILL.md` directory.
+
 ### 1. Find or install the runtime
 
 Run:

--- a/skills/qodo-setup/references/authentication.md
+++ b/skills/qodo-setup/references/authentication.md
@@ -1,0 +1,47 @@
+# Authentication and execution context
+
+Read for an identity failure or before any customer-deployment login. Invoke the identity
+command from SKILL.md so the active package/version/distribution/host provenance is preserved.
+
+## Classify the identity result
+
+- Successful identified account: retain it and proceed to catalog verification.
+- `unknown command` or `unknown option`: runtime-contract failure; report it and stop.
+- Network, TLS, service, or authorization errors: preserve the error and address that cause.
+  Do not treat every nonzero exit as signed out or automatically start login.
+- `not_logged_in` or missing credentials: this can mean an absent credential or an inaccessible
+  keychain. In a sandbox that may block credential access, request the host's approval for
+  one exact read-only identity retry outside that sandbox. This is unnecessary when already
+  running in the working context or after an approved unsandboxed check established sign-out.
+  If denied, stop. If it succeeds, retain that context and proceed. If it again reports missing
+  credentials, choose login below. Other retry errors retain their own diagnosis.
+- Explicit sandbox/network denial: request the narrow permission needed for the failed check
+  through the host. Do not relax the host's configuration.
+
+Keep the executable, user, QODO_HOME and deployment consistent. Once login or an identity
+check works outside a restricted sandbox, run subsequent identity/catalog checks in that
+same context with the host's required approvals. Do not first repeat them in the sandbox
+known to hide credentials. Approval for one diagnostic does not authorize other commands.
+Do not change credential storage, set QODO_NO_KEYCHAIN, or export tokens as a workaround.
+
+If the post-login identity still fails in the context where login succeeded, stop with that
+error; do not loop through browser sign-in. Never refresh tools before identity succeeds.
+
+## Resolve the login destination
+
+Choose the login command before opening a browser:
+
+- For Qodo Cloud, run `<qodo> login`.
+- For a customer deployment, preserve the exact deployment-specific command from the
+  installer, administrator, or user, such as `<qodo> login --auth-url <their-url>`.
+- Plain login is safe for a customer only with explicit evidence in this interaction that
+  CLI 0.1.0-next.37 or newer retained the endpoint (for example, logout reported retaining
+  it). Never assume a previous installation saved the endpoint, or read credentials to
+  infer it. Keep any provided QODO_AUTH_URL consistent with the chosen destination.
+- If a customer deployment is known but no exact command, endpoint, or retained-endpoint
+  evidence is available, obtain that command from the administrator before login.
+  Never probe or fall back to Qodo Cloud.
+
+Tell the user browser sign-in will open. Run login once, wait for the process to finish and
+inspect its outcome. On cancellation or failure, report that Qodo is still not connected.
+After success, verify identity using the main skill's command, then verify the catalog.

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -1,0 +1,22 @@
+# Host-specific recovery
+
+## Handle a skill update notice
+
+A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
+`code` is `qodo_skill_update_available`, keep the command's result and finish the current
+task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
+Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
+once before any mutation. If the user declines, keep the current version usable.
+
+Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
+implicitly. After an approved update, ask for the host restart named by the notice; the current
+session may still have the old skill loaded.
+
+## Repeated Kiro read approvals
+
+When the host is Kiro and safe reads prompt repeatedly, explain the optional persistent rule before
+the next read. The only broad pattern to offer is `<qodo> read *`: that CLI gateway rejects every
+managed tool not explicitly marked non-mutating by the live catalog. Keep the version probe as its
+own exact `<qodo> --version` rule. Never suggest `<qodo> *` or `<qodo> codebase *`, and never edit
+Kiro permission files from the agent. The user may choose Kiro's **Always allow** action and scope,
+or review the generated `qodo-read-only.permissions.yaml` supplied with the Qodo Power.

--- a/skills/qodo-setup/references/runtime.md
+++ b/skills/qodo-setup/references/runtime.md
@@ -17,31 +17,38 @@ ad hoc code. The installer requires Node.js >=20.6.0 and verifies the CLI artifa
 the SHA-256 in its distribution's version.json before installing it under QODO_HOME
 (default ~/.qodo). It also configures its launchers and shell PATH integration.
 
-1. Resolve the distribution from this interaction. For Qodo Cloud use
-   `https://get.qodo.ai/install.sh` (POSIX) or `https://get.qodo.ai/install.ps1` (PowerShell).
-   If an organization-specific installer, QODO_INSTALL_BASE or login endpoint was provided,
-   preserve it. A known customer deployment without its installation instructions requires
-   the administrator's exact command; never substitute the public distribution.
+1. Resolve the distribution from this interaction and keep its installer URL, expected
+   SHA-256, channel and distribution/auth settings together throughout installation.
+   For Qodo Cloud use these published, immutable installer pins:
+
+   | Platform | Installer URL | Expected SHA-256 |
+   | --- | --- | --- |
+   | POSIX | `https://get.qodo.ai/installers/bd546a0fc51ac4bb32486c9f766870ba0dedef27bf0472bb1e15ffdede52acf8/install.sh` | `bd546a0fc51ac4bb32486c9f766870ba0dedef27bf0472bb1e15ffdede52acf8` |
+   | PowerShell | `https://get.qodo.ai/installers/4ebee2878d8d39bbbdd3153aff1c6a329601d844df7ce915b7a54739aa32d498/install.ps1` | `4ebee2878d8d39bbbdd3153aff1c6a329601d844df7ce915b7a54739aa32d498` |
+
+   For a customer deployment, use its exact installer URL and expected SHA-256 from the
+   organization-provided installation instructions. Preserve QODO_INSTALL_BASE, the login
+   endpoint and any channel/installer arguments. Do not fetch the public installer or apply
+   a Cloud digest to a customer script. A base or login endpoint alone does not establish the
+   installer URL and checksum; obtain missing information from the administrator. Never guess
+   a mirror path or fall back to the public distribution.
 2. Check `node --version`. If missing or too old, explain the prerequisite and help the user
    install a supported Node version within their authorization before resuming setup.
-3. Download the installer to a unique temporary file and read it before execution. Use the
-   exact official URL above; no web search, guessed README URL, npm package or remote pipe
-   into a shell is needed. For example, on POSIX:
-
-   ```sh
-   qodo_setup_dir=$(mktemp -d "${TMPDIR:-/tmp}/qodo-setup.XXXXXXXX") || exit 1
-   curl --fail --silent --show-error --location https://get.qodo.ai/install.sh --output "$qodo_setup_dir/install.sh" || exit 1
-   printf '%s\n' "$qodo_setup_dir/install.sh"
-   ```
-
-   Keep the returned absolute path across tool calls. On PowerShell use a temporary file
-   ending in `.ps1` and `Invoke-WebRequest -Uri https://get.qodo.ai/install.ps1 -OutFile ...`.
-4. Explain that you will run the official installer, which verifies the CLI download and
-   writes the user-scoped runtime and PATH integration. A user who asked to set up Qodo
+3. Download from the selected URL into a unique, user-private temporary directory. Use
+   `curl --fail --silent --show-error --location` on POSIX, or `Invoke-WebRequest` with a
+   `.ps1` destination on PowerShell. Calculate the file's SHA-256 with `sha256sum`,
+   `shasum -a 256` or Node's `crypto.createHash('sha256')`; PowerShell has `Get-FileHash`.
+   Require an exact match to the expected digest before reading or executing the script.
+   Stop on a failed download, missing digest or mismatch; never derive the expected digest
+   from the downloaded file, replace it after a mismatch or use a mutable installer alias.
+   Keep the verified absolute file path across tool calls and execute those same bytes.
+   No guessed README URL, npm package, remote pipe or installer reconstruction is needed.
+4. Inspect the verified script, then explain that you will run it to install the user-scoped
+   runtime and PATH integration. A user who asked to set up Qodo
    has requested this installation; request only approvals still required by the host or
    a narrower user instruction. Inspect the downloaded script before requesting execution.
-   Never invent a checksum or claim the installer script itself was checksum-verified
-   merely because it verifies the CLI artifact.
+   Installer verification above and the installer's later CLI-artifact verification are
+   separate checks; require both and never invent a checksum.
 5. Run the saved script with `sh` (POSIX) or a PowerShell process (Windows), preserving any
    provided distribution/auth settings. Use a non-PTY tool invocation with redirected
    stdin/stdout: the installer skips its interactive agent-selection setup when stdout is

--- a/skills/qodo-setup/references/runtime.md
+++ b/skills/qodo-setup/references/runtime.md
@@ -1,0 +1,62 @@
+# Runtime discovery and installation
+
+Read when the CLI is missing, outdated, or the host uses PowerShell.
+Keep the first working executable for the rest of setup; no extra PATH edits are needed.
+
+## PowerShell discovery
+
+```powershell
+$qodoRuntimeHome = if ($env:QODO_HOME) { $env:QODO_HOME } else { Join-Path $HOME '.qodo' }
+& (Join-Path $qodoRuntimeHome 'bin/qodo.cmd') --version
+```
+
+## Missing runtime
+
+Use the official installer; do not reconstruct the manifest/download/shim installation in
+ad hoc code. The installer requires Node.js >=20.6.0 and verifies the CLI artifact against
+the SHA-256 in its distribution's version.json before installing it under QODO_HOME
+(default ~/.qodo). It also configures its launchers and shell PATH integration.
+
+1. Resolve the distribution from this interaction. For Qodo Cloud use
+   `https://get.qodo.ai/install.sh` (POSIX) or `https://get.qodo.ai/install.ps1` (PowerShell).
+   If an organization-specific installer, QODO_INSTALL_BASE or login endpoint was provided,
+   preserve it. A known customer deployment without its installation instructions requires
+   the administrator's exact command; never substitute the public distribution.
+2. Check `node --version`. If missing or too old, explain the prerequisite and help the user
+   install a supported Node version within their authorization before resuming setup.
+3. Download the installer to a unique temporary file and read it before execution. Use the
+   exact official URL above; no web search, guessed README URL, npm package or remote pipe
+   into a shell is needed. For example, on POSIX:
+
+   ```sh
+   qodo_setup_dir=$(mktemp -d "${TMPDIR:-/tmp}/qodo-setup.XXXXXXXX") || exit 1
+   curl --fail --silent --show-error --location https://get.qodo.ai/install.sh --output "$qodo_setup_dir/install.sh" || exit 1
+   printf '%s\n' "$qodo_setup_dir/install.sh"
+   ```
+
+   Keep the returned absolute path across tool calls. On PowerShell use a temporary file
+   ending in `.ps1` and `Invoke-WebRequest -Uri https://get.qodo.ai/install.ps1 -OutFile ...`.
+4. Explain that you will run the official installer, which verifies the CLI download and
+   writes the user-scoped runtime and PATH integration. A user who asked to set up Qodo
+   has requested this installation; request only approvals still required by the host or
+   a narrower user instruction. Inspect the downloaded script before requesting execution.
+   Never invent a checksum or claim the installer script itself was checksum-verified
+   merely because it verifies the CLI artifact.
+5. Run the saved script with `sh` (POSIX) or a PowerShell process (Windows), preserving any
+   provided distribution/auth settings. Use a non-PTY tool invocation with redirected
+   stdin/stdout: the installer skips its interactive agent-selection setup when stdout is
+   not a terminal. Do not allocate a TTY, run `qodo setup`, or install skill packages again.
+   If the host requires a TTY, redirect installer stdout to a temporary log and inspect it.
+   Honor execution-policy restrictions; do not bypass them. Stop if execution is denied.
+6. Require installer success, rerun the standard user-scoped executable's `--version`, then
+   return to the main skill's version gate and authentication step immediately. Installation
+   is not login or readiness. Report checksum/download failures exactly; never run a failed
+   download or continue after verification fails. Remove only temporary files you created.
+
+## Old or unparseable runtime
+
+Do not run whoami or login until the minimum CLI version in SKILL.md is met. Explain the
+compatibility issue and use `<qodo> update`, which retains the runtime's recorded origin.
+Proceed if the user's setup request covers this update; otherwise ask once. Keep customer
+origins unchanged. Rerun the unadorned version probe after updating. If declined, failed or
+still incompatible, stop without modifying the skill package or diagnosing an auth failure.

--- a/test/setup-packaging.test.mjs
+++ b/test/setup-packaging.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = join(root, 'skills/qodo-setup');
+const read = (dir, path) => readFileSync(join(dir, path), 'utf8').replace(/\r\n/g, '\n');
+const main = read(source, 'SKILL.md');
+const references = [...main.matchAll(/\]\((references\/[^)]+\.md)\)/g)].map((match) => match[1]);
+
+test('setup on-demand references survive every marketplace adapter', () => {
+  assert.ok(references.length > 0, 'compact setup must link its conditional procedures');
+  for (const adapter of ['packages/qodo', 'codex-packages/qodo', 'kiro-power']) {
+    const installed = join(root, adapter, 'skills/qodo-setup');
+    const entrypoint = read(installed, 'SKILL.md');
+    // Leave room for generated host and lifecycle provenance above the 4000-byte source budget.
+    assert.ok(Buffer.byteLength(entrypoint, 'utf8') <= 4096, `${adapter}: oversized setup entrypoint`);
+    for (const reference of references) {
+      assert.ok(entrypoint.includes(`](${reference})`), `${adapter}: reference is not discoverable`);
+      assert.equal(read(installed, reference), read(source, reference), `${adapter}: missing/stale procedure`);
+      // References are copied verbatim; exact version/host flags belong in the stamped entrypoint.
+      assert.doesNotMatch(read(installed, reference), /--skill-version\s+\S+\s+--distribution/);
+    }
+  }
+});
+
+test('CLI-managed setup preserves on-demand reference contents', () => {
+  const bundle = JSON.parse(read(root, 'distribution/qodo-cli-managed-bundle.json'));
+  const files = new Map(bundle.skills['qodo-setup'].files.map((file) => [
+    file.path, Buffer.from(file.content, file.encoding).toString('utf8'),
+  ]));
+  for (const reference of references) {
+    assert.equal(files.get(reference), read(source, reference), `CLI-managed: ${reference}`);
+  }
+});


### PR DESCRIPTION
Marketplace setup currently stops when the Qodo CLI is missing, requiring another request and ad hoc installation. After browser login, it can also repeat checks in a sandbox that cannot access the keychain. This change continues authorized setup through installation, retains the working execution context with required host approvals, and verifies identity before refreshing tools.

Conditional runtime, authentication and host-recovery instructions move into packaged references. Links resolve relative to the installed SKILL.md directory. The main prompt shrinks from 9,306 to 3,898 bytes, with source/generated size budgets and reference coverage across marketplace, CLI-managed and enterprise packages.

Cloud installation uses published immutable installer URLs and verifies the script SHA-256 before execution; the installer separately verifies the CLI artifact. Customer installations preserve their exact supplied URL, digest, channel and distribution/auth settings without public fallback. Catalog output stays bounded and credentials remain owned by the CLI.

Validation: full npm test passed in an isolated release preview (88 Node tests plus CLI-managed, release, workflow, marketplace and enterprise suites). Both public installer pins were fetched and matched the published CLI 0.1.0-next.45 README checksums. The updated preview archive passes the merged QAR validator, with all twelve setup reference copies matching source bytes. Generated entrypoints are Claude 3,973, Codex 3,961 and Kiro 3,956 bytes. New-head CI is running; fresh marketplace invocation/browser-login acceptance and a new-head Qodo review remain unverified.

The consumer prerequisite [qodo-ai/qodo-agent-runtime#618](https://github.com/qodo-ai/qodo-agent-runtime/pull/618) merged at 1ec309132b77b372688aa1e05c4727b765f0bb11. Enterprise adoption of skills 2.x still needs its separate reviewed topology/pin update removing the retired qodo-pr-resolver alias. Source versions and generated distributions remain owned by the separate release PR workflow; this source PR does not publish a release.

Refs [CLI-345](https://linear.app/qodo/issue/CLI-345/smooth-marketplace-setup-install-missing-cli-and-avoid-repeated).
