### PR TITLE
fix: keep skill update notices passive and explain enterprise maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,10 @@ qodo agents install --agent cursor --standards --json
 - skills.sh install: inventory the installed scope with `npx skills list --json` and
   `npx skills list -g --json`, then run a scope-preserving skills.sh update/re-add command.
 - Verified enterprise install: Qodo maintains recorded copies under the disclosed automatic policy.
-  Requested maintenance uses `qodo agents update --enterprise` for a full preview and confirmation;
-  scripts use `--dry-run --json` followed by the returned `--apply-plan ... --yes` command.
+  For requested maintenance, check `qodo agents update --help` first. When planning is supported,
+  `qodo agents update --enterprise` previews the full operation before confirmation; scripts use
+  `--dry-run --json` followed by the returned `--apply-plan ... --yes` command. With an older CLI,
+  use its interactive `qodo agents update --enterprise` flow instead of passing unsupported flags.
 - Qodo CLI: updates independently through `qodo update` and its background runtime updater.
 
 Availability and completion notices on stderr are passive: continue the task without inventory

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The canonical, provider-neutral source for Qodo’s local coding-agent skills.
 
 Every distributed skill contains its complete reviewed workflow. Coding agents do not fetch task
 instructions from the Qodo CLI. The CLI provides authentication, managed tools, offline tool help,
-runtime updates, and a compact stale-skill notice; it never installs or rewrites skills.
+runtime updates, passive skill notices, and verified maintenance through each recorded lifecycle
+owner. Enterprise and historical CLI-managed installations can update automatically; marketplace
+plugins remain owned by their host.
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -77,11 +77,16 @@ qodo agents install --agent cursor --standards --json
 - Marketplace install: apply the Qodo update in that host, then start a new session.
 - skills.sh install: inventory the installed scope with `npx skills list --json` and
   `npx skills list -g --json`, then run a scope-preserving skills.sh update/re-add command.
+- Verified enterprise install: Qodo maintains recorded copies under the disclosed automatic policy.
+  Requested maintenance uses `qodo agents update --enterprise` for a full preview and confirmation;
+  scripts use `--dry-run --json` followed by the returned `--apply-plan ... --yes` command.
 - Qodo CLI: updates independently through `qodo update` and its background runtime updater.
 
-When a skill is stale, a successful Qodo command may emit a structured `QODO_NOTICE` on stderr.
-The loaded skill finishes the current task, inventories its lifecycle owner, shows the exact
-scoped update action, and asks before any mutation.
+Availability and completion notices on stderr are passive: continue the task without inventory
+or an unsolicited update question. Automatic maintenance follows the existing disclosed policy,
+source and opt-outs. Only requested manual maintenance requires resolving the full operation
+before any additional consent; reuse approval that already covers it. New sessions load updated
+files when convenient.
 
 ## Repository layout
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,17 @@ qodo agents install --agent cursor --standards --json
 
 ## Update
 
+The coding-agent conversation is the primary experience. Agents run the CLI without a TTY,
+resolve the complete operation and request only missing human approval in the conversation.
+Users need not type commands, paths or an agent-ID list.
+
 - Marketplace install: apply the Qodo update in that host, then start a new session.
 - skills.sh install: inventory the installed scope with `npx skills list --json` and
   `npx skills list -g --json`, then run a scope-preserving skills.sh update/re-add command.
 - Verified enterprise install: Qodo maintains recorded copies under the disclosed automatic policy.
-  For requested maintenance, check `qodo agents update --help` first. When planning is supported,
-  `qodo agents update --enterprise` previews the full operation before confirmation; scripts use
-  `--dry-run --json` followed by the returned `--apply-plan ... --yes` command. With an older CLI,
-  use its interactive `qodo agents update --enterprise` flow instead of passing unsupported flags.
+  For requested maintenance, the agent checks `qodo agents update --help`, then uses
+  `--enterprise --dry-run --json` and the exact returned `--apply-plan` command after resolving
+  any still-needed approval. Direct terminal users can choose `qodo agents update --enterprise`.
 - Qodo CLI: updates independently through `qodo update` and its background runtime updater.
 
 Availability and completion notices on stderr are passive: continue the task without inventory
@@ -89,6 +92,15 @@ or an unsolicited update question. Automatic maintenance follows the existing di
 source and opt-outs. Only requested manual maintenance requires resolving the full operation
 before any additional consent; reuse approval that already covers it. New sessions load updated
 files when convenient.
+
+If the installed CLI lacks planning, the agent inspects `qodo update --help` and uses the supported
+`qodo update --check --json` to establish the available CLI release and recorded source. Explain
+the runtime prerequisite and request only missing authorization before one `qodo update --json`.
+Skill-update consent alone does not authorize a CLI upgrade. Never override source or channel;
+recheck version and planning support afterward. A failed/unsupported check, no available update,
+failed upgrade or missing planning support ends this maintenance attempt with a conversational
+blocker, without a terminal handoff or reinstall. CLI-only consent does not authorize the subsequent
+skills operation; resolve its complete plan and reuse any approval covering that scope.
 
 ## Repository layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,9 +16,9 @@ lifecycle UI—not in workflow content or authority.
 | `qodo-skills` | canonical workflow bodies, package membership, versions, provider projections, marketplace packets, and the data-only CLI-managed compatibility bundle | credentials, API transport, installed host state |
 | Marketplace | install, cache, update, rollback, and removal of its Qodo plugin | Qodo runtime binary or login |
 | skills.sh | install, link/copy, scope, update, and removal for agents without a Qodo listing | Qodo runtime binary or login |
-| Enterprise bundle / QAR | immutable offline skill package, reviewed pin, same-origin download, and lifecycle ownership of explicitly selected enterprise roots | public CLI binary contents or silent agent-root mutation |
+| Enterprise bundle / QAR | immutable offline skill package, reviewed pin, same-origin download, and lifecycle ownership of explicitly selected enterprise roots | public CLI binary contents or mutation outside the disclosed maintenance policy |
 | CLI-managed compatibility channel | automatic updates only for byte-exact roots created by a shipped pre-cutover CLI | new installs, missing skills, marketplace/enterprise roots, user-modified copies |
-| Qodo CLI | login, credentials, managed-tool catalog, tool invocation, offline tool help, runtime update, stale-skill notices, the compatibility updater, and an authenticated launcher for the pinned enterprise skills engine | authoring or embedding skill bodies, maintaining agent mappings, parsing skill archives, task-time playbooks, marketplace caches, or roots owned by another lifecycle channel |
+| Qodo CLI | login, credentials, managed-tool catalog, tool invocation, offline tool help, runtime update, stale-skill notices, the compatibility updater, and an authenticated launcher for the pinned enterprise skills engine | authoring canonical skill bodies, task-time playbooks, marketplace caches, or roots owned by another lifecycle channel |
 
 The enterprise command is a transport launcher, not a second installer implementation. It is
 available only when the CLI's recorded private origin serves QAR's path-scoped discovery feeds and
