### PR TITLE
Record explicitly authorized local review dismissals

### DIFF
--- a/skills/qodo-review/SKILL.md
+++ b/skills/qodo-review/SKILL.md
@@ -404,6 +404,10 @@ this check exists to catch. Either way apply exactly what the evaluation decided
 it (fix the sound ones; skip the wrong/deliberate ones with a reason), and report what you applied
 and what you skipped.
 
+When the user explicitly authorizes declining a local finding, follow
+[Record local triage](references/local-triage.md) to persist the decision. A conversational
+"skip" alone is not a stored dismissal and must not be reported as one.
+
 Re-run `qodo review` after applying to confirm the diff comes back clean. Commit/push per the user's
 workflow — ask before pushing unless they've told you to.
 

--- a/skills/qodo-review/references/local-triage.md
+++ b/skills/qodo-review/references/local-triage.md
@@ -1,0 +1,34 @@
+# Record local triage
+
+Use this only for an explicitly authorized dismissal of findings from a completed local review.
+Keep fixing, declining, and uncertainty distinct. Existing session authorization can cover the
+batch; a recommendation or a skipped edit alone does not authorize a status change.
+
+1. Read each finding's `id` and `local_review_id` from the review result. Keep findings from
+   different local reviews in separate batches. Never invent these values or substitute a PR URL.
+2. Choose the supported reason that matches the decision: `false_positive` for an incorrect
+   finding, `intentional` for deliberate behavior, `deferred` for postponed work, or `rejected`
+   for an understood concern the developer declines to fix. Record a concise explanation.
+3. Check the available write contract with `qodo read tools pr-review-session --json`. If
+   `local_review_id` is absent, refresh discovery once with `qodo tools --refresh`. If still
+   unsupported, report that the backend cannot persist this local decision yet.
+4. Submit the authorized batch through the existing status tool:
+
+```bash
+qodo pr-review-session dismiss --finding-ids ID1,ID2 --local-review-id REVIEW_ID \
+  --reason rejected --explanation "The caller enforces the required limit." --json
+```
+
+5. Inspect every result. `dismissed` or `already_dismissed` confirms the stored decision;
+   `reconciled: false` means downstream synchronization needs a retry of that exact request.
+   `conflict` or `not_found` is not success. For a stale review reference, review again and
+   reassess the finding before acting on the new result.
+
+Keep the returned finding IDs and outcomes in the session's disposition report. Review again
+after code changes and read both current findings and `finding_state`; a dismissal does not
+establish review coverage or resolve other findings.
+
+An applicable decision can follow the finding into the same verified PR or Gerrit Change.
+It does not suppress unrelated Changes, waive repository merge policy, or automatically
+cover a changed concern. The server supplies authenticated ownership; do not pass actor,
+workspace, or origin values as tool arguments.

--- a/skills/qodo-review/references/local-triage.md
+++ b/skills/qodo-review/references/local-triage.md
@@ -19,8 +19,11 @@ qodo pr-review-session dismiss --finding-ids ID1,ID2 --local-review-id REVIEW_ID
   --reason rejected --explanation "The caller enforces the required limit." --json
 ```
 
-5. Inspect every result. `dismissed` or `already_dismissed` confirms the stored decision;
-   `reconciled: false` means downstream synchronization needs a retry of that exact request.
+5. Inspect every result and report the returned stored `reason` and `explanation`.
+   `already_dismissed` preserves the original decision: compare those returned values with
+   the request. If they differ, say the prior dismissal remains; do not claim the new reason
+   or explanation was saved. `reconciled: false` means downstream synchronization needs
+   a retry of that exact request.
    `conflict` or `not_found` is not success. For a stale review reference, review again and
    reassess the finding before acting on the new result.
 

--- a/skills/qodo-review/references/local-triage.md
+++ b/skills/qodo-review/references/local-triage.md
@@ -9,6 +9,8 @@ batch; a recommendation or a skipped edit alone does not authorize a status chan
 2. Choose the supported reason that matches the decision: `false_positive` for an incorrect
    finding, `intentional` for deliberate behavior, `deferred` for postponed work, or `rejected`
    for an understood concern the developer declines to fix. Record a concise explanation.
+   Batch only findings sharing the same `local_review_id`, reason, and explanation. Use
+   separate calls when their authorized reasons or explanations differ, even within one review.
 3. Check the available write contract with `qodo read tools pr-review-session --json`. If
    `local_review_id` is absent, refresh discovery once with `qodo tools --refresh`. If still
    unsupported, report that the backend cannot persist this local decision yet.


### PR DESCRIPTION
When a developer explicitly declines a local review finding, the review skill currently leaves that decision in the conversation. This adds a short, linked procedure for recording the decision through the existing dismissal command, using the finding ID and local review reference returned by the server.

The procedure preserves session authorization, separates batches by review, checks every outcome, and explains stale references and failed synchronization. It does not treat a skipped edit as authorization or waive repository merge policy. The canonical skill remains below 500 lines; release versions and generated adapters are prepared by the existing release workflow.

Validation: full `npm test` passed in a detached CI source-preview checkout (88 unit tests plus adapter, compatibility, release and enterprise bundle checks); Claude marketplace contract passed.

Tracks [NVI-86 Phase 1](https://linear.app/qodo/issue/NVI-86/phase-1-honor-local-triage-in-the-same-gerrit-change). Depends on the runtime/engine local-triage contract; the instructions check discovery before use. [Approved phase split](https://www.notion.so/3d71a4c172d6815fbbfdc1bfef280f81). Portal audit visibility is Phase 2.
