### PR TITLE
ci: use the skills-release publication environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,6 +14,8 @@ the existing publication and marketplace gates. Contributors do not need to star
 | [Marketplaces: Verify listings](verify-marketplace-visibility.yml) | Shipping succeeds, or the 15-minute check runs | Inspect provider visibility now |
 
 These six workflows cover separate steps. **Publish skills** creates the immutable GitHub release.
+Its approval and App credentials belong to the **skills-release** environment. The
+**marketplace-claude**, **marketplace-kiro**, and **marketplace-codex** environments gate provider handoffs.
 The CLI repository then promotes its compatibility pointer through the existing production approval.
 **Start shipping** waits for that pointer; **Ship release** prepares provider packets and waits for
 handoff approvals. **Verify listings** reports when external directories expose the release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     environment:
-      name: marketplace-kiro
+      name: skills-release
     steps:
       - name: Check out the release commit
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -85,8 +85,8 @@ jobs:
           RELEASE_APP_PRIVATE_KEY: ${{ secrets.QODO_SKILLS_RELEASE_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          [[ "${RELEASE_APP_ID}" =~ ^[0-9]+$ ]] || { echo 'QODO_SKILLS_RELEASE_APP_ID must be configured in marketplace-kiro.' >&2; exit 1; }
-          test -n "${RELEASE_APP_PRIVATE_KEY}" || { echo 'QODO_SKILLS_RELEASE_APP_PRIVATE_KEY must be configured in marketplace-kiro.' >&2; exit 1; }
+          [[ "${RELEASE_APP_ID}" =~ ^[0-9]+$ ]] || { echo 'QODO_SKILLS_RELEASE_APP_ID must be configured in skills-release.' >&2; exit 1; }
+          test -n "${RELEASE_APP_PRIVATE_KEY}" || { echo 'QODO_SKILLS_RELEASE_APP_PRIVATE_KEY must be configured in skills-release.' >&2; exit 1; }
 
       - name: Mint installation-wide read-only release preflight token
         id: release-preflight-token

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -108,11 +108,13 @@ rollback.
 - For Codex, confirm the company-owned publisher identity and the disposition of the earlier
   personally owned listing. Do not assume an in-place ownership transfer or automatic user migration.
 - Create protected GitHub environments `marketplace-claude`, `marketplace-kiro`, and
-  `marketplace-codex` with required release-owner reviewers.
+  `marketplace-codex` with required release-owner reviewers for provider handoffs. Create a separate
+  `skills-release` environment with required reviewers and protected-branch restrictions for
+  immutable skills publication.
 - Enable immutable releases in `qodo-ai/qodo-skills`.
 - Install the dedicated `qodo-skills-release-bot` GitHub App on `qodo-ai/qodo-skills` with only
   `Administration: read`, `Contents: write`, and `Metadata: read`. Store its App id and private key only in the protected
-  `marketplace-kiro` environment as `QODO_SKILLS_RELEASE_APP_ID` and
+  `skills-release` environment as `QODO_SKILLS_RELEASE_APP_ID` and
   `QODO_SKILLS_RELEASE_APP_PRIVATE_KEY`, and require at least one release reviewer. For the initial
   cutover, admin bypass remains enabled, self-review is allowed, and protected branches may deploy;
   the team accepts this weaker approval posture and can harden it independently later.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -60,11 +60,11 @@ Do not place an administrator PAT or a shared QAR release credential in this pub
 The normal release workflow uses its scoped `GITHUB_TOKEN` for publication. Pre-publication
 immutability verification uses a dedicated `qodo-skills-release-bot` GitHub App
 with only `Administration: read`, `Contents: write`, and `Metadata: read`; the protected
-`marketplace-kiro` environment stores its numeric App id as
+`skills-release` environment stores its numeric App id as
 `QODO_SKILLS_RELEASE_APP_ID` and its private key as
 `QODO_SKILLS_RELEASE_APP_PRIVATE_KEY`. The workflow mints a short-lived token restricted to
 `qodo-ai/qodo-skills` only after environment approval. The release workflow uses the same
-`marketplace-kiro` gate to mint an Administration-read token and verify immutability before it
+`skills-release` gate to mint an Administration-read token and verify immutability before it
 creates a tag or draft; publication still uses the normal scoped workflow token.
 
 Before the first release and after any protection change, a repository administrator must run:
@@ -80,8 +80,11 @@ require its complete repository list to be exactly `qodo-ai/qodo-skills`; GitHub
 only to an App installation token, not to the administrator's normal OAuth/PAT session. The token is
 revoked by the action after the job. No administrator credential is stored in Actions.
 Kiro reads `main`; marketplace shipping does not mint an App write token or promote a separate
-branch. The existing `marketplace-kiro` environment name remains the release-approval/credential
-boundary for immutable publication; it does not select Kiro's source branch. The unused legacy
+branch. The `skills-release` environment gates immutable publication and holds its App credentials;
+`marketplace-kiro` gates Kiro's provider handoff. Configure `skills-release` with required reviewers,
+protected-branch restrictions, and both App settings before using the release workflow. Keep the
+existing `marketplace-kiro` environment for provider handoffs and its credentials while older release
+runs still reference it. Neither environment selects Kiro's source branch. The unused legacy
 branch and its ruleset do not need to be deleted or changed for this transition.
 Keep exactly one active, no-exclusion, no-bypass **Immutable release tags** ruleset on
 `refs/tags/v*`; it permits creation but blocks every tag update and deletion. The preflight
@@ -92,7 +95,7 @@ token for that pre-publication check. The checked-in audit, runtime preflight, a
 missing credentials, disabled immutability, duplicate/invalid rulesets, forbidden creation rules,
 draft corruption, draft resume, publication, and immutable retry all fail closed.
 Merging a release record onto main starts **Release: Publish skills** automatically. The existing
-`marketplace-kiro` approval and runtime compatibility preflight still apply; a missing compatible CLI
+`skills-release` approval and runtime compatibility preflight still apply; a missing compatible CLI
 release blocks publication. Rerun the captured release run after resolving a transient failure.
 Manual dispatch remains available for a fully prepared main snapshot or reviewed draft recovery.
 Ordinary source merges do not start publication. The workflow:

--- a/scripts/audit-release-protections.sh
+++ b/scripts/audit-release-protections.sh
@@ -31,6 +31,14 @@ if [[ "$(jq '
   exit 1
 fi
 
+if [[ "$(jq '
+  .deployment_branch_policy.protected_branches == true and
+  .deployment_branch_policy.custom_branch_policies == false
+' <<< "${ENVIRONMENT_JSON}")" != 'true' ]]; then
+  echo 'skills-release must allow deployments from protected branches only.' >&2
+  exit 1
+fi
+
 RELEASE_APP_ID="$(gh api \
   "repos/${GITHUB_REPOSITORY}/environments/skills-release/variables/QODO_SKILLS_RELEASE_APP_ID" \
   --jq '.value')"

--- a/scripts/audit-release-protections.sh
+++ b/scripts/audit-release-protections.sh
@@ -20,29 +20,29 @@ if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/immutable-releases" --jq '.enabled')
   exit 1
 fi
 
-ENVIRONMENT_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/environments/marketplace-kiro")"
+ENVIRONMENT_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/environments/skills-release")"
 if [[ "$(jq '
   any(.protection_rules[]?;
     .type == "required_reviewers" and
     (.reviewers | type == "array" and length >= 1)
   )
 ' <<< "${ENVIRONMENT_JSON}")" != 'true' ]]; then
-  echo 'marketplace-kiro must require at least one release reviewer.' >&2
+  echo 'skills-release must require at least one release reviewer.' >&2
   exit 1
 fi
 
 RELEASE_APP_ID="$(gh api \
-  "repos/${GITHUB_REPOSITORY}/environments/marketplace-kiro/variables/QODO_SKILLS_RELEASE_APP_ID" \
+  "repos/${GITHUB_REPOSITORY}/environments/skills-release/variables/QODO_SKILLS_RELEASE_APP_ID" \
   --jq '.value')"
 if [[ ! "${RELEASE_APP_ID}" =~ ^[0-9]+$ ]]; then
-  echo 'marketplace-kiro must define numeric QODO_SKILLS_RELEASE_APP_ID.' >&2
+  echo 'skills-release must define numeric QODO_SKILLS_RELEASE_APP_ID.' >&2
   exit 1
 fi
 
-if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/environments/marketplace-kiro/secrets" --jq '
+if [[ "$(gh api "repos/${GITHUB_REPOSITORY}/environments/skills-release/secrets" --jq '
   [.secrets[].name] | index("QODO_SKILLS_RELEASE_APP_PRIVATE_KEY") != null
 ')" != 'true' ]]; then
-  echo 'marketplace-kiro must define QODO_SKILLS_RELEASE_APP_PRIVATE_KEY.' >&2
+  echo 'skills-release must define QODO_SKILLS_RELEASE_APP_PRIVATE_KEY.' >&2
   exit 1
 fi
 

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -324,7 +324,7 @@ if (process.platform !== 'win32') {
     if (probe.error && probe.error.code !== 'ENOENT') throw probe.error;
   }
   if (!bashProbe.error && !jqProbe.error) {
-    const preflightFixture = mkdtempSync(join(tmpdir(), 'qodo-kiro-preflight-'));
+    const preflightFixture = mkdtempSync(join(tmpdir(), 'qodo-release-preflight-'));
     try {
       const bin = join(preflightFixture, 'bin');
       mkdirSync(bin);
@@ -335,7 +335,7 @@ if [[ "$*" == "api /apps/qodo-skills-release-bot" ]]; then
   printf '{"id":12345,"slug":"qodo-skills-release-bot","owner":{"login":"qodo-ai"},"permissions":{"administration":"read","contents":"write","metadata":"read"}}\\n'
 elif [[ "$*" == *"immutable-releases --jq .enabled"* ]]; then
   printf '%s\\n' "\${QODO_TEST_IMMUTABLE_RELEASES:-true}"
-elif [[ "$*" == "api repos/qodo-ai/qodo-skills/environments/marketplace-kiro" ]]; then
+elif [[ "$*" == "api repos/qodo-ai/qodo-skills/environments/skills-release" ]]; then
   if [[ "\${QODO_TEST_MISSING_REVIEWER:-}" == 1 ]]; then
     printf '{"can_admins_bypass":true,"deployment_branch_policy":{"protected_branches":true,"custom_branch_policies":false},"protection_rules":[]}\\n'
   else
@@ -343,7 +343,7 @@ elif [[ "$*" == "api repos/qodo-ai/qodo-skills/environments/marketplace-kiro" ]]
   fi
 elif [[ "$*" == *"variables/QODO_SKILLS_RELEASE_APP_ID --jq .value"* ]]; then
   printf '%s\\n' "\${QODO_TEST_ENVIRONMENT_APP_ID:-12345}"
-elif [[ "$*" == *"environments/marketplace-kiro/secrets --jq"* ]]; then
+elif [[ "$*" == *"environments/skills-release/secrets --jq"* ]]; then
   printf 'true\\n'
 elif [[ "$*" == *"orgs/qodo-ai/installations?per_page=100"* ]]; then
   if [[ "\${QODO_TEST_MISSING_INSTALLATION:-}" != 1 ]]; then

--- a/scripts/test-marketplace-release.mjs
+++ b/scripts/test-marketplace-release.mjs
@@ -305,7 +305,6 @@ assert.match(workflow, /approved provider handoff succeeded/);
 const protectionAudit = readFileSync(join(root, 'scripts', 'audit-release-protections.sh'), 'utf8');
 assert.doesNotMatch(protectionAudit, /\.can_admins_bypass/);
 assert.doesNotMatch(protectionAudit, /prevent_self_review/);
-assert.doesNotMatch(protectionAudit, /deployment-branch-policies/);
 assert.match(protectionAudit, /\.type == "required_reviewers"/);
 assert.match(protectionAudit, /QODO_SKILLS_RELEASE_APP_PRIVATE_KEY/);
 assert.match(protectionAudit, /\.permissions == \{"administration":"read","contents":"write","metadata":"read"\}/);
@@ -336,7 +335,9 @@ if [[ "$*" == "api /apps/qodo-skills-release-bot" ]]; then
 elif [[ "$*" == *"immutable-releases --jq .enabled"* ]]; then
   printf '%s\\n' "\${QODO_TEST_IMMUTABLE_RELEASES:-true}"
 elif [[ "$*" == "api repos/qodo-ai/qodo-skills/environments/skills-release" ]]; then
-  if [[ "\${QODO_TEST_MISSING_REVIEWER:-}" == 1 ]]; then
+  if [[ -n "\${QODO_TEST_RELEASE_ENVIRONMENT:-}" ]]; then
+    printf '%s\\n' "$QODO_TEST_RELEASE_ENVIRONMENT"
+  elif [[ "\${QODO_TEST_MISSING_REVIEWER:-}" == 1 ]]; then
     printf '{"can_admins_bypass":true,"deployment_branch_policy":{"protected_branches":true,"custom_branch_policies":false},"protection_rules":[]}\\n'
   else
     printf '{"can_admins_bypass":true,"deployment_branch_policy":{"protected_branches":true,"custom_branch_policies":false},"protection_rules":[{"type":"required_reviewers","prevent_self_review":false,"reviewers":[{}]}]}\\n'
@@ -380,6 +381,26 @@ fi
       });
       assert.equal(validAudit.status, 0, validAudit.stderr);
       assert.match(validAudit.stdout, /app_id=12345 tag_ruleset=78/);
+      for (const policy of [
+        null,
+        undefined,
+        {},
+        { protected_branches: false, custom_branch_policies: false },
+        { protected_branches: false, custom_branch_policies: true },
+        { protected_branches: true, custom_branch_policies: true },
+        { protected_branches: true },
+        { protected_branches: 'true', custom_branch_policies: 'false' },
+      ]) {
+        const invalidPolicyAudit = spawnSync('bash', [join(root, 'scripts', 'audit-release-protections.sh')], {
+          encoding: 'utf8', timeout: 5_000,
+          env: { ...auditEnvironment, QODO_TEST_RELEASE_ENVIRONMENT: JSON.stringify({
+            deployment_branch_policy: policy,
+            protection_rules: [{ type: 'required_reviewers', reviewers: [{}] }],
+          }) },
+        });
+        assert.equal(invalidPolicyAudit.status, 1, `Audit accepted policy: ${JSON.stringify(policy)}`);
+        assert.match(invalidPolicyAudit.stderr, /deployments from protected branches only/);
+      }
       const missingInstallationAudit = spawnSync('bash', [join(root, 'scripts', 'audit-release-protections.sh')], {
         encoding: 'utf8', env: { ...auditEnvironment, QODO_TEST_MISSING_INSTALLATION: '1' }, timeout: 5_000,
       });

--- a/scripts/test-release-workflow.mjs
+++ b/scripts/test-release-workflow.mjs
@@ -76,7 +76,7 @@ const publishedDownload = releaseSource.indexOf('gh release download', draftPubl
 const publishedVerification = releaseSource.indexOf('verify_release_assets "${PUBLISHED_VERIFY_DIR}"', publishedDownload);
 assert.match(protectionAudit, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/, 'the administrator audit must check repository immutability');
 assert.match(preflight, /repos\/\$\{GITHUB_REPOSITORY\}\/immutable-releases/, 'the protected App token must verify immutability before publication');
-assert.match(workflow, /environment:\s*\n\s*name: marketplace-kiro/);
+assert.match(workflow, /environment:\s*\n\s*name: skills-release/);
 assert.match(workflow, /actions\/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1/);
 assert.match(workflow, /permission-administration: read/);
 assert.match(workflow, /Mint installation-wide read-only release preflight token/);


### PR DESCRIPTION
Skills publication currently asks for `marketplace-kiro` approval, which makes a shared release look like a Kiro-only operation. Use the already-configured `skills-release` environment for publication and its protection audit, and update the existing regression fixtures and release documentation. Provider handoffs retain their `marketplace-*` environments.

The protection audit now also rejects unrestricted, missing, or custom deployment branch policies: `skills-release` must enable protected branches and disable custom policies. Regression fixtures reproduce the previous false success for null and missing policies and cover eight invalid variants.

Validation: full `npm test`, native Claude marketplace/core/Standards validators, and the live release-protection audit passed. The new environment has required reviewers, protected-branch restrictions, App ID `4790725`, and the named private-key secret. The secret value is not readable; its authentication will be checked by the next protected publication run after merge. Existing environments and credentials are retained for older runs.

Tracks [CLI-346](https://linear.app/qodo/issue/CLI-346).