@@ -27,8 +27,15 @@ The CLI materializes a digest-verified packaging build of exact-pinned `skills@1
 `DO_NOT_TRACK=1`; that engine performs current agent discovery and installation. The client never
 contacts npm, skills.sh, GitHub, or a marketplace, so the same path works in an air-gapped deployment.
 The discovery manifest requires Qodo CLI `0.1.0-next.39` or newer, independently from the older
-package-wide compatibility floor. Updates remain prompted until that engine can prove modified-root
-preservation.
+package-wide compatibility floor. Setup discloses automatic maintenance of the selected enterprise
+installations and packages. The CLI stages verified releases through the pinned engine and updates
+only roots whose source, ownership receipt, directory identity and unmodified file hashes still
+match. Opt-outs remain effective; missing or edited roots and competing owners block maintenance.
+
+For requested manual updates, capable CLIs prepare a complete `--dry-run --json` plan before consent,
+then revalidate its returned `--apply-plan` fingerprint before mutation. A narrow `--agent` request
+cannot silently expand. Separate physical copies remain coupled by the enterprise release receipt;
+optional-package selections remain unchanged.
 
 After an explicit migration command, the CLI may retire only byte-identical copies produced by a
 shipped CLI release. It atomically moves them out of the host skill name into a recoverable hidden

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,10 +32,21 @@ installations and packages. The CLI stages verified releases through the pinned 
 only roots whose source, ownership receipt, directory identity and unmodified file hashes still
 match. Opt-outs remain effective; missing or edited roots and competing owners block maintenance.
 
-For requested manual updates, capable CLIs prepare a complete `--dry-run --json` plan before consent,
-then revalidate its returned `--apply-plan` fingerprint before mutation. A narrow `--agent` request
+Coding agents are the primary CLI consumers; non-TTY execution still supports human consent in
+the conversation. Ordinary tool calls drive verified automatic maintenance. For requested updates,
+the agent obtains a complete `--dry-run --json` plan before any still-needed approval, then executes
+the returned command with JSON output. The CLI revalidates its `--apply-plan` fingerprint before
+mutation. Users need not operate a terminal or supply an agent list. A narrow `--agent` request
 cannot silently expand. Separate physical copies remain coupled by the enterprise release receipt;
 optional-package selections remain unchanged.
+
+When planning is missing, the agent checks runtime update capabilities and the available release
+from the recorded source. A runtime upgrade is a distinct prerequisite: reuse authorization that
+covers it or ask once, preserving source and channel. After one attempt, recheck the version and
+planning capability. Failed checks/upgrades or continued incompatibility stop this maintenance
+attempt with a conversational explanation. Do not substitute a terminal handoff, reinstall, public
+source or guessed agent-scoped update. Resolve the skills plan afterward and obtain only consent
+still missing for its actual scope; runtime-only consent cannot expand into a skills update.
 
 After an explicit migration command, the CLI may retire only byte-identical copies produced by a
 shipped CLI release. It atomically moves them out of the host skill name into a recoverable hidden

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,7 +128,9 @@ Production-usage data prioritizes smoke testing but does not define an allowlist
 - Generated paths are repository-relative and validated against traversal.
 - Release assets are checksummed and releases must be immutable.
 - Marketplace packets contain no credentials.
-- A stale notice never mutates; it requires read-only inventory and explicit approval.
+- Availability and completion notices remain passive; they do not trigger inventory or approval
+  requests. Verified automatic maintenance uses the disclosed standing policy. Requested manual
+  maintenance resolves the full operation before any additional consent.
 - Optional packages are never pulled in by update.
 - A CLI-managed update requires an exact shipped fingerprint or an existing ownership receipt;
   modified copies and marketplace/enterprise roots are preserved.

--- a/docs/cutover-and-release-strategy.md
+++ b/docs/cutover-and-release-strategy.md
@@ -248,10 +248,15 @@ Rollback: publish a new immutable patch. Never replace the release asset.
   newest tested release that both supports discovery v0.2 and executes at Qodo's Node 20.6 floor.
   It materializes that helper by SHA-256 under Qodo's private runtime directory and forces
   `DO_NOT_TRACK=1`. No npm, npx, skills.sh, GitHub, or marketplace access occurs on the client.
-- Background maintenance checks only the QAR version pointer. When newer content exists it emits
-  the exact `qodo agents update --enterprise` action. Updates are never unattended: the user sees
-  the lifecycle engine's overwrite summary and confirms it. This remains the policy until the
-  upstream engine can prove modified-root preservation; local edits are not silently discarded.
+- Setup discloses automatic maintenance of the selected enterprise installations and packages from
+  the recorded organization origin. Background maintenance verifies release metadata, receipt,
+  unchanged files, directory identities and ownership before updating all coupled physical copies.
+  It preserves opt-outs, local edits and optional-package choices. Notices are passive and
+  deduplicated; persistent verification failures remain visible without an unrelated consent flow.
+- Requested manual maintenance resolves the complete operation before confirmation. Capable CLIs
+  support `qodo agents update --enterprise --dry-run --json` and the returned `--apply-plan` command;
+  an intervening source, owner, release or file change invalidates approval. A narrow unattended
+  agent request cannot silently authorize other installations. Older CLIs retain interactive updates.
 - The discovery manifest declares `minimumCliVersion: 0.1.0-next.39` independently from the
   package-wide `.37` minimum. QAR rejects the feed until its CLI lock reaches that version.
 
@@ -378,14 +383,16 @@ deleted.
 
 ## Update experience after cutover
 
-1. The marketplace or skills.sh publishes/observes the new complete skill.
-2. The CLI’s daily bounded metadata refresh may notice that the loaded skill version is stale. For
-   enterprise installs this is a detached QAR pointer check, never an unattended root mutation.
-3. The current Qodo command succeeds and emits `QODO_NOTICE` on stderr.
-4. The skill finishes the current task, inventories its lifecycle owner read-only, shows the fully
-   resolved scope-preserving action, and asks once.
-5. The lifecycle owner updates the skill. For skills.sh-owned roots, the shown action is the exact
-   `qodo agents update --agent <ids> --yes` command; the user then starts a new agent session.
+1. Each lifecycle owner publishes or observes a new complete release.
+2. The CLI checks enterprise releases during ordinary use and automatically maintains verified
+   recorded copies under the disclosed policy. Marketplace and skills.sh installations retain
+   their lifecycle owner; their compact version index does not authorize a new installer.
+3. Availability, completion and persistent blocker notices remain passive and deduplicated.
+   Continue the current task without inventory or an unsolicited update question.
+4. Requested enterprise maintenance previews all affected locations and installed packages before
+   any additional consent. Apply only the unchanged approved plan; reuse authorization that covers it.
+5. Dismissing information or declining a one-time manual update does not disable automatic
+   maintenance. New coding-agent sessions load updated files when convenient.
 
 The CLI never runs `npx skills` in the background and never rewrites marketplace files. New
 optional skills are discoverable but never auto-installed.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -38,17 +38,16 @@ marketplace/skills.sh package. Codex discovery checks both its current shared ro
 
 ## Update notices
 
-The CLI refreshes only a compact checksummed version index. When a loaded skill is older, the
-command still succeeds and emits `QODO_NOTICE`. The skill must:
+The CLI emits passive, deduplicated availability and completion notices. Continue the task without
+inventory or unsolicited update questions. Old loaded instructions do not prove installed files
+are stale. Enterprise installations use their disclosed automatic-maintenance policy, verified
+source and opt-outs; other installations keep their lifecycle owner.
 
-1. keep the successful result and finish the task;
-2. inventory the lifecycle owner read-only;
-3. preserve package, agent, and project/global scope;
-4. show a fully resolved update command or host UI action;
-5. ask once before mutation;
-6. request a new agent session after update.
-
-Declining an update leaves the current skill usable. The CLI never silently performs the update.
+For requested maintenance, inspect command support, preview the full packages and physical scope
+with `qodo agents update --enterprise --dry-run --json`, then use the returned `--apply-plan` command
+only with authorization covering that operation. Older CLIs use interactive enterprise maintenance.
+Never expand a narrow approval or add optional packages. Dismissing a notice or declining a manual
+update does not disable the existing automatic policy. New sessions load updated files when convenient.
 
 ## Runtime compatibility
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -335,20 +335,22 @@ allowing a discovery-capable bundle to pair with an incapable CLI.
 
 The archive and discovery feeds are enterprise distribution inputs, not hidden CLI payloads. After
 authentication, the QAR-supplied CLI launches its build-pinned skills engine against the same-origin
-core feed; Standards uses a separate feed and remains explicit. The CLI embeds no skill body,
-agent registry, or archive installer. It forces `DO_NOT_TRACK=1`, and client runtime needs no public
+core feed; Standards uses a separate feed and remains explicit. Canonical skill bodies remain in this repository; the CLI verifies and stages the engine output.
+It forces `DO_NOT_TRACK=1`, and client runtime needs no public
 registry or package-manager access.
 
 The CLI reads QAR's same-origin compact index, CLI-managed bundle, and enterprise pointer. The
 compatibility updater still touches only proven historical CLI-managed roots. The enterprise
-checker never mutates roots in the background or falls back to a public origin. It emits
-`qodo agents update --enterprise`; the user then reviews the lifecycle engine's overwrite summary
-and confirms the update.
+updater uses the disclosed automatic-maintenance policy, respecting opt-outs, and never falls
+back to a public origin. It verifies source, receipt, unmodified files and ownership before replacing
+any recorded copy. Availability, completion and persistent blockers are passive and deduplicated.
+Manual maintenance previews all affected locations and installed packages before one approval; the
+CLI revalidates the approved operation before applying it.
 
 Gate: deterministic rebuild, manifest/archive/discovery digests, no credential or CLI bytes, core
 and Standards isolation, QAR same-origin download, private-origin no-egress behavior,
-telemetry-disabled pinned-helper use at Node 20.6, clean-machine delegated import, prompted update,
-retry, and a new agent session.
+telemetry-disabled pinned-helper use at Node 20.6, clean-machine delegated import, verified automatic maintenance, full-scope manual approval,
+retry, and loading updated instructions in a new agent session.
 
 ## Rollback
 

--- a/skills/qodo-codebase-wisdom/SKILL.md
+++ b/skills/qodo-codebase-wisdom/SKILL.md
@@ -32,18 +32,10 @@ contract, resolve the repository, narrow the search, and return only evidence-ba
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
-Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
-Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
-Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
-For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
-In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
-When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
-Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
-Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
+Treat `QODO_NOTICE` updates as passive, even if an older CLI requests action. Continue the task
+without inventory or update questions; mention each event at most once. Dismissal leaves recorded maintenance
+policy and opt-outs unchanged. Updated skills load next session; do not interrupt this one.
+For user-requested updates, follow the [manual-update procedure](references/skill-updates.md).
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-codebase-wisdom/SKILL.md
+++ b/skills/qodo-codebase-wisdom/SKILL.md
@@ -41,7 +41,7 @@ For this fallback, explain the CLI prerequisite before updating: skill-update co
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
 Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
 Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 

--- a/skills/qodo-codebase-wisdom/SKILL.md
+++ b/skills/qodo-codebase-wisdom/SKILL.md
@@ -32,19 +32,18 @@ contract, resolve the repository, narrow the search, and return only evidence-ba
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
-Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention each update event at most once; dismissal does not disable updates.
-Qodo automatically maintains verified enterprise installations under their recorded policy,
-source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
-Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
-enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
-packages, physical locations and affected integrations before any additional consent. Reuse
-existing approval covering that operation, then execute its exact returned `--apply-plan` command.
-Never expand a narrow approval or add optional packages. Without preview support, direct the
-user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
-Report persistent failures once without bypassing checks. New sessions load updated files; old
-loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
+Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
+Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
+For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
+Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
+Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
+In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
+Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
+Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
+Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-codebase-wisdom/SKILL.md
+++ b/skills/qodo-codebase-wisdom/SKILL.md
@@ -32,15 +32,19 @@ contract, resolve the repository, narrow the search, and return only evidence-ba
 
 ## Handle a skill update notice
 
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
-`code` is `qodo_skill_update_available`, keep the command's result and finish the current
-task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
-Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
-
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
-implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
+Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
+Mention it at most once; dismissal does not disable updates.
+Qodo automatically maintains verified enterprise installations under their recorded policy,
+source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
+Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
+enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
+packages, physical locations and affected integrations before any additional consent. Reuse
+existing approval covering that operation, then execute its exact returned `--apply-plan` command.
+Never expand a narrow approval or add optional packages. Without preview support, direct the
+user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
+Report persistent failures once without bypassing checks. New sessions load updated files; old
+loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-codebase-wisdom/SKILL.md
+++ b/skills/qodo-codebase-wisdom/SKILL.md
@@ -32,9 +32,9 @@ contract, resolve the repository, narrow the search, and return only evidence-ba
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
 Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention it at most once; dismissal does not disable updates.
+Mention each update event at most once; dismissal does not disable updates.
 Qodo automatically maintains verified enterprise installations under their recorded policy,
 source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
 Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview

--- a/skills/qodo-codebase-wisdom/SKILL.md
+++ b/skills/qodo-codebase-wisdom/SKILL.md
@@ -34,12 +34,12 @@ contract, resolve the repository, narrow the search, and return only evidence-ba
 
 Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
 Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
-Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
-Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
+Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
+Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
 For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
 Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.

--- a/skills/qodo-codebase-wisdom/references/skill-updates.md
+++ b/skills/qodo-codebase-wisdom/references/skill-updates.md
@@ -1,0 +1,15 @@
+# Manual enterprise skill updates
+
+Keep commands and approvals in this conversation; do not hand off to a terminal.
+
+1. Resolve `<qodo>` and complete the parent skill’s Runtime compatibility gate, starting with unadorned `<qodo> --version`. Reuse completed checks; any runtime upgrade counts toward the one recovery attempt below.
+2. Check `<qodo> agents update --help` for planning support. If missing, use runtime recovery below. Otherwise preview with `<qodo> agents update --enterprise --dry-run --json`.
+3. Explain the packages and complete affected installation scope. Reuse covering authorization or ask once, then execute the exact returned `--apply-plan` command using `commands.sh` or `commands.powershell` for the tool's shell (Git Bash uses `sh`; older previews expose `command`).
+
+Never widen approval, change owners or add optional packages. Report persistent failures once without bypassing checks. Loaded instructions may be older than installed files.
+
+## Runtime recovery
+
+Stop if a runtime upgrade was already attempted. Otherwise inspect `<qodo> update --help`, then use the supported `<qodo> update --check --json`; require a newer release and the recorded source in its result.
+Explain the CLI prerequisite and reuse runtime-update authorization or ask once; skills-only consent is insufficient. Run `<qodo> update --json` once without source/channel overrides. Recheck unadorned `<qodo> --version` and require the skill minimum before rechecking planning support and returning to the preview.
+Stop on denial, failure, missing metadata or continued incompatibility; never reinstall or switch sources. Runtime-only consent does not approve the skills operation.

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -32,19 +32,18 @@ build focused semantic queries, merge ranked results, print the Qodo rules block
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
-Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention each update event at most once; dismissal does not disable updates.
-Qodo automatically maintains verified enterprise installations under their recorded policy,
-source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
-Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
-enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
-packages, physical locations and affected integrations before any additional consent. Reuse
-existing approval covering that operation, then execute its exact returned `--apply-plan` command.
-Never expand a narrow approval or add optional packages. Without preview support, direct the
-user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
-Report persistent failures once without bypassing checks. New sessions load updated files; old
-loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
+Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
+Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
+For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
+Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
+Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
+In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
+Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
+Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
+Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -32,15 +32,19 @@ build focused semantic queries, merge ranked results, print the Qodo rules block
 
 ## Handle a skill update notice
 
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
-`code` is `qodo_skill_update_available`, keep the command's result and finish the current
-task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
-Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
-
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
-implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
+Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
+Mention it at most once; dismissal does not disable updates.
+Qodo automatically maintains verified enterprise installations under their recorded policy,
+source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
+Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
+enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
+packages, physical locations and affected integrations before any additional consent. Reuse
+existing approval covering that operation, then execute its exact returned `--apply-plan` command.
+Never expand a narrow approval or add optional packages. Without preview support, direct the
+user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
+Report persistent failures once without bypassing checks. New sessions load updated files; old
+loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -41,7 +41,7 @@ For this fallback, explain the CLI prerequisite before updating: skill-update co
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
 Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
 Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -32,18 +32,10 @@ build focused semantic queries, merge ranked results, print the Qodo rules block
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
-Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
-Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
-Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
-For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
-In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
-When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
-Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
-Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
+Treat `QODO_NOTICE` updates as passive, even if an older CLI requests action. Continue the task
+without inventory or update questions; mention each event at most once. Dismissal leaves recorded maintenance
+policy and opt-outs unchanged. Updated skills load next session; do not interrupt this one.
+For user-requested updates, follow the [manual-update procedure](references/skill-updates.md).
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -32,9 +32,9 @@ build focused semantic queries, merge ranked results, print the Qodo rules block
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
 Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention it at most once; dismissal does not disable updates.
+Mention each update event at most once; dismissal does not disable updates.
 Qodo automatically maintains verified enterprise installations under their recorded policy,
 source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
 Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview

--- a/skills/qodo-get-rules/SKILL.md
+++ b/skills/qodo-get-rules/SKILL.md
@@ -34,12 +34,12 @@ build focused semantic queries, merge ranked results, print the Qodo rules block
 
 Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
 Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
-Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
-Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
+Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
+Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
 For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
 Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.

--- a/skills/qodo-get-rules/references/skill-updates.md
+++ b/skills/qodo-get-rules/references/skill-updates.md
@@ -1,0 +1,15 @@
+# Manual enterprise skill updates
+
+Keep commands and approvals in this conversation; do not hand off to a terminal.
+
+1. Resolve `<qodo>` and complete the parent skill’s Runtime compatibility gate, starting with unadorned `<qodo> --version`. Reuse completed checks; any runtime upgrade counts toward the one recovery attempt below.
+2. Check `<qodo> agents update --help` for planning support. If missing, use runtime recovery below. Otherwise preview with `<qodo> agents update --enterprise --dry-run --json`.
+3. Explain the packages and complete affected installation scope. Reuse covering authorization or ask once, then execute the exact returned `--apply-plan` command using `commands.sh` or `commands.powershell` for the tool's shell (Git Bash uses `sh`; older previews expose `command`).
+
+Never widen approval, change owners or add optional packages. Report persistent failures once without bypassing checks. Loaded instructions may be older than installed files.
+
+## Runtime recovery
+
+Stop if a runtime upgrade was already attempted. Otherwise inspect `<qodo> update --help`, then use the supported `<qodo> update --check --json`; require a newer release and the recorded source in its result.
+Explain the CLI prerequisite and reuse runtime-update authorization or ask once; skills-only consent is insufficient. Run `<qodo> update --json` once without source/channel overrides. Recheck unadorned `<qodo> --version` and require the skill minimum before rechecking planning support and returning to the preview.
+Stop on denial, failure, missing metadata or continued incompatibility; never reinstall or switch sources. Runtime-only consent does not approve the skills operation.

--- a/skills/qodo-manage-standards/SKILL.md
+++ b/skills/qodo-manage-standards/SKILL.md
@@ -34,18 +34,10 @@ target, preview destructive or bulk work, obtain confirmation, mutate once, and 
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
-Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
-Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
-Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
-For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
-In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
-When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
-Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
-Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
+Treat `QODO_NOTICE` updates as passive, even if an older CLI requests action. Continue the task
+without inventory or update questions; mention each event at most once. Dismissal leaves recorded maintenance
+policy and opt-outs unchanged. Updated skills load next session; do not interrupt this one.
+For user-requested updates, follow the [manual-update procedure](references/skill-updates.md).
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-manage-standards/SKILL.md
+++ b/skills/qodo-manage-standards/SKILL.md
@@ -43,7 +43,7 @@ For this fallback, explain the CLI prerequisite before updating: skill-update co
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
 Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
 Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 

--- a/skills/qodo-manage-standards/SKILL.md
+++ b/skills/qodo-manage-standards/SKILL.md
@@ -36,12 +36,12 @@ target, preview destructive or bulk work, obtain confirmation, mutate once, and 
 
 Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
 Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
-Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
-Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
+Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
+Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
 For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
 Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.

--- a/skills/qodo-manage-standards/SKILL.md
+++ b/skills/qodo-manage-standards/SKILL.md
@@ -34,9 +34,9 @@ target, preview destructive or bulk work, obtain confirmation, mutate once, and 
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
 Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention it at most once; dismissal does not disable updates.
+Mention each update event at most once; dismissal does not disable updates.
 Qodo automatically maintains verified enterprise installations under their recorded policy,
 source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
 Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview

--- a/skills/qodo-manage-standards/SKILL.md
+++ b/skills/qodo-manage-standards/SKILL.md
@@ -34,19 +34,18 @@ target, preview destructive or bulk work, obtain confirmation, mutate once, and 
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
-Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention each update event at most once; dismissal does not disable updates.
-Qodo automatically maintains verified enterprise installations under their recorded policy,
-source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
-Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
-enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
-packages, physical locations and affected integrations before any additional consent. Reuse
-existing approval covering that operation, then execute its exact returned `--apply-plan` command.
-Never expand a narrow approval or add optional packages. Without preview support, direct the
-user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
-Report persistent failures once without bypassing checks. New sessions load updated files; old
-loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
+Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
+Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
+For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
+Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
+Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
+In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
+Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
+Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
+Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-manage-standards/SKILL.md
+++ b/skills/qodo-manage-standards/SKILL.md
@@ -34,15 +34,19 @@ target, preview destructive or bulk work, obtain confirmation, mutate once, and 
 
 ## Handle a skill update notice
 
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
-`code` is `qodo_skill_update_available`, keep the command's result and finish the current
-task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
-Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
-
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
-implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
+Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
+Mention it at most once; dismissal does not disable updates.
+Qodo automatically maintains verified enterprise installations under their recorded policy,
+source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
+Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
+enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
+packages, physical locations and affected integrations before any additional consent. Reuse
+existing approval covering that operation, then execute its exact returned `--apply-plan` command.
+Never expand a narrow approval or add optional packages. Without preview support, direct the
+user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
+Report persistent failures once without bypassing checks. New sessions load updated files; old
+loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-manage-standards/references/skill-updates.md
+++ b/skills/qodo-manage-standards/references/skill-updates.md
@@ -1,0 +1,15 @@
+# Manual enterprise skill updates
+
+Keep commands and approvals in this conversation; do not hand off to a terminal.
+
+1. Resolve `<qodo>` and complete the parent skill’s Runtime compatibility gate, starting with unadorned `<qodo> --version`. Reuse completed checks; any runtime upgrade counts toward the one recovery attempt below.
+2. Check `<qodo> agents update --help` for planning support. If missing, use runtime recovery below. Otherwise preview with `<qodo> agents update --enterprise --dry-run --json`.
+3. Explain the packages and complete affected installation scope. Reuse covering authorization or ask once, then execute the exact returned `--apply-plan` command using `commands.sh` or `commands.powershell` for the tool's shell (Git Bash uses `sh`; older previews expose `command`).
+
+Never widen approval, change owners or add optional packages. Report persistent failures once without bypassing checks. Loaded instructions may be older than installed files.
+
+## Runtime recovery
+
+Stop if a runtime upgrade was already attempted. Otherwise inspect `<qodo> update --help`, then use the supported `<qodo> update --check --json`; require a newer release and the recorded source in its result.
+Explain the CLI prerequisite and reuse runtime-update authorization or ask once; skills-only consent is insufficient. Run `<qodo> update --json` once without source/channel overrides. Recheck unadorned `<qodo> --version` and require the skill minimum before rechecking planning support and returning to the preview.
+Stop on denial, failure, missing metadata or continued incompatibility; never reinstall or switch sources. Runtime-only consent does not approve the skills operation.

--- a/skills/qodo-review-resolver/SKILL.md
+++ b/skills/qodo-review-resolver/SKILL.md
@@ -56,18 +56,10 @@ present open findings, apply only approved fixes, and record only outcomes actua
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
-Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
-Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
-Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
-For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
-In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
-When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
-Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
-Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
+Treat `QODO_NOTICE` updates as passive, even if an older CLI requests action. Continue the task
+without inventory or update questions; mention each event at most once. Dismissal leaves recorded maintenance
+policy and opt-outs unchanged. Updated skills load next session; do not interrupt this one.
+For user-requested updates, follow the [manual-update procedure](references/skill-updates.md).
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-review-resolver/SKILL.md
+++ b/skills/qodo-review-resolver/SKILL.md
@@ -56,19 +56,18 @@ present open findings, apply only approved fixes, and record only outcomes actua
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
-Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention each update event at most once; dismissal does not disable updates.
-Qodo automatically maintains verified enterprise installations under their recorded policy,
-source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
-Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
-enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
-packages, physical locations and affected integrations before any additional consent. Reuse
-existing approval covering that operation, then execute its exact returned `--apply-plan` command.
-Never expand a narrow approval or add optional packages. Without preview support, direct the
-user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
-Report persistent failures once without bypassing checks. New sessions load updated files; old
-loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
+Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
+Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
+For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
+Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
+Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
+In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
+Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
+Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
+Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-review-resolver/SKILL.md
+++ b/skills/qodo-review-resolver/SKILL.md
@@ -58,12 +58,12 @@ present open findings, apply only approved fixes, and record only outcomes actua
 
 Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
 Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
-Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
-Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
+Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
+Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
 For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
 Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.

--- a/skills/qodo-review-resolver/SKILL.md
+++ b/skills/qodo-review-resolver/SKILL.md
@@ -56,15 +56,19 @@ present open findings, apply only approved fixes, and record only outcomes actua
 
 ## Handle a skill update notice
 
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
-`code` is `qodo_skill_update_available`, keep the command's result and finish the current
-task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
-Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
-
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
-implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
+Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
+Mention it at most once; dismissal does not disable updates.
+Qodo automatically maintains verified enterprise installations under their recorded policy,
+source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
+Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
+enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
+packages, physical locations and affected integrations before any additional consent. Reuse
+existing approval covering that operation, then execute its exact returned `--apply-plan` command.
+Never expand a narrow approval or add optional packages. Without preview support, direct the
+user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
+Report persistent failures once without bypassing checks. New sessions load updated files; old
+loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
 
 ## Runtime compatibility gate
 

--- a/skills/qodo-review-resolver/SKILL.md
+++ b/skills/qodo-review-resolver/SKILL.md
@@ -56,9 +56,9 @@ present open findings, apply only approved fixes, and record only outcomes actua
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
 Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention it at most once; dismissal does not disable updates.
+Mention each update event at most once; dismissal does not disable updates.
 Qodo automatically maintains verified enterprise installations under their recorded policy,
 source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
 Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview

--- a/skills/qodo-review-resolver/SKILL.md
+++ b/skills/qodo-review-resolver/SKILL.md
@@ -65,7 +65,7 @@ For this fallback, explain the CLI prerequisite before updating: skill-update co
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
 Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
 Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 

--- a/skills/qodo-review-resolver/references/skill-updates.md
+++ b/skills/qodo-review-resolver/references/skill-updates.md
@@ -1,0 +1,15 @@
+# Manual enterprise skill updates
+
+Keep commands and approvals in this conversation; do not hand off to a terminal.
+
+1. Resolve `<qodo>` and complete the parent skill’s Runtime compatibility gate, starting with unadorned `<qodo> --version`. Reuse completed checks; any runtime upgrade counts toward the one recovery attempt below.
+2. Check `<qodo> agents update --help` for planning support. If missing, use runtime recovery below. Otherwise preview with `<qodo> agents update --enterprise --dry-run --json`.
+3. Explain the packages and complete affected installation scope. Reuse covering authorization or ask once, then execute the exact returned `--apply-plan` command using `commands.sh` or `commands.powershell` for the tool's shell (Git Bash uses `sh`; older previews expose `command`).
+
+Never widen approval, change owners or add optional packages. Report persistent failures once without bypassing checks. Loaded instructions may be older than installed files.
+
+## Runtime recovery
+
+Stop if a runtime upgrade was already attempted. Otherwise inspect `<qodo> update --help`, then use the supported `<qodo> update --check --json`; require a newer release and the recorded source in its result.
+Explain the CLI prerequisite and reuse runtime-update authorization or ask once; skills-only consent is insufficient. Run `<qodo> update --json` once without source/channel overrides. Recheck unadorned `<qodo> --version` and require the skill minimum before rechecking planning support and returning to the preview.
+Stop on denial, failure, missing metadata or continued incompatibility; never reinstall or switch sources. Runtime-only consent does not approve the skills operation.

--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -28,21 +28,24 @@ This is the **pre-PR** half of the review loop. After the PR exists, switch to r
 
 ## Instructions
 
-Follow the workflow below: preserve notices, attach self-contained context, show progress, use a
-suitable timeout, read the structured result, and act on findings.
+Preserve notices, attach self-contained context, show progress, use a suitable timeout,
+read the structured result, and act on findings.
 
 ## Handle a skill update notice
-
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When `code` is
-`qodo_skill_update_available`, keep the command's result and finish the current task. Then follow the
-notice's `steps`: do read-only inventory first, resolve the installed Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
-
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
+Treat `QODO_NOTICE` availability as passive; continue the task without inventory or update questions.
+Mention it at most once; dismissal does not disable updates.
+Qodo automatically maintains verified enterprise installations under their recorded policy,
+source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
+Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
+enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
+packages, physical locations and affected integrations before any additional consent. Reuse
+existing approval covering that operation, then execute its exact returned `--apply-plan` command.
+Never expand a narrow approval or add optional packages. Without preview support, direct the
+user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
+Report persistent failures once without bypassing checks. New sessions load updated files; old
+loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
 
 ## Runtime compatibility gate
-
 Resolve the executable using this skill's command-not-found fallback, then run `<qodo> --version`
 with no provenance flags. This skill requires Qodo CLI **0.1.0-next.37 or newer**. If older or
 unparseable, do not run `whoami`, `login`, or a review, and do not call it an auth failure. Show

--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -32,8 +32,8 @@ Preserve notices, attach self-contained context, show progress, use a suitable t
 read the structured result, and act on findings.
 
 ## Handle a skill update notice
-Treat `QODO_NOTICE` availability as passive; continue the task without inventory or update questions.
-Mention it at most once; dismissal does not disable updates.
+Treat `QODO_NOTICE` availability and completion as passive; continue the task without inventory or update questions.
+Mention each update event at most once; dismissal does not disable updates.
 Qodo automatically maintains verified enterprise installations under their recorded policy,
 source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
 Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview

--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -32,18 +32,18 @@ Preserve notices, attach self-contained context, show progress, use a suitable t
 read the structured result, and act on findings.
 
 ## Handle a skill update notice
-Treat `QODO_NOTICE` availability and completion as passive; continue the task without inventory or update questions.
-Mention each update event at most once; dismissal does not disable updates.
-Qodo automatically maintains verified enterprise installations under their recorded policy,
-source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
-Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
-enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
-packages, physical locations and affected integrations before any additional consent. Reuse
-existing approval covering that operation, then execute its exact returned `--apply-plan` command.
-Never expand a narrow approval or add optional packages. Without preview support, direct the
-user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
-Report persistent failures once without bypassing checks. New sessions load updated files; old
-loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
+Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
+Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
+For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
+Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
+Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
+In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
+Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
+Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
+Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 
 ## Runtime compatibility gate
 Resolve the executable using this skill's command-not-found fallback, then run `<qodo> --version`

--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -41,7 +41,7 @@ For this fallback, explain the CLI prerequisite before updating: skill-update co
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
 Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
 Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 

--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -32,18 +32,10 @@ Preserve notices, attach self-contained context, show progress, use a suitable t
 read the structured result, and act on findings.
 
 ## Handle a skill update notice
-Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
-Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
-Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
-Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
-For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
-In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
-When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
-Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
-Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
+Treat `QODO_NOTICE` updates as passive, even if an older CLI requests action. Continue the task
+without inventory or update questions; mention each event at most once. Dismissal leaves recorded maintenance
+policy and opt-outs unchanged. Updated skills load next session; do not interrupt this one.
+For user-requested updates, follow the [manual-update procedure](references/skill-updates.md).
 
 ## Runtime compatibility gate
 Resolve the executable using this skill's command-not-found fallback, then run `<qodo> --version`

--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -34,12 +34,12 @@ read the structured result, and act on findings.
 ## Handle a skill update notice
 Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
 Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
-Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
-Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For requested enterprise maintenance, first resolve `<qodo>` and complete the Runtime compatibility gate below, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any gate-triggered runtime upgrade toward the single recovery attempt below.
+Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
+Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
 For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
 Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.

--- a/skills/qodo-review/references/skill-updates.md
+++ b/skills/qodo-review/references/skill-updates.md
@@ -1,0 +1,15 @@
+# Manual enterprise skill updates
+
+Keep commands and approvals in this conversation; do not hand off to a terminal.
+
+1. Resolve `<qodo>` and complete the parent skill’s Runtime compatibility gate, starting with unadorned `<qodo> --version`. Reuse completed checks; any runtime upgrade counts toward the one recovery attempt below.
+2. Check `<qodo> agents update --help` for planning support. If missing, use runtime recovery below. Otherwise preview with `<qodo> agents update --enterprise --dry-run --json`.
+3. Explain the packages and complete affected installation scope. Reuse covering authorization or ask once, then execute the exact returned `--apply-plan` command using `commands.sh` or `commands.powershell` for the tool's shell (Git Bash uses `sh`; older previews expose `command`).
+
+Never widen approval, change owners or add optional packages. Report persistent failures once without bypassing checks. Loaded instructions may be older than installed files.
+
+## Runtime recovery
+
+Stop if a runtime upgrade was already attempted. Otherwise inspect `<qodo> update --help`, then use the supported `<qodo> update --check --json`; require a newer release and the recorded source in its result.
+Explain the CLI prerequisite and reuse runtime-update authorization or ask once; skills-only consent is insufficient. Run `<qodo> update --json` once without source/channel overrides. Recheck unadorned `<qodo> --version` and require the skill minimum before rechecking planning support and returning to the preview.
+Stop on denial, failure, missing metadata or continued incompatibility; never reinstall or switch sources. Runtime-only consent does not approve the skills operation.

--- a/skills/qodo-setup/SKILL.md
+++ b/skills/qodo-setup/SKILL.md
@@ -23,9 +23,9 @@ A shell and browser sign-in. Never request or read credentials.
 ## Instructions
 
 Resolve `references/...` links relative to this installed `SKILL.md` directory.
-Before enterprise installation, disclose automatic maintenance of the selected installations and
-packages from the verified organization source, respecting opt-outs. Setup consent covers this
-policy; it never permits overwriting edits, changing owners or adding optional packages.
+Runtime/login setup does not authorize enterprise installation or maintenance.
+For a separately requested enterprise install, disclose selected installations, packages and verified-source
+automatic maintenance before approval. Preserve opt-outs, edits, owners and optional-package choices.
 
 ### 1. Find or install the runtime
 

--- a/skills/qodo-setup/SKILL.md
+++ b/skills/qodo-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: qodo-setup
-description: Set up Qodo in a local coding agent — install the CLI, sign in, and verify tools. Use after plugin installation, on a setup request, or when another Qodo skill finds a missing CLI or login.
+description: Set up Qodo in a coding agent — install the CLI, sign in, and verify tools. Use after plugin installation, on setup requests, or when a Qodo skill finds a missing CLI or login.
 owner: Qodo
 metadata:
   vendor: qodo
@@ -14,16 +14,18 @@ metadata:
 
 ## Description
 
-Complete setup in this conversation: find or install the CLI, sign in, and verify tools.
-Plugin installation does not connect an account.
+Install, connect and verify Qodo in this conversation. Plugin installation does not connect an account.
 
 ## Prerequisites
 
-A local shell and a user for browser sign-in. Never request or read credentials.
+A shell and browser sign-in. Never request or read credentials.
 
 ## Instructions
 
 Resolve `references/...` links relative to this installed `SKILL.md` directory.
+Before enterprise installation, disclose automatic maintenance of the selected installations and
+packages from the verified organization source, respecting opt-outs. Setup consent covers this
+policy; it never permits overwriting edits, changing owners or adding optional packages.
 
 ### 1. Find or install the runtime
 
@@ -35,9 +37,8 @@ qodo --version
 
 If missing, try `"${QODO_HOME:-$HOME/.qodo}/bin/qodo" --version` on POSIX.
 For PowerShell or a missing CLI, read [runtime.md](references/runtime.md).
-Install through that procedure and continue here without requiring a second setup request.
-A setup request covers the CLI install; honor host approvals and user restrictions.
-Plugin installation alone does not authorize installing software.
+Follow that procedure and continue. Setup requests cover CLI installation, subject to host
+approvals and user restrictions. Plugin installation alone is not authorization.
 
 Keep the working executable as `<qodo>`. Require Qodo CLI **0.1.0-next.37 or newer**.
 If older or unparseable, follow the runtime reference before any authenticated command.
@@ -79,7 +80,6 @@ and `<qodo> tools --refresh` as the retry. Do not log in again for a catalog fai
 
 ## Configuration
 
-Keep executable, deployment, execution context and provenance throughout setup.
 The CLI owns credentials, transport and runtime updates; the package's
 lifecycle owner updates skills. For `QODO_NOTICE` updates or repeated Kiro read approvals,
 read [host-recovery.md](references/host-recovery.md) only when encountered.

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -11,7 +11,7 @@ For this fallback, explain the CLI prerequisite before updating: skill-update co
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
 Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
 Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -2,15 +2,25 @@
 
 ## Handle a skill update notice
 
-A Qodo command can emit `QODO_NOTICE <json>` to stderr while still succeeding. When
-`code` is `qodo_skill_update_available`, keep the command's result and finish the current
-task. Then follow the notice's `steps`: do read-only inventory first, resolve the installed
-Qodo package and scope, show the exact lifecycle-owner update command or UI action, and ask
-once before any mutation. If the user declines, keep the current version usable.
+Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
+Mention it at most once; dismissal does not disable updates.
+Qodo automatically maintains verified enterprise installations under their recorded policy,
+source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
+Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
+enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
+packages, physical locations and affected integrations before any additional consent. Reuse
+existing approval covering that operation, then execute its exact returned `--apply-plan` command.
+Never expand a narrow approval or add optional packages. Without preview support, direct the
+user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
+Report persistent failures once without bypassing checks. New sessions load updated files; old
+loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
 
-Never invoke a different lifecycle owner, guess a placeholder, or install an optional package
-implicitly. After an approved update, ask for the host restart named by the notice; the current
-session may still have the old skill loaded.
+## Enterprise setup policy
+
+Before installing enterprise skills, explain that Qodo will automatically maintain the disclosed
+installations and selected packages from the verified organization source, respecting existing
+opt-outs. Setup consent covers that policy; a notice or unrelated task does not authorize enrollment.
 
 ## Repeated Kiro read approvals
 

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -2,19 +2,18 @@
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
-Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention each update event at most once; dismissal does not disable updates.
-Qodo automatically maintains verified enterprise installations under their recorded policy,
-source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
-Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
-enterprise updates with `<qodo> agents update --enterprise --dry-run --json`; explain the full
-packages, physical locations and affected integrations before any additional consent. Reuse
-existing approval covering that operation, then execute its exact returned `--apply-plan` command.
-Never expand a narrow approval or add optional packages. Without preview support, direct the
-user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
-Report persistent failures once without bypassing checks. New sessions load updated files; old
-loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
+Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
+Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
+For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
+Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
+Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
+In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
+Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
+Reuse approval covering that operation and execute its exact returned `--apply-plan` command through the agent. The user need not type flags, paths or an agent-ID list.
+Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
+Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
 
 ## Repeated Kiro read approvals
 

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -2,18 +2,10 @@
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
-Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, first resolve `<qodo>` and complete step 1 of the main setup skill, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any runtime upgrade toward the single recovery attempt below.
-Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
-Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
-For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
-In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
-When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
-Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
-Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.
-Report persistent failures once without bypassing checks. New sessions load updated files; old loaded instructions do not prove installed files are outdated. Do not interrupt or restart the current session.
+Treat `QODO_NOTICE` updates as passive, even if an older CLI requests action. Continue the task
+without inventory or update questions; mention each event at most once. Dismissal leaves recorded maintenance
+policy and opt-outs unchanged. Updated skills load next session; do not interrupt this one.
+For user-requested updates, follow the [manual-update procedure](skill-updates.md).
 
 ## Repeated Kiro read approvals
 

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -2,9 +2,9 @@
 
 ## Handle a skill update notice
 
-Treat `QODO_NOTICE` availability as passive information: retain the result and continue the task.
+Treat `QODO_NOTICE` availability and completion as passive information: retain the result and continue the task.
 Do not inventory or ask to update because of a notice, even if an older CLI says to ask.
-Mention it at most once; dismissal does not disable updates.
+Mention each update event at most once; dismissal does not disable updates.
 Qodo automatically maintains verified enterprise installations under their recorded policy,
 source and opt-outs. Other installations retain their lifecycle owner; do not replace it.
 Only for requested maintenance, inspect `<qodo> agents update --help`. When supported, preview
@@ -15,12 +15,6 @@ Never expand a narrow approval or add optional packages. Without preview support
 user to interactive `<qodo> agents update --enterprise`; do not guess an agent-scoped command.
 Report persistent failures once without bypassing checks. New sessions load updated files; old
 loaded instructions do not prove installed files are outdated. Do not interrupt or restart.
-
-## Enterprise setup policy
-
-Before installing enterprise skills, explain that Qodo will automatically maintain the disclosed
-installations and selected packages from the verified organization source, respecting existing
-opt-outs. Setup consent covers that policy; a notice or unrelated task does not authorize enrollment.
 
 ## Repeated Kiro read approvals
 

--- a/skills/qodo-setup/references/host-recovery.md
+++ b/skills/qodo-setup/references/host-recovery.md
@@ -4,12 +4,12 @@
 
 Treat `QODO_NOTICE` availability and completion as passive: continue the task without inventory or update questions, even if an older CLI asks.
 Mention each event at most once. Dismissal does not disable verified enterprise maintenance under its recorded policy, source and opt-outs; other lifecycle owners remain unchanged.
-For requested enterprise maintenance, keep commands and any approvals in this conversation; do not require a terminal or TTY.
-Inspect `<qodo> agents update --help`. If planning is supported, skip runtime recovery and use the skills preview below.
-Only if planning is unavailable, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
+For requested enterprise maintenance, first resolve `<qodo>` and complete step 1 of the main setup skill, including the unadorned `<qodo> --version` probe; reuse an already completed gate. Keep commands and approvals in this conversation without a TTY. Count any runtime upgrade toward the single recovery attempt below.
+Inspect `<qodo> agents update --help`. If planning is supported, use the skills preview below. If it is unavailable after a runtime upgrade in this request, explain the blocker and stop.
+Only if planning is unavailable and no runtime upgrade was attempted in this maintenance request, inspect `<qodo> update --help` and use the supported `<qodo> update --check --json`. Require the recorded source and a newer release in its result, not just exit zero; otherwise explain the blocker and stop this maintenance attempt.
 For this fallback, explain the CLI prerequisite before updating: skill-update consent alone does not authorize a CLI upgrade. Reuse authorization covering the runtime update, otherwise ask once.
 In that fallback, run `<qodo> update --json` once within that authorization; never override the source or channel. Stop on denial or failure; do not reinstall, switch owners or fall back to a public source.
-Recheck `<qodo> --version` and `<qodo> agents update --help`; if planning remains unavailable, report the blocker in this conversation without repeating the upgrade or directing the user to a terminal.
+After an upgrade, rerun `<qodo> --version`; stop if it is unparseable or below the minimum. Otherwise recheck `<qodo> agents update --help`; if planning remains unavailable, explain the blocker without another upgrade or terminal handoff.
 When planning is supported, run `<qodo> agents update --enterprise --dry-run --json`. Explain the package and complete affected installation scope in plain language before any still-needed approval.
 Reuse approval covering that operation. Execute the returned `--apply-plan` command from `commands.sh` or `commands.powershell` for the tool’s shell (Git Bash uses `sh`, including on Windows); older previews expose `command`. The user need not type flags, paths or agent IDs.
 Never expand a narrow approval or add optional packages. CLI-only consent does not approve the skills operation; reuse any existing approval covering its resolved scope.

--- a/skills/qodo-setup/references/skill-updates.md
+++ b/skills/qodo-setup/references/skill-updates.md
@@ -1,0 +1,15 @@
+# Manual enterprise skill updates
+
+Keep commands and approvals in this conversation; do not hand off to a terminal.
+
+1. Resolve `<qodo>` and complete step 1 of the setup skill, starting with unadorned `<qodo> --version`. Reuse completed checks; any runtime upgrade counts toward the one recovery attempt below.
+2. Check `<qodo> agents update --help` for planning support. If missing, use runtime recovery below. Otherwise preview with `<qodo> agents update --enterprise --dry-run --json`.
+3. Explain the packages and complete affected installation scope. Reuse covering authorization or ask once, then execute the exact returned `--apply-plan` command using `commands.sh` or `commands.powershell` for the tool's shell (Git Bash uses `sh`; older previews expose `command`).
+
+Never widen approval, change owners or add optional packages. Report persistent failures once without bypassing checks. Loaded instructions may be older than installed files.
+
+## Runtime recovery
+
+Stop if a runtime upgrade was already attempted. Otherwise inspect `<qodo> update --help`, then use the supported `<qodo> update --check --json`; require a newer release and the recorded source in its result.
+Explain the CLI prerequisite and reuse runtime-update authorization or ask once; skills-only consent is insufficient. Run `<qodo> update --json` once without source/channel overrides. Recheck unadorned `<qodo> --version` and require the skill minimum before rechecking planning support and returning to the preview.
+Stop on denial, failure, missing metadata or continued incompatibility; never reinstall or switch sources. Runtime-only consent does not approve the skills operation.


### PR DESCRIPTION
Skill-update notices previously instructed coding agents to inventory installations and open an unrelated maintenance conversation after finishing the user’s task.

Keep a 51-word passive-notice rule in each skill; load its bundled manual-update reference only when maintenance is requested. Use the coding-agent conversation and JSON commands for that flow. For requested updates, resolve the executable and complete the unadorned version-first compatibility gate before checking planning support. If planning is unavailable, permit at most one authorized runtime upgrade from the recorded source, counting any upgrade performed by that gate. Failure stays in the conversation without a terminal handoff. Preview the complete skills operation and execute its exact returned command for the tool’s shell, reusing only approval that covers that scope.

Runtime/login setup does not authorize enterprise installation or automatic maintenance. Separately requested enterprise installation requires disclosure of its selected installations, packages and verified-source maintenance before approval. Preserve opt-outs, edits, lifecycle owners and optional-package choices. Update lifecycle documentation to match.

Validation: the supported temporary release-preview workflow and complete `npm test` passed, including 88 Node tests and release, marketplace, CLI-managed and enterprise bundle checks. All 24 generated provider/CLI-managed references match their canonical content and relative links resolve. Source limits pass, including the 4,000-byte setup budget. Contributor PRs leave versions and generated packages unchanged: CI generates a temporary preview, and the bot-owned release PR commits distribution artifacts, as required by `AGENTS.md`.

Tracking and review assessments: [CLI-347](https://linear.app/qodo/issue/CLI-347). Companion CLI implementation: https://github.com/qodo-ai/qodo-in-cli/pull/263
